### PR TITLE
feat(titiler): semantic XYZ tiles with server-side palette styling   

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ APP ?= georiva
 WORKER_DEFAULT ?= georiva-celery-default-worker
 WORKER_INGESTION ?= georiva-celery-ingestion-worker
 BEAT ?= georiva-celery-beat
+TITILER ?= georiva-titiler-app
 
 LOG_ARGS ?= --tail 100
 
@@ -116,6 +117,9 @@ dev-worker-ingestion-logs:
 dev-beat-logs:
 	$(DEV_DC) logs -f $(BEAT) $(LOG_ARGS)
 
+dev-titiler-logs:
+	$(DEV_DC) logs -f $(TITILER) $(LOG_ARGS)
+
 dev-shell:
 	$(DEV_DC) exec $(APP) bash
 
@@ -127,6 +131,9 @@ dev-worker-ingestion-shell:
 
 dev-beat-shell:
 	$(DEV_DC) exec $(BEAT) bash
+
+dev-titiler-shell:
+	$(DEV_DC) exec $(TITILER) bash
 
 dev-migrate:
 	$(DEV_DC) exec $(APP) georiva migrate

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -96,6 +96,21 @@ http {
             proxy_set_header X-Forwarded-Port $server_port;
         }
 
+
+        location /titiler/ {
+            set $upstream georiva-titiler-app:8000;
+
+            rewrite ^/titiler/(.*) /$1 break;
+            proxy_pass http://$upstream;
+            proxy_redirect off;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+        }
+
         location /static/ {
             alias /wagtail_static/;
         }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,3 +42,12 @@ services:
     ports:
       - "9000:9000"   # S3 API
       - "9001:9001"   # Web Console
+
+  georiva-titiler-app:
+    command: [ "python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload" ]
+    volumes:
+      - ./titiler-app/app:/app/app
+    ports:
+      - "8888:8000"
+    environment:
+      - UVICORN_LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,9 @@ services:
       MINIO_REGION_NAME: "us-east-1"
       MINIO_USE_HTTPS: "false"
       CORS_ALLOWED_ORIGINS: "*"
+      MINIO_BUCKET_NAME: "georiva-assets"
+      REDIS_URL: "redis://georiva-redis:6379/0"
+      DJANGO_BASE_URL: "http://georiva:8000"
 
   georiva-stac-browser:
     build:

--- a/georiva/src/georiva/api/urls.py
+++ b/georiva/src/georiva/api/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 
+from georiva.core.tile_config_view import TileConfigView
 from georiva.edr import urls as edr_urls
 from georiva.ingestion.views import minio_event_webhook
 from georiva.stac import urls as georiva_stac_urls
@@ -8,4 +9,9 @@ urlpatterns = [
     path('webhook/', minio_event_webhook, name='minio_event_webhook'),
     path('stac/', include(georiva_stac_urls), name='stac'),
     path('edr/', include(edr_urls), name='edr'),
+    path(
+        'tile-config/<slug:catalog_slug>/<slug:collection_slug>/<slug:variable_slug>/',
+        TileConfigView.as_view(),
+        name='tile_config',
+    ),
 ]

--- a/georiva/src/georiva/core/apps.py
+++ b/georiva/src/georiva/core/apps.py
@@ -6,6 +6,22 @@ from django.db.models.signals import post_save
 logger = logging.getLogger(__name__)
 
 
+def on_variable_save(sender, instance, **kwargs):
+    from georiva.core.palette_cache import warm_variable
+    warm_variable(instance)
+
+
+def on_palette_save(sender, instance, **kwargs):
+    from georiva.core.palette_cache import warm_variable
+    for variable in (
+        instance.variable_set
+        .filter(is_active=True)
+        .select_related('collection__catalog', 'palette')
+        .prefetch_related('palette__stops')
+    ):
+        warm_variable(variable)
+
+
 def _put_keep(bucket, path):
     try:
         bucket.save(path, b"")
@@ -41,10 +57,22 @@ class CoreConfig(AppConfig):
     verbose_name = "GeoRIVA Core"
     
     def ready(self):
-        from .models import Collection
+        from .models import Collection, Variable
         from .tasks import update_collection_loader_plugin_periodic_task
-        
+        from .models.visualization import ColorPalette
+
         post_save.connect(update_collection_loader_plugin_periodic_task, sender=Collection)
-        
+
         # Create .keep file in incoming bucket when a new collection is created
         post_save.connect(collection_post_save, sender=Collection)
+
+        # Re-warm palette cache when a variable or palette changes
+        post_save.connect(on_variable_save, sender=Variable)
+        post_save.connect(on_palette_save, sender=ColorPalette)
+
+        # Warm palette cache on startup (guard against pre-migration state)
+        try:
+            from georiva.core.palette_cache import warm_all
+            warm_all()
+        except Exception as e:
+            logger.warning("Palette cache warm failed on startup: %s", e)

--- a/georiva/src/georiva/core/palette_cache.py
+++ b/georiva/src/georiva/core/palette_cache.py
@@ -1,0 +1,119 @@
+"""
+Palette cache utilities for Titiler tile rendering.
+
+Django writes variable rendering config to Redis at startup and on save.
+Titiler reads these keys directly (bypassing Django's cache framework prefix)
+to apply server-side colormaps when serving XYZ tiles.
+
+Key format:  georiva:palette:{catalog_slug}:{collection_slug}:{variable_slug}
+Value format (JSON):
+  With palette:    {"vmin": -10.0, "vmax": 40.0, "scale_type": "linear", "colormap": {"0": [r,g,b,a], ...}}
+  Without palette: {"vmin": -10.0, "vmax": 40.0, "scale_type": "linear"}
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+PALETTE_KEY_PREFIX = "georiva:palette"
+
+
+def get_palette_cache_key(catalog_slug: str, collection_slug: str, variable_slug: str) -> str:
+    return f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}"
+
+
+def _ensure_rgba(color: list) -> list:
+    """Ensure color has 4 components [r, g, b, a]."""
+    if len(color) == 3:
+        return color + [255]
+    return list(color[:4])
+
+
+def build_colormap_256(palette_stops: list, vmin: float, vmax: float) -> dict:
+    """
+    Interpolate [[value, [r,g,b]] or [value, [r,g,b,a]], ...] stops to a
+    256-entry dict {0: [r,g,b,a], ..., 255: [r,g,b,a]}.
+
+    Clamps values outside the stop range to the nearest stop color.
+    Returns a grayscale fallback if stops are empty or range is degenerate.
+    """
+    if not palette_stops:
+        return {i: [i, i, i, 255] for i in range(256)}
+
+    val_range = vmax - vmin
+    if val_range == 0:
+        color = _ensure_rgba(palette_stops[0][1])
+        return {i: color for i in range(256)}
+
+    stops = sorted(palette_stops, key=lambda s: s[0])
+    positions = [(s[0] - vmin) / val_range * 255 for s in stops]
+    colors = [_ensure_rgba(s[1]) for s in stops]
+
+    result = {}
+    for i in range(256):
+        if i <= positions[0]:
+            result[i] = colors[0]
+        elif i >= positions[-1]:
+            result[i] = colors[-1]
+        else:
+            for j in range(len(positions) - 1):
+                if positions[j] <= i <= positions[j + 1]:
+                    span = positions[j + 1] - positions[j]
+                    t = (i - positions[j]) / span if span > 0 else 0
+                    result[i] = [
+                        round(colors[j][k] + t * (colors[j + 1][k] - colors[j][k]))
+                        for k in range(4)
+                    ]
+                    break
+
+    return result
+
+
+def build_variable_payload(variable) -> dict:
+    """Build the rendering payload dict for a Variable."""
+    payload = {
+        "vmin": variable.value_min,
+        "vmax": variable.value_max,
+        "scale_type": variable.scale_type or "linear",
+    }
+
+    if variable.palette:
+        stops = variable.palette.as_weatherlayers_palette()
+        payload["colormap"] = build_colormap_256(stops, variable.value_min, variable.value_max)
+
+    return payload
+
+
+def warm_variable(variable) -> None:
+    """Write one Variable's rendering config to Redis."""
+    from django_redis import get_redis_connection
+
+    try:
+        catalog_slug = variable.collection.catalog.slug
+        collection_slug = variable.collection.slug
+        key = get_palette_cache_key(catalog_slug, collection_slug, variable.slug)
+        payload = build_variable_payload(variable)
+        redis_conn = get_redis_connection("default")
+        redis_conn.set(key, json.dumps(payload))
+    except Exception as e:
+        logger.warning("Failed to warm palette cache for variable %s: %s", getattr(variable, 'slug', '?'), e)
+
+
+def warm_all() -> None:
+    """Warm all active Variables. Called on Django startup."""
+    from georiva.core.models import Variable
+
+    qs = (
+        Variable.objects
+        .filter(is_active=True)
+        .select_related('collection__catalog', 'palette')
+        .prefetch_related('palette__stops')
+    )
+
+    count = 0
+    for variable in qs:
+        warm_variable(variable)
+        count += 1
+
+    logger.info("Warmed palette cache for %d variables", count)

--- a/georiva/src/georiva/core/tile_config_view.py
+++ b/georiva/src/georiva/core/tile_config_view.py
@@ -1,0 +1,41 @@
+"""
+Internal tile-config endpoint consumed by Titiler on Redis cache miss.
+
+GET /api/tile-config/{catalog_slug}/{collection_slug}/{variable_slug}/
+
+Returns the same payload structure as the Redis palette cache:
+  With palette:    {"vmin", "vmax", "scale_type", "colormap": {0-255 entries}}
+  Without palette: {"vmin", "vmax", "scale_type"}
+"""
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework import status
+
+from georiva.core.models import Variable
+from georiva.core.palette_cache import build_variable_payload
+
+
+class TileConfigView(APIView):
+    """Return rendering config for a variable (internal use by Titiler)."""
+
+    permission_classes = []
+    authentication_classes = []
+
+    def get(self, request, catalog_slug, collection_slug, variable_slug):
+        try:
+            variable = (
+                Variable.objects
+                .select_related('collection__catalog', 'palette')
+                .prefetch_related('palette__stops')
+                .get(
+                    collection__catalog__slug=catalog_slug,
+                    collection__slug=collection_slug,
+                    slug=variable_slug,
+                    is_active=True,
+                )
+            )
+        except Variable.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(build_variable_payload(variable))

--- a/titiler-app/app/main.py
+++ b/titiler-app/app/main.py
@@ -1,26 +1,197 @@
+import json
+import logging
 import os
 import re
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Annotated, Optional
 
-from fastapi import FastAPI, Query, HTTPException
+import httpx
+import redis
+from fastapi import Depends, FastAPI, HTTPException, Path, Query
+from rio_tiler.models import ImageData
+from rio_tiler.types import ColorMapType
 from starlette.middleware.cors import CORSMiddleware
+from titiler.core.algorithm.base import BaseAlgorithm
 from titiler.core.factory import TilerFactory
 
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
 MINIO_HOST = os.getenv("MINIO_HOST", "http://georiva-minio:9000")
-MINIO_BUCKET_PREFIX = os.getenv("MINIO_BUCKET_PREFIX", "georiva/processed")
+MINIO_BUCKET_NAME = os.getenv("MINIO_BUCKET_NAME", "georiva-assets")
+REDIS_URL = os.getenv("REDIS_URL", "redis://georiva-redis:6379/0")
+DJANGO_BASE_URL = os.getenv("DJANGO_BASE_URL", "http://georiva:8000")
+
+PALETTE_KEY_PREFIX = "georiva:palette"
+PATH_RE = re.compile(r"^[\w/.-]+\.tif$")
+
+# ---------------------------------------------------------------------------
+# Redis client
+# ---------------------------------------------------------------------------
+
+redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
 
 
-def GeoRivaPathParams(
-        dataset_path: str = Query(
-            ...,
-            description="Path relative to bucket prefix, e.g. ecmwf-ais/ecmwf-ais-temperature/temperature/2026/01/31/temperature_060000.tif"
-        ),
+# ---------------------------------------------------------------------------
+# Django fallback (lru_cache — only used on Redis cache miss)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=512)
+def _fetch_config_from_django(catalog: str, collection: str, variable: str) -> Optional[dict]:
+    """Fetch rendering config from Django internal API on Redis miss.
+    Result is cached in-process for the process lifetime."""
+    url = f"{DJANGO_BASE_URL}/api/tile-config/{catalog}/{collection}/{variable}/"
+    try:
+        resp = httpx.get(url, timeout=5.0)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception as e:
+        logger.warning(
+            "Django tile-config fallback failed for %s/%s/%s: %s",
+            catalog, collection, variable, e,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def build_cog_url(
+        catalog: str,
+        collection: str,
+        variable: str,
+        time_dt: datetime,
+        reftime_dt: Optional[datetime],
 ) -> str:
-    if not re.match(r"^[\w/.-]+\.tif$", dataset_path):
-        raise HTTPException(status_code=400, detail=f"Invalid path: {dataset_path}")
-    return f"{MINIO_HOST}/{MINIO_BUCKET_PREFIX}/{dataset_path}"
+    """
+    Construct the MinIO COG URL from path components.
+
+    Path convention (matches ingestion/service.py:626-640):
+      {catalog}/{collection}/{variable}/{YYYY}/{MM}/{DD}/{variable}_{HHMMSS}.tif
+      {catalog}/{collection}/{variable}/{YYYY}/{MM}/{DD}/{variable}_{HHMMSS}__ref{YYYYMMDDTHHmmss}.tif
+    """
+    date_path = time_dt.strftime("%Y/%m/%d")
+    time_str = time_dt.strftime("%H%M%S")
+    
+    if reftime_dt is not None:
+        ref_str = reftime_dt.strftime("%Y%m%dT%H%M%S")
+        filename = f"{variable}_{time_str}__ref{ref_str}.tif"
+    else:
+        filename = f"{variable}_{time_str}.tif"
+    
+    dataset_path = f"{catalog}/{collection}/{variable}/{date_path}/{filename}"
+    
+    if not PATH_RE.match(dataset_path):
+        raise HTTPException(status_code=400, detail=f"Invalid constructed path: {dataset_path}")
+    
+    return f"{MINIO_HOST}/{MINIO_BUCKET_NAME}/{dataset_path}"
 
 
-app = FastAPI()
+def parse_iso_datetime(value: str, param_name: str) -> datetime:
+    """Parse ISO 8601 UTC datetime string, raising 400 on failure."""
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc)
+    except (ValueError, AttributeError):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid {param_name} — expected ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Custom TilerFactory dependencies
+# ---------------------------------------------------------------------------
+
+def SemanticTileConfig(
+        catalog_slug: Annotated[str, Path(...)],
+        collection_slug: Annotated[str, Path(...)],
+        variable_slug: Annotated[str, Path(...)],
+) -> dict:
+    """Resolve rendering config for a variable.
+
+    Resolution order: Redis → Django internal API → HTTP 503.
+    FastAPI caches this result per request so colormap and rescale
+    dependencies share a single Redis call.
+    """
+    raw = redis_client.get(f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}")
+    if raw:
+        return json.loads(raw)
+    
+    config = _fetch_config_from_django(catalog_slug, collection_slug, variable_slug)
+    if config is not None:
+        return config
+    
+    raise HTTPException(
+        status_code=503,
+        detail="Tile config unavailable — Redis cold and Django fallback failed",
+    )
+
+
+def SemanticPathParams(
+        catalog_slug: Annotated[str, Path(...)],
+        collection_slug: Annotated[str, Path(...)],
+        variable_slug: Annotated[str, Path(...)],
+        time: str = Query(..., description="Valid time in ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)"),
+        reftime: Optional[str] = Query(None, description="Forecast reference time in ISO 8601 UTC"),
+) -> str:
+    """Resolve the COG URL from semantic path params and time query params."""
+    time_dt = parse_iso_datetime(time, "time")
+    
+    reftime_dt = parse_iso_datetime(reftime, "reftime") if reftime else None
+    return build_cog_url(catalog_slug, collection_slug, variable_slug, time_dt, reftime_dt)
+
+
+def SemanticColorMap(
+        tile_config: dict = Depends(SemanticTileConfig),
+) -> Optional[ColorMapType]:
+    """Return the 256-entry colormap from Redis config, or grayscale fallback."""
+    raw = tile_config.get("colormap")
+    if raw:
+        return {int(k): tuple(v) for k, v in raw.items()}
+    # Grayscale fallback for variables without an assigned palette
+    return {i: (i, i, i, 255) for i in range(256)}
+
+
+class RescaleAlgorithm(BaseAlgorithm):
+    """Rescale raw float COG data to 0-255 before colormap lookup."""
+    
+    vmin: float
+    vmax: float
+    
+    def __call__(self, img: ImageData) -> ImageData:
+        img.rescale(in_range=[(self.vmin, self.vmax)], out_range=[(0, 255)])
+        return img
+
+
+def SemanticRescale(
+        tile_config: dict = Depends(SemanticTileConfig),
+) -> Optional[BaseAlgorithm]:
+    """Return a rescale algorithm using vmin/vmax from the tile config."""
+    return RescaleAlgorithm(vmin=tile_config["vmin"], vmax=tile_config["vmax"])
+
+
+# ---------------------------------------------------------------------------
+# TilerFactory with semantic dependencies
+# ---------------------------------------------------------------------------
+
+cog = TilerFactory(
+    path_dependency=SemanticPathParams,
+    colormap_dependency=SemanticColorMap,
+    process_dependency=SemanticRescale,
+    router_prefix="/{catalog_slug}/{collection_slug}/{variable_slug}",
+)
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="GeoRiva Tile Server")
 
 app.add_middleware(
     CORSMiddleware,
@@ -30,5 +201,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-cog = TilerFactory(path_dependency=GeoRivaPathParams)
-app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"])
+app.include_router(
+    cog.router,
+    prefix="/{catalog_slug}/{collection_slug}/{variable_slug}",
+)

--- a/titiler-app/requirements.txt
+++ b/titiler-app/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn[standard]
 titiler.core
+redis
+httpx


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                                                                     
  - Replaces the generic `?dataset_path=` Titiler endpoint with semantic URLs:
    `/{catalog}/{collection}/{variable}/tiles/WebMercatorQuad/{z}/{x}/{y}?time=ISO8601[&reftime=ISO8601]`                                                                                                                            
  - Uses TilerFactory with three custom dependencies (path, colormap, rescale) so all standard endpoints come for free: `/tilejson.json`, `/info`, `/statistics`, `/preview`, `/point/{lon},{lat}`
  - Django warms a Redis cache of per-variable rendering config (vmin, vmax, colormap) on startup and on `Variable`/`ColorPalette` save; Titiler reads it server-side with a Django API fallback on cache miss                       
                                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                                         
                                                                                                                                                                                                                                     
  - **titiler-app**: full rewrite of `main.py` — `SemanticPathParams` resolves COG path from slugs + time, `SemanticRescale` maps float data to 0–255, `SemanticColorMap` applies the 256-entry palette (grayscale fallback for      
  variables without a palette)                                                                                                                                                                                                       
  - **core**: new `palette_cache.py` — `build_colormap_256()`, `warm_variable()`, `warm_all()`; wired into `apps.py` signals and startup
  - **core**: new internal endpoint `GET /api/tile-config/{catalog}/{collection}/{variable}/` for Titiler fallback                                                                                                                   
  - **infra**: nginx `/titiler/` proxy route, titiler dev hot-reload config, `REDIS_URL`/`MINIO_BUCKET_NAME`/`DJANGO_BASE_URL` env vars   