### PR TITLE
feat(core): collection items detail view

### DIFF
--- a/georiva/src/georiva/core/models/item.py
+++ b/georiva/src/georiva/core/models/item.py
@@ -17,7 +17,6 @@ from wagtail.models import Orderable
 from wagtail.snippets.models import register_snippet
 
 
-@register_snippet
 class Item(TimescaleModel, TimeStampedModel, ClusterableModel):
     """
     A single spatiotemporal entry in a Collection.

--- a/georiva/src/georiva/core/templates/core/collection_items.html
+++ b/georiva/src/georiva/core/templates/core/collection_items.html
@@ -1,0 +1,19 @@
+{% extends "wagtailadmin/generic/base.html" %}
+
+{% load i18n wagtailadmin_tags static wagtailiconchooser_tags %}
+
+{% block main_content %}
+    <div>
+        {% if page_obj.object_list %}
+            {% component table %}
+        {% else %}
+            <p>No items found for this collection</p>
+        {% endif %}
+
+        {% if paginator.num_pages > 1 %}
+            <div style="margin-top:40px;">
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/core/templates/core/collection_items.html
+++ b/georiva/src/georiva/core/templates/core/collection_items.html
@@ -1,19 +1,698 @@
 {% extends "wagtailadmin/generic/base.html" %}
 
-{% load i18n wagtailadmin_tags static wagtailiconchooser_tags %}
+{% load i18n wagtailadmin_tags static %}
+
+{% block titletag %}{{ collection.name }} — Items{% endblock %}
+
+{% block extra_css %}
+    <style>
+        /* ── Summary card ─────────────────────────────────────────────── */
+        .ci-summary-card {
+            padding: 1.25rem;
+            margin-top: 2rem;
+            margin-bottom: 1.5rem;
+            background: var(--w-color-surface-field);
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+        }
+
+        .ci-summary-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 1.1rem;
+        }
+
+        .ci-summary-title {
+            margin: 0 0 0.25rem;
+        }
+
+        .ci-summary-slug {
+            margin: 0;
+        }
+
+        .ci-summary-badges {
+            display: flex;
+            gap: 0.4rem;
+            flex-shrink: 0;
+            margin-left: 1rem;
+        }
+
+        .ci-meta-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 0.75rem 1.5rem;
+        }
+
+        .ci-meta-grid--span2 {
+            grid-column: span 2;
+        }
+
+        .ci-meta-label {
+            margin: 0 0 0.15rem;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .ci-meta-value {
+            margin: 0;
+            font-weight: 600;
+        }
+
+        /* ── Variables strip ──────────────────────────────────────────── */
+        .ci-variables-section {
+            margin-bottom: 1.5rem;
+        }
+
+        .ci-variables-section h2 {
+            margin-bottom: 0.5rem;
+        }
+
+        .ci-variables-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .ci-var-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.3rem 0.65rem;
+            background: var(--w-color-surface-page);
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 4px;
+            font-size: 0.8rem;
+        }
+
+        .ci-var-chip__swatch {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 2px;
+            flex-shrink: 0;
+        }
+
+        .ci-var-chip__slug {
+            font-size: 0.75rem;
+        }
+
+        .ci-var-chip__name {
+            font-size: 0.75rem;
+        }
+
+        .ci-var-chip__tag {
+            font-size: 0.65rem;
+            padding: 0 4px;
+        }
+
+        /* ── Automation card ──────────────────────────────────────────── */
+        .ci-automation-card {
+            margin-top: 4rem;
+            margin-bottom: 1.5rem;
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+            overflow: hidden;
+        }
+
+        .ci-automation-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.65rem 1rem;
+            background: var(--w-color-surface-field);
+            border-bottom: 1px solid var(--w-color-border-furniture);
+        }
+
+        .ci-automation-header__left {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+        }
+
+        .ci-automation-header__title {
+            margin: 0;
+        }
+
+        .ci-automation-header__profile-name {
+            color: var(--w-color-text-label);
+        }
+
+        .ci-automation-header__right {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 0.82rem;
+            color: var(--w-color-text-label);
+        }
+
+        .ci-automation-header__right form {
+            margin: 0;
+        }
+
+        .ci-automation-icon {
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+        }
+
+        .ci-ingestion-stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem 2rem;
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid var(--w-color-border-furniture);
+        }
+
+        .ci-ingestion-stat__label {
+            display: block;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .ci-ingestion-stat__value {
+            margin: 0;
+            font-weight: 600;
+        }
+
+        .ci-runs-table {
+            margin: 0;
+        }
+
+        .ci-automation-empty {
+            padding: 0.75rem 1rem;
+            margin: 0;
+        }
+
+        /* ── Items section ────────────────────────────────────────────── */
+        .ci-items-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .ci-items-header h2 {
+            margin: 0;
+        }
+
+        .ci-asset-badge {
+            display: inline-block;
+            padding: 1px 9px;
+            background: var(--w-color-surface-field);
+            border-radius: 10px;
+            font-weight: 600;
+        }
+
+        .ci-source-file {
+            color: var(--w-color-text-label);
+        }
+
+        .ci-log-tag {
+            font-size: 0.7rem;
+        }
+
+        .ci-log-tag--help {
+            cursor: help;
+        }
+
+        .ci-horizon-note {
+            font-size: 0.7rem;
+        }
+
+        /* ── Pagination ───────────────────────────────────────────────── */
+        .ci-pagination {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .ci-pagination__info {
+            margin: 0;
+        }
+
+        .ci-pagination__nav {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+
+        .ci-pagination__disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+
+        .ci-pagination__current {
+            font-weight: 600;
+        }
+
+        .ci-pagination__ellipsis {
+            padding: 0 0.25rem;
+        }
+    </style>
+{% endblock %}
 
 {% block main_content %}
-    <div>
-        {% if page_obj.object_list %}
-            {% component table %}
-        {% else %}
-            <p>No items found for this collection</p>
-        {% endif %}
+
+    <div class="ci-summary-card">
+
+        <div class="ci-summary-header">
+            <div>
+                <h1 class="w-label-1 ci-summary-title">{{ collection.name }}</h1>
+                <p class="help-text ci-summary-slug">
+                    <code class="w-font-mono w-text-14">{{ collection.catalog.slug }}/{{ collection.slug }}</code>
+                    {% if collection.description %}
+                        &nbsp;·&nbsp; {{ collection.description }}
+                    {% endif %}
+                </p>
+            </div>
+            <div class="ci-summary-badges">
+                {% if collection.is_active %}
+                    <span class="w-status-tag w-status-tag--primary">{% trans "Active" %}</span>
+                {% else %}
+                    <span class="w-status-tag w-status-tag--critical">{% trans "Inactive" %}</span>
+                {% endif %}
+                {% if collection.is_forecast %}
+                    <span class="w-status-tag w-status-tag--secondary">{% trans "Forecast" %}</span>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="ci-meta-grid">
+
+            <div>
+                <p class="help-text ci-meta-label">{% trans "Catalog" %}</p>
+                <p class="w-text-14 ci-meta-value">
+                    {{ catalog.name }}
+                    <span class="w-status-tag ci-var-chip__tag" style="margin-left: 4px;">
+                    {{ catalog.get_file_format_display }}
+                </span>
+                </p>
+            </div>
+
+            <div>
+                <p class="help-text ci-meta-label">{% trans "Items" %}</p>
+                <p class="w-text-14 ci-meta-value">{{ collection.item_count|default:paginator.count }}</p>
+            </div>
+
+            <div>
+                <p class="help-text ci-meta-label">{% trans "Variables" %}</p>
+                <p class="w-text-14 ci-meta-value">{{ variable_count }}</p>
+            </div>
+
+            {% if collection.time_resolution %}
+                <div>
+                    <p class="help-text ci-meta-label">{% trans "Resolution" %}</p>
+                    <p class="w-text-14 ci-meta-value">{{ collection.get_time_resolution_display }}</p>
+                </div>
+            {% endif %}
+
+            {% if collection.time_start %}
+                <div class="ci-meta-grid--span2">
+                    <p class="help-text ci-meta-label">{% trans "Time extent" %}</p>
+                    <p class="w-text-14 w-font-mono ci-meta-value">
+                        {{ collection.time_start|date:"Y-m-d H:i" }}
+                        &nbsp;→&nbsp;
+                        {{ collection.time_end|date:"Y-m-d H:i"|default:"ongoing" }}
+                    </p>
+                </div>
+            {% endif %}
+
+            {% if collection.is_forecast and collection.forecast_horizon_hours %}
+                <div>
+                    <p class="help-text ci-meta-label">{% trans "Horizon" %}</p>
+                    <p class="w-text-14 ci-meta-value">{{ collection.forecast_horizon_hours }}h</p>
+                </div>
+            {% endif %}
+
+            {% if collection.bounds %}
+                <div class="ci-meta-grid--span2">
+                    <p class="help-text ci-meta-label">{% trans "Bounds (W S E N)" %}</p>
+                    <p class="w-text-14 w-font-mono ci-meta-value" style="font-weight: normal;">
+                        [&nbsp;{{ collection.bounds.0|floatformat:3 }},
+                        {{ collection.bounds.1|floatformat:3 }},
+                        {{ collection.bounds.2|floatformat:3 }},
+                        {{ collection.bounds.3|floatformat:3 }}&nbsp;]
+                        &nbsp;<span class="help-text">{{ collection.crs }}</span>
+                    </p>
+                </div>
+            {% endif %}
+
+            {% if catalog.boundary %}
+                <div>
+                    <p class="help-text ci-meta-label">{% trans "Clip" %}</p>
+                    <p class="w-text-14 ci-meta-value" style="font-weight: normal;">
+                        {{ catalog.boundary.name_0|default:catalog.boundary }}
+                        <span class="help-text">({{ catalog.get_clip_mode_display }})</span>
+                    </p>
+                </div>
+            {% endif %}
+
+        </div>
+    </div>
+
+    {% if variable_list %}
+        <div class="ci-variables-section">
+            <h2 class="w-label-2">{% trans "Variables" %}</h2>
+            <div class="ci-variables-list">
+                {% for var in variable_list %}
+                    <div class="ci-var-chip">
+                        {% if var.palette %}
+                            <span class="ci-var-chip__swatch"
+                                  style="background: linear-gradient(to right,
+                                          {{ var.palette.css_gradient|default:'#ccc, #333' }});">
+                        </span>
+                        {% endif %}
+                        <code class="w-font-mono ci-var-chip__slug">{{ var.slug }}</code>
+                        <span class="help-text ci-var-chip__name">{{ var.name }}</span>
+                        {% if var.units %}
+                            <span class="w-status-tag ci-var-chip__tag">{{ var.units }}</span>
+                        {% endif %}
+                        {% if var.is_derived %}
+                            <span class="w-status-tag w-status-tag--secondary ci-var-chip__tag"
+                                  title="{{ var.get_transform_type_display }}">
+                            {% trans "derived" %}
+                        </span>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endif %}
+    <div class="ci-items-header">
+        <h2 class="w-label-1">
+            {% trans "Items" %}
+            <span class="w-status w-status--label w-ml-3">{{ paginator.count }}</span>
+        </h2>
+    </div>
+    {% if variable_list|length > 1 %}
+        <div class="w-tabs">
+            <div class="w-tabs__list" role="tablist">
+
+                {# All tab #}
+                <a href="?"
+                   class="w-tabs__tab {% if not active_var_slug %}w-tabs__tab--active{% endif %}"
+                   role="tab"
+                   aria-selected="{% if not active_var_slug %}true{% else %}false{% endif %}">
+                    {% trans "All" %}
+                </a>
+
+                {% for var in variable_list %}
+                    <a href="?var={{ var.slug }}"
+                       class="w-tabs__tab {% if active_var_slug == var.slug %}w-tabs__tab--active{% endif %}"
+                       role="tab"
+                       aria-selected="{% if active_var_slug == var.slug %}true{% else %}false{% endif %}">
+                        {{ var.name }}
+                        {% if var.units %}
+                            <span class="ci-var-chip__tag w-status-tag" style="margin-left: 4px;">
+                            {{ var.units }}
+                        </span>
+                        {% endif %}
+                    </a>
+                {% endfor %}
+
+            </div>
+        </div>
+    {% endif %}
+    {% if page_obj.object_list %}
+        <table class="listing">
+            <thead>
+            <tr>
+                <th>{% trans "Valid time" %}</th>
+                {% if collection.is_forecast %}
+                    <th>{% trans "Reference time" %}</th>
+                {% endif %}
+                <th>{% trans "Assets" %}</th>
+                <th>{% trans "Ingestion" %}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for item in page_obj.object_list %}
+                <tr>
+                    <td class="w-text-14 w-font-mono">{{ item.time|date:"Y-m-d H:i" }}</td>
+
+                    {% if collection.is_forecast %}
+                        <td class="w-text-14 w-font-mono">
+                            {% if item.reference_time %}
+                                {{ item.reference_time|date:"Y-m-d H:i" }}
+                                <span class="help-text ci-horizon-note">
+                                    (+{{ item.horizon_hours|floatformat:0 }}h)
+                                </span>
+                            {% else %}
+                                <span class="w-text-grey-400">—</span>
+                            {% endif %}
+                        </td>
+                    {% endif %}
+
+                    <td class="w-text-14">
+                        <span class="ci-asset-badge">{{ item.asset_count }}</span>
+                    </td>
+
+                    <td class="w-text-14">
+                        {% if item.ingestion_log %}
+                            {% with log=item.ingestion_log %}
+                                {% if log.status == 'completed' %}
+                                    <span class="w-status-tag w-status-tag--primary ci-log-tag">
+                                        {{ log.get_status_display }}
+                                    </span>
+                                {% elif log.status == 'failed' %}
+                                    <span class="w-status-tag w-status-tag--critical ci-log-tag ci-log-tag--help"
+                                          title="{{ log.error }}">
+                                        {{ log.get_status_display }}
+                                    </span>
+                                {% elif log.status == 'processing' %}
+                                    <span class="w-status-tag w-status-tag--secondary ci-log-tag">
+                                        {{ log.get_status_display }}
+                                    </span>
+                                {% else %}
+                                    <span class="w-status-tag ci-log-tag">
+                                        {{ log.get_status_display }}
+                                    </span>
+                                {% endif %}
+                            {% endwith %}
+                        {% else %}
+                            <span class="w-text-grey-400">—</span>
+                        {% endif %}
+                    </td>
+
+                    <td>
+                        <a href="{% url 'item_preview' item.pk %}"
+                           class="button button-small button-secondary"
+                           title="{% trans 'View item' %}">
+                            <svg class="icon icon-view" aria-hidden="true" style="width:14px;height:14px;">
+                                <use href="#icon-view"></use>
+                            </svg>
+                            {% trans "View" %}
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
 
         {% if paginator.num_pages > 1 %}
-            <div style="margin-top:40px;">
-                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
+            <div class="ci-pagination">
+                <p class="help-text ci-pagination__info">
+                    {% blocktrans with start=page_obj.start_index end=page_obj.end_index total=paginator.count %}
+                        Showing {{ start }}–{{ end }} of {{ total }} items
+                    {% endblocktrans %}
+                </p>
+                <nav class="ci-pagination__nav" aria-label="{% trans 'Pagination' %}">
+                    {% if page_obj.has_previous %}
+                        <a href="?{% if active_var_slug %}var={{ active_var_slug }}&{% endif %}p={{ page_obj.previous_page_number }}"
+                           class="button button-secondary button-small">‹</a>
+                    {% else %}
+                        <span class="button button-secondary button-small ci-pagination__disabled">‹</span>
+                    {% endif %}
+
+                    {% for p in elided_page_range %}
+                        {% if p is None %}
+                            <span class="help-text ci-pagination__ellipsis">…</span>
+                        {% elif p == page_obj.number %}
+                            <span class="button button-small ci-pagination__current"
+                                  aria-current="page">{{ p }}</span>
+                        {% else %}
+                            <a href="?{% if active_var_slug %}var={{ active_var_slug }}&{% endif %}p={{ p }}"
+                               class="button button-secondary button-small">{{ p }}</a>
+                        {% endif %}
+                    {% endfor %}
+
+                    {% if page_obj.has_next %}
+                        <a href="?{% if active_var_slug %}var={{ active_var_slug }}&{% endif %}p={{ page_obj.next_page_number }}"
+                           class="button button-secondary button-small">›</a>
+                    {% else %}
+                        <span class="button button-secondary button-small ci-pagination__disabled">›</span>
+                    {% endif %}
+                </nav>
             </div>
         {% endif %}
-    </div>
+
+    {% else %}
+        <p class="help-text">
+            {% if active_variable %}
+                {% blocktrans with name=active_variable.name %}No items found for variable "{{ name }}".
+                {% endblocktrans %}
+            {% else %}
+                {% trans "No items found for this collection." %}
+            {% endif %}
+        </p>
+    {% endif %}
+
+    {% if loader_profile %}
+        <div class="ci-automation-card">
+
+            <div class="ci-automation-header">
+                <div class="ci-automation-header__left">
+                    <svg class="icon icon-plug ci-automation-icon" aria-hidden="true">
+                        <use href="#icon-plug"></use>
+                    </svg>
+                    <h2 class="w-label-2 ci-automation-header__title">{% trans "Automation" %}</h2>
+                    <span class="w-font-mono w-text-14 ci-automation-header__profile-name">
+                    {{ loader_profile.name }}
+                </span>
+                    {% if loader_profile.is_active %}
+                        <span class="w-status-tag w-status-tag--primary ci-var-chip__tag">{% trans "Active" %}</span>
+                    {% else %}
+                        <span class="w-status-tag ci-var-chip__tag">{% trans "Paused" %}</span>
+                    {% endif %}
+                </div>
+
+                <div class="ci-automation-header__right">
+                    <span>{% trans "Every" %} {{ loader_profile.interval_minutes }}{% trans "min" %}</span>
+                    {% if loader_profile.last_run_at %}
+                        <span>{% trans "Last run:" %} {{ loader_profile.last_run_at|timesince }} {% trans "ago" %}</span>
+                    {% endif %}
+                    <form method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="trigger_ingestion">
+                        <button type="submit" class="button button-small bicolor button--icon">
+                        <span class="icon-wrapper">
+                            <svg class="icon icon-tick" aria-hidden="true">
+                                <use href="#icon-tick"></use>
+                            </svg>
+                        </span>
+                            {% trans "Run now" %}
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            {% if ingestion_summary %}
+                <div class="ci-ingestion-stats">
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Total files" %}</span>
+                        <p class="w-text-14 ci-ingestion-stat__value">{{ ingestion_summary.total|default:0 }}</p>
+                    </div>
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Completed" %}</span>
+                        <p class="w-text-14 w-text-positive-100 ci-ingestion-stat__value">
+                            {{ ingestion_summary.completed|default:0 }}
+                        </p>
+                    </div>
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Pending" %}</span>
+                        <p class="w-text-14 ci-ingestion-stat__value">{{ ingestion_summary.pending|default:0 }}</p>
+                    </div>
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Processing" %}</span>
+                        <p class="w-text-14 ci-ingestion-stat__value">{{ ingestion_summary.processing|default:0 }}</p>
+                    </div>
+                    {% if ingestion_summary.failed %}
+                        <div>
+                            <span class="help-text ci-ingestion-stat__label">{% trans "Failed" %}</span>
+                            <p class="w-text-14 w-text-critical-100 ci-ingestion-stat__value">
+                                {{ ingestion_summary.failed }}
+                            </p>
+                        </div>
+                    {% endif %}
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Items created" %}</span>
+                        <p class="w-text-14 ci-ingestion-stat__value">
+                            {{ ingestion_summary.total_items_created|default:0 }}
+                        </p>
+                    </div>
+                    <div>
+                        <span class="help-text ci-ingestion-stat__label">{% trans "Assets created" %}</span>
+                        <p class="w-text-14 ci-ingestion-stat__value">
+                            {{ ingestion_summary.total_assets_created|default:0 }}
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if recent_runs %}
+                <table class="listing ci-runs-table">
+                    <thead>
+                    <tr>
+                        <th>{% trans "Started" %}</th>
+                        <th>{% trans "Status" %}</th>
+                        <th>{% trans "Fetched" %}</th>
+                        <th>{% trans "Skipped" %}</th>
+                        <th>{% trans "Failed" %}</th>
+                        <th>{% trans "Queued" %}</th>
+                        <th>{% trans "Duration" %}</th>
+                        <th>{% trans "Errors" %}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for run in recent_runs %}
+                        <tr>
+                            <td class="w-text-14 w-font-mono">{{ run.started_at|date:"Y-m-d H:i" }}</td>
+                            <td>
+                                {% if run.status == 'success' %}
+                                    <span class="w-status-tag w-status-tag--primary">{{ run.get_status_display }}</span>
+                                {% elif run.status == 'failed' %}
+                                    <span class="w-status-tag w-status-tag--critical">{{ run.get_status_display }}</span>
+                                {% elif run.status == 'partial' %}
+                                    <span class="w-status-tag w-status-tag--warning">{{ run.get_status_display }}</span>
+                                {% elif run.status == 'running' %}
+                                    <span class="w-status-tag w-status-tag--secondary">{{ run.get_status_display }}</span>
+                                {% else %}
+                                    <span class="w-status-tag">{{ run.get_status_display }}</span>
+                                {% endif %}
+                            </td>
+                            <td class="w-text-14">{{ run.files_fetched }}</td>
+                            <td class="w-text-14">{{ run.files_skipped }}</td>
+                            <td class="w-text-14">
+                                {% if run.files_failed %}
+                                    <span class="w-text-critical-100">{{ run.files_failed }}</span>
+                                {% else %}
+                                    0
+                                {% endif %}
+                            </td>
+                            <td class="w-text-14">{{ run.files_queued }}</td>
+                            <td class="w-text-14">
+                                {% if run.duration_seconds %}
+                                    {{ run.duration_seconds|floatformat:0 }}s
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td class="w-text-14">
+                                {% if run.errors %}
+                                    <span class="w-text-critical-100 ci-log-tag--help"
+                                          title="{{ run.errors|join:', ' }}">
+                                        {{ run.errors|length }} error{{ run.errors|length|pluralize }}
+                                    </span>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p class="help-text ci-automation-empty">{% trans "No loader runs yet for this collection." %}</p>
+            {% endif %}
+
+        </div>
+    {% endif %}
+
+
 {% endblock %}

--- a/georiva/src/georiva/core/views.py
+++ b/georiva/src/georiva/core/views.py
@@ -1,16 +1,18 @@
-from django.shortcuts import render
+from django.core.paginator import InvalidPage
+from django.shortcuts import render, get_object_or_404
 from django.urls import reverse_lazy, reverse
 from django.utils.translation import gettext as _
+from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import ButtonsColumnMixin, TitleColumn, Table, BooleanColumn
 from wagtail.admin.widgets import ListingButton, HeaderButton, ButtonWithDropdown
 
-from georiva.core.models import Catalog
+from georiva.core.models import Catalog, Collection, Item
 from .table import LinkColumnWithIcon
 from .viewsets import CatalogViewSet, CollectionViewSet
 
 
 def get_collection_items_url(collection):
-    return "#"
+    return reverse("collection_items_list", args=[collection.pk])
 
 
 def catalog_index(request):
@@ -119,3 +121,40 @@ def catalog_index(request):
     }
     
     return render(request, 'core/catalog_list.html', context)
+
+
+def collection_items_list(request, collection_pk):
+    collection = get_object_or_404(Collection, pk=collection_pk)
+    items = Item.objects.filter(collection=collection)
+    
+    # Get search parameters from the query string.
+    try:
+        page_num = int(request.GET.get("p", 0))
+    except ValueError:
+        page_num = 0
+    
+    paginator = WagtailPaginator(items, 2)
+    
+    try:
+        page_obj = paginator.page(page_num + 1)
+    except InvalidPage:
+        page_obj = paginator.page(1)
+    
+    columns = [
+        TitleColumn("__str__", label=_("Item")),
+    ]
+    
+    elided_page_range = paginator.get_elided_page_range(page_num)
+    
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": "", "label": _("Catalogs")},
+        ],
+        "paginator": paginator,
+        "elided_page_range": elided_page_range,
+        "page_obj": page_obj,
+        "table": Table(columns, page_obj.object_list),
+    }
+    
+    return render(request, 'core/collection_items.html', context)

--- a/georiva/src/georiva/core/views.py
+++ b/georiva/src/georiva/core/views.py
@@ -1,12 +1,20 @@
+from django.contrib import messages
 from django.core.paginator import InvalidPage
-from django.shortcuts import render, get_object_or_404
-from django.urls import reverse_lazy, reverse
+from django.db.models import Count, OuterRef, Q, Subquery, Sum
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
+from wagtail.admin import messages
 from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import ButtonsColumnMixin, TitleColumn, Table, BooleanColumn
 from wagtail.admin.widgets import ListingButton, HeaderButton, ButtonWithDropdown
 
-from georiva.core.models import Catalog, Collection, Item
+from georiva.core.models import Catalog
+from georiva.core.models import Collection, Item
+from georiva.ingestion.models import IngestionLog
+from georiva.sources.models import LoaderRun
 from .table import LinkColumnWithIcon
 from .viewsets import CatalogViewSet, CollectionViewSet
 
@@ -124,37 +132,138 @@ def catalog_index(request):
 
 
 def collection_items_list(request, collection_pk):
-    collection = get_object_or_404(Collection, pk=collection_pk)
-    items = Item.objects.filter(collection=collection)
+    collection = get_object_or_404(
+        Collection.objects.select_related("catalog", "catalog__boundary"),
+        pk=collection_pk,
+    )
     
-    # Get search parameters from the query string.
+    # ------------------------------------------------------------------
+    # POST actions
+    # ------------------------------------------------------------------
+    if request.method == "POST":
+        action = request.POST.get("action")
+        
+        if action == "trigger_ingestion":
+            # TODO: wire up real Celery task, e.g.:
+            # from georiva.ingestion.tasks import run_loader_for_collection
+            # run_loader_for_collection.delay(collection.pk)
+            messages.success(request, _("Ingestion queued (placeholder)."))
+            return redirect(request.path)
+    
+    # ------------------------------------------------------------------
+    # Variables
+    # ------------------------------------------------------------------
+    variable_list = list(
+        collection.variables.filter(is_active=True).select_related("palette")
+    )
+    
+    # ------------------------------------------------------------------
+    # Active variable tab
+    # ------------------------------------------------------------------
+    active_var_slug = request.GET.get("var", "")
+    active_variable = None
+    if active_var_slug:
+        active_variable = next(
+            (v for v in variable_list if v.slug == active_var_slug), None
+        )
+        # Unrecognised slug — fall back to "All"
+        if not active_variable:
+            active_var_slug = ""
+    
+    # ------------------------------------------------------------------
+    # Items queryset
+    # Use a Subquery for asset_count rather than annotate(Count(...)).
+    # annotate + COUNT triggers GROUP BY which conflicts with TimescaleModel's
+    # extra fields (created, modified) on PostgreSQL.
+    # ------------------------------------------------------------------
+    from georiva.core.models import Asset
+    
+    asset_count_sq = (
+        Asset.objects.filter(item=OuterRef("pk"))
+        .order_by()
+        .values("item")
+        .annotate(c=Count("pk"))
+        .values("c")
+    )
+    
+    items = (
+        Item.objects.filter(collection=collection)
+        .annotate(asset_count=Subquery(asset_count_sq))
+        .select_related("ingestion_log")
+        .order_by("-time")
+    )
+    
+    if active_variable:
+        # Only items that have at least one asset for this variable
+        items = items.filter(assets__variable=active_variable).distinct()
+    
+    # ------------------------------------------------------------------
+    # Pagination
+    # ------------------------------------------------------------------
     try:
         page_num = int(request.GET.get("p", 0))
     except ValueError:
         page_num = 0
     
-    paginator = WagtailPaginator(items, 2)
+    paginator = WagtailPaginator(items, 25)
     
     try:
         page_obj = paginator.page(page_num + 1)
     except InvalidPage:
         page_obj = paginator.page(1)
     
-    columns = [
-        TitleColumn("__str__", label=_("Item")),
-    ]
+    elided_page_range = paginator.get_elided_page_range(page_obj.number)
     
-    elided_page_range = paginator.get_elided_page_range(page_num)
+    # ------------------------------------------------------------------
+    # Automation section (only rendered if loader_profile is set)
+    # ------------------------------------------------------------------
+    loader_profile = None
+    recent_runs = []
+    ingestion_summary = {}
     
+    if collection.loader_profile_id:
+        loader_profile = collection.loader_profile
+        
+        recent_runs = list(
+            LoaderRun.objects.filter(collection=collection)
+            .order_by("-started_at")[:5]
+        )
+        
+        logs_qs = IngestionLog.objects.filter(
+            collection_slug=collection.slug,
+            catalog_slug=collection.catalog.slug,
+        )
+        ingestion_summary = logs_qs.aggregate(
+            total=Count("id"),
+            completed=Count("id", filter=Q(status=IngestionLog.Status.COMPLETED)),
+            failed=Count("id", filter=Q(status=IngestionLog.Status.FAILED)),
+            pending=Count("id", filter=Q(status=IngestionLog.Status.PENDING)),
+            processing=Count("id", filter=Q(status=IngestionLog.Status.PROCESSING)),
+            total_items_created=Sum("items_created"),
+            total_assets_created=Sum("assets_created"),
+        )
+    
+    # ------------------------------------------------------------------
+    # Context
+    # ------------------------------------------------------------------
     context = {
         "breadcrumbs_items": [
-            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
-            {"url": "", "label": _("Catalogs")},
+            {"url": reverse("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse("catalog_index"), "label": _("Catalogs")},
+            {"url": "", "label": collection.name},
         ],
+        "collection": collection,
+        "catalog": collection.catalog,
+        "variable_list": variable_list,
+        "variable_count": len(variable_list),
+        "active_var_slug": active_var_slug,
+        "active_variable": active_variable,
+        "page_obj": page_obj,
         "paginator": paginator,
         "elided_page_range": elided_page_range,
-        "page_obj": page_obj,
-        "table": Table(columns, page_obj.object_list),
+        "loader_profile": loader_profile,
+        "recent_runs": recent_runs,
+        "ingestion_summary": ingestion_summary,
     }
     
-    return render(request, 'core/collection_items.html', context)
+    return render(request, "core/collection_items.html", context)

--- a/georiva/src/georiva/core/views.py
+++ b/georiva/src/georiva/core/views.py
@@ -201,14 +201,14 @@ def collection_items_list(request, collection_pk):
     # Pagination
     # ------------------------------------------------------------------
     try:
-        page_num = int(request.GET.get("p", 0))
+        page_num = int(request.GET.get("p", 1))
     except ValueError:
         page_num = 0
     
     paginator = WagtailPaginator(items, 25)
     
     try:
-        page_obj = paginator.page(page_num + 1)
+        page_obj = paginator.page(page_num)
     except InvalidPage:
         page_obj = paginator.page(1)
     

--- a/georiva/src/georiva/core/viewsets.py
+++ b/georiva/src/georiva/core/viewsets.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.widgets import ListingButton
+from wagtail.snippets.views.snippets import SnippetViewSet, IndexView
 
 from georiva.core.models import Item, Catalog, Collection, ColorPalette
 from georiva.core.models.catalog import Topic
@@ -100,7 +102,7 @@ class CollectionViewSet(ModelViewSet):
     index_view_class = CollectionIndexView
 
 
-class ItemIndexView(generic.IndexView):
+class ItemIndexView(IndexView):
     def get_list_more_buttons(self, instance):
         buttons = super().get_list_more_buttons(instance)
         
@@ -121,12 +123,18 @@ class ItemIndexView(generic.IndexView):
         return buttons
 
 
-class ItemViewSet(ModelViewSet):
+class ItemFilterSet(WagtailFilterSet):
+    class Meta:
+        model = Item
+        fields = ["collection"]
+
+
+class ItemViewSet(SnippetViewSet):
     model = Item
     icon = "snippet"
-    add_to_admin_menu = True
     exclude_form_fields = ["created_at", "updated_at"]
     index_view_class = ItemIndexView
+    list_filter = ["collection"]
 
 
 class ColorPaletteModelViewSet(ModelViewSet):

--- a/georiva/src/georiva/core/wagtail_hooks.py
+++ b/georiva/src/georiva/core/wagtail_hooks.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
-from .views import catalog_index
+from .views import catalog_index, collection_items_list
 from .viewsets import BoundaryChooserViewSet, admin_viewsets
 
 
@@ -12,6 +12,7 @@ from .viewsets import BoundaryChooserViewSet, admin_viewsets
 def urlconf_georivacore():
     return [
         path('catalogs/', catalog_index, name="catalog_index"),
+        path('collection/<int:collection_pk>/items/', collection_items_list, name="collection_items_list"),
     ]
 
 

--- a/georiva/src/georiva/core/wagtail_hooks.py
+++ b/georiva/src/georiva/core/wagtail_hooks.py
@@ -3,9 +3,11 @@ from django.urls import path, reverse
 from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
+from wagtail.snippets.models import register_snippet
 
 from .views import catalog_index, collection_items_list
 from .viewsets import BoundaryChooserViewSet, admin_viewsets
+from .viewsets import ItemViewSet
 
 
 @hooks.register('register_admin_urls')
@@ -29,6 +31,9 @@ def register_viewset():
         AdminBoundaryViewSetGroup(),
         BoundaryChooserViewSet("boundary_chooser"),
     ]
+
+
+register_snippet(ItemViewSet)
 
 
 @hooks.register('construct_main_menu')

--- a/georiva/src/georiva/version.py
+++ b/georiva/src/georiva/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 0, 6, "final", 0)
+VERSION = (0, 0, 7, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
Replaces the minimal collection_items_list stub with a full detail view.

## View
- Select-related catalog and boundary upfront to avoid N+1 on summary card
- Asset count via correlated Subquery instead of annotate(Count()) to
  avoid GROUP BY conflict with TimescaleModel's extra fields on PostgreSQL
- Variable tab filtering via ?var=<slug> — filters items to those with
  at least one asset for the selected variable, with .distinct() to
  prevent duplicate rows from the join
- Ingestion summary aggregated in a single query (total, completed,
  failed, pending, processing, items/assets created)
- Last 5 LoaderRun entries fetched for automation section
- Pagination p param treated as 1-based to match Django paginator output


## Template
- Summary card: collection/catalog metadata, time extent, bounds,
  CRS, forecast horizon, clip boundary, status badges
- Variables strip: palette swatch, slug, name, units, derived badge
- Automation card: loader profile status, interval, last run time,
  ingestion stats row, recent runs table, Run Now placeholder action;
  hidden when no loader_profile is set
- Items table: valid time, reference time + horizon (forecast only),
  asset count badge, truncated source file, ingestion log status tag,
  View button linking to item_preview
- Variable tabs  rendered when collection has 2+ variables;
  All tab plus one tab per variable with units badge
- Pagination links carry ?var=<slug> when a tab is active
- Context-aware empty state names the active variable when no items
  match the current tab