### PR TITLE
feat(analysis): add timeseries submodule with point and area endpoints

### DIFF
--- a/georiva/requirements.txt
+++ b/georiva/requirements.txt
@@ -44,3 +44,4 @@ rio-cogeo==7.0.2
 pint==0.25.3
 virtual_tiff==0.4.0
 virtualizarr==2.6.0
+kerchunk==0.2.10

--- a/georiva/src/georiva/analysis/timeseries/apps.py
+++ b/georiva/src/georiva/analysis/timeseries/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class TimeseriesConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'georiva.analysis.timeseries'
+    label = 'georiva_analysis_timeseries'
+    verbose_name = "GeoRIVA Timeseries Analysis"

--- a/georiva/src/georiva/analysis/timeseries/serializers.py
+++ b/georiva/src/georiva/analysis/timeseries/serializers.py
@@ -1,0 +1,156 @@
+"""
+Request and response serializers for the timeseries API.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+# ---------------------------------------------------------------------------
+# Shared fields
+# ---------------------------------------------------------------------------
+
+class VariablePathField(serializers.CharField):
+    """
+    Parses and validates ``catalog_slug/collection_slug/variable_slug``.
+
+    Returns a resolved ``Variable`` instance via ``to_internal_value``.
+    """
+    
+    def to_internal_value(self, data: str):
+        value = super().to_internal_value(data)
+        parts = value.strip("/").split("/")
+        if len(parts) != 3:
+            raise serializers.ValidationError(
+                "Must be catalog_slug/collection_slug/variable_slug, "
+                f"e.g. chirps/chirps-monthly/precipitation. Got: {value!r}"
+            )
+        catalog_slug, collection_slug, variable_slug = parts
+        
+        from georiva.core.models import Variable
+        
+        try:
+            return Variable.objects.select_related(
+                "collection",
+                "collection__catalog",
+                "unit",
+            ).get(
+                slug=variable_slug,
+                collection__slug=collection_slug,
+                collection__catalog__slug=catalog_slug,
+                is_active=True,
+            )
+        except Variable.DoesNotExist:
+            raise serializers.ValidationError(
+                f"Variable not found or inactive: {value!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Request serializers
+# ---------------------------------------------------------------------------
+
+class PointRequestSerializer(serializers.Serializer):
+    variable = VariablePathField(
+        help_text="catalog_slug/collection_slug/variable_slug"
+    )
+    lat = serializers.FloatField(min_value=-90.0, max_value=90.0)
+    lon = serializers.FloatField(min_value=-180.0, max_value=180.0)
+    time_start = serializers.DateTimeField(required=False, default=None)
+    time_end = serializers.DateTimeField(required=False, default=None)
+    
+    def validate(self, attrs):
+        start = attrs.get("time_start")
+        end = attrs.get("time_end")
+        if start and end and start >= end:
+            raise serializers.ValidationError(
+                "time_start must be before time_end."
+            )
+        return attrs
+
+
+class AreaRequestSerializer(serializers.Serializer):
+    AGGREGATIONS = ["mean", "sum", "min", "max", "std"]
+    
+    variable = VariablePathField(
+        help_text="catalog_slug/collection_slug/variable_slug"
+    )
+    geometry = serializers.JSONField(
+        help_text="GeoJSON geometry (Polygon or MultiPolygon)"
+    )
+    aggregation = serializers.ChoiceField(
+        choices=AGGREGATIONS,
+        default="mean",
+    )
+    time_start = serializers.DateTimeField(required=False, default=None)
+    time_end = serializers.DateTimeField(required=False, default=None)
+    
+    def validate_geometry(self, value):
+        """Check geometry is a valid GeoJSON Polygon or MultiPolygon."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Must be a GeoJSON geometry object.")
+        
+        geom_type = value.get("type")
+        if geom_type not in ("Polygon", "MultiPolygon"):
+            raise serializers.ValidationError(
+                f"geometry.type must be Polygon or MultiPolygon, got {geom_type!r}."
+            )
+        if "coordinates" not in value:
+            raise serializers.ValidationError(
+                "geometry must have a 'coordinates' key."
+            )
+        
+        # Validate with shapely so we catch self-intersections etc.
+        try:
+            from shapely.geometry import shape
+            from shapely.validation import explain_validity
+            
+            geom = shape(value)
+            if not geom.is_valid:
+                raise serializers.ValidationError(
+                    f"Invalid geometry: {explain_validity(geom)}"
+                )
+        except ImportError:
+            pass  # shapely not installed — skip deep validation
+        
+        return value
+    
+    def validate(self, attrs):
+        start = attrs.get("time_start")
+        end = attrs.get("time_end")
+        if start and end and start >= end:
+            raise serializers.ValidationError(
+                "time_start must be before time_end."
+            )
+        return attrs
+
+
+# ---------------------------------------------------------------------------
+# Response serializers
+# ---------------------------------------------------------------------------
+
+class TimeseriesValueSerializer(serializers.Serializer):
+    time = serializers.DateTimeField()
+    value = serializers.FloatField(allow_null=True)
+
+
+class PointResponseSerializer(serializers.Serializer):
+    variable = serializers.CharField()
+    units = serializers.CharField()
+    lat = serializers.FloatField()
+    lon = serializers.FloatField()
+    time_start = serializers.DateTimeField(allow_null=True)
+    time_end = serializers.DateTimeField(allow_null=True)
+    count = serializers.IntegerField()
+    data = TimeseriesValueSerializer(many=True)
+
+
+class AreaResponseSerializer(serializers.Serializer):
+    variable = serializers.CharField()
+    units = serializers.CharField()
+    aggregation = serializers.CharField()
+    time_start = serializers.DateTimeField(allow_null=True)
+    time_end = serializers.DateTimeField(allow_null=True)
+    count = serializers.IntegerField()
+    data = TimeseriesValueSerializer(many=True)

--- a/georiva/src/georiva/analysis/timeseries/service.py
+++ b/georiva/src/georiva/analysis/timeseries/service.py
@@ -1,0 +1,284 @@
+"""
+
+TimeseriesService — extracts time series from virtual Zarr manifests.
+
+Point queries are synchronous and return immediately.
+Area queries (arbitrary GeoJSON polygons) are designed for async use via
+Celery but can also be called synchronously for small polygons.
+
+Both methods share the same open → subset → load pipeline.  The manifest
+is opened fresh per call — there is no process-level cache here.  If you
+need caching, wrap the caller (e.g. Django cache on the view layer).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class ManifestNotReady(Exception):
+    """Raised when the VirtualZarrManifest for a variable is not READY."""
+
+
+class TimeseriesService:
+    """
+    Extracts time series data from virtual Zarr manifests.
+
+    Parameters
+    ----------
+    internal : bool
+        True  → fetch chunks via the internal MinIO endpoint (default,
+                 used from Celery workers and Django views inside the
+                 container).
+        False → fetch chunks via the public endpoint (external callers).
+    """
+    
+    def __init__(self, *, internal: bool = True) -> None:
+        self._internal = internal
+    
+    # -------------------------------------------------------------------------
+    # Public API
+    # -------------------------------------------------------------------------
+    
+    def point(
+            self,
+            variable: "Variable",
+            lat: float,
+            lon: float,
+            time_start: datetime | None = None,
+            time_end: datetime | None = None,
+    ) -> pd.Series:
+        """
+        Extract a point time series for a single lat/lon coordinate.
+
+        Uses xarray nearest-neighbour selection — the closest grid cell to
+        (lat, lon) is returned.  No interpolation is performed.
+
+        Parameters
+        ----------
+        variable : Variable
+            The Variable model instance to query.
+        lat, lon : float
+            WGS84 coordinates of the point.
+        time_start, time_end : datetime, optional
+            Inclusive time range filter.  If omitted, the full archive is
+            returned.
+
+        Returns
+        -------
+        pd.Series
+            Index: UTC datetime.  Values: float (variable's output units).
+            Name: variable.slug.
+
+        Raises
+        ------
+        ManifestNotReady
+            If the variable has no READY manifest.
+        """
+        ds = self._open_dataset(variable)
+        
+        da = ds[variable.slug]
+        da = self._filter_time(da, time_start, time_end)
+        
+        logger.debug(
+            "Point query: %s @ (%.4f, %.4f)", variable.slug, lat, lon
+        )
+        
+        result = (
+            da
+            .sel(lat=lat, lon=lon, method="nearest")
+            .load()
+        )
+        
+        return self._to_series(result, variable.slug)
+    
+    def area(
+            self,
+            variable: "Variable",
+            geometry: dict,
+            aggregation: str = "mean",
+            time_start: datetime | None = None,
+            time_end: datetime | None = None,
+    ) -> pd.Series:
+        """
+        Zonal statistics over an arbitrary GeoJSON polygon.
+
+        Strategy:
+          1. Bbox subset  — reduces data fetched from MinIO to tiles that
+                            intersect the polygon bounding box.
+          2. Polygon mask — sets pixels outside the geometry to NaN using
+                            regionmask.
+          3. Aggregation  — mean/sum/min/max/std over the masked spatial dims.
+
+        Parameters
+        ----------
+        variable : Variable
+            The Variable model instance to query.
+        geometry : dict
+            GeoJSON geometry (Polygon or MultiPolygon).
+        aggregation : str
+            One of ``mean``, ``sum``, ``min``, ``max``, ``std``.
+        time_start, time_end : datetime, optional
+            Inclusive time range filter.
+
+        Returns
+        -------
+        pd.Series
+            Index: UTC datetime.  Values: float (aggregated, variable units).
+            Name: ``{variable.slug}_{aggregation}``.
+
+        Raises
+        ------
+        ManifestNotReady
+            If the variable has no READY manifest.
+        ValueError
+            If ``aggregation`` is not one of the supported values.
+        """
+        supported = {"mean", "sum", "min", "max", "std"}
+        if aggregation not in supported:
+            raise ValueError(
+                f"Unsupported aggregation {aggregation!r}. "
+                f"Choose from: {sorted(supported)}"
+            )
+        
+        ds = self._open_dataset(variable)
+        
+        da = ds[variable.slug]
+        da = self._filter_time(da, time_start, time_end)
+        
+        # --- Bbox subset ----------------------------------------------------
+        # Reduce the spatial extent to the polygon's bounding box before
+        # loading any data.  Only the intersecting COG tiles are fetched.
+        da = self._bbox_subset(da, geometry)
+        
+        # --- Load into memory ------------------------------------------------
+        # Load after bbox subset so we only pull the tiles we need.
+        da = da.load()
+        
+        # --- Polygon mask ----------------------------------------------------
+        da = self._apply_polygon_mask(da, geometry)
+        
+        # --- Spatial aggregation ---------------------------------------------
+        agg_fn = {
+            "mean": da.mean,
+            "sum": da.sum,
+            "min": da.min,
+            "max": da.max,
+            "std": da.std,
+        }[aggregation]
+        
+        result = agg_fn(dim=["lat", "lon"], skipna=True)
+        
+        series_name = f"{variable.slug}_{aggregation}"
+        return self._to_series(result, series_name)
+    
+    # -------------------------------------------------------------------------
+    # Private helpers
+    # -------------------------------------------------------------------------
+    
+    def _open_dataset(self, variable: "Variable"):
+        """
+        Open the virtual Zarr manifest for a variable as a lazy xarray Dataset.
+
+        Raises ManifestNotReady if the manifest does not exist or is not READY.
+        Downloads the manifest JSON from MinIO to a temp file, then opens it
+        via the kerchunk engine.
+        """
+        from georiva.virtual_zarr.models import VirtualZarrManifest
+        
+        try:
+            manifest = VirtualZarrManifest.objects.get(variable=variable)
+        except VirtualZarrManifest.DoesNotExist:
+            raise ManifestNotReady(
+                f"No virtual Zarr manifest found for {variable}. "
+                "Run: manage.py build_virtual_zarr "
+                f"--collection {variable.collection.catalog.slug}"
+                f"/{variable.collection.slug} "
+                f"--variable {variable.slug}"
+            )
+        
+        return manifest.open_dataset(internal=self._internal, chunks={})
+    
+    def _filter_time(self, da, time_start, time_end):
+        """Apply an optional time range slice to a DataArray."""
+        if time_start is None and time_end is None:
+            return da
+        
+        # Normalise to tz-naive UTC strings for xarray slice
+        def _fmt(dt: datetime) -> str:
+            if hasattr(dt, "tzinfo") and dt.tzinfo is not None:
+                import pytz
+                dt = dt.astimezone(pytz.utc).replace(tzinfo=None)
+            return str(dt)
+        
+        start = _fmt(time_start) if time_start else None
+        end = _fmt(time_end) if time_end else None
+        
+        return da.sel(time=slice(start, end))
+    
+    def _bbox_subset(self, da, geometry: dict):
+        """
+        Subset a DataArray to the bounding box of a GeoJSON geometry.
+
+        Uses shapely to compute the bbox — no rasterio or GDAL required.
+        The subset is inclusive so border pixels are included.
+        """
+        from shapely.geometry import shape
+        
+        geom = shape(geometry)
+        minx, miny, maxx, maxy = geom.bounds
+        
+        return da.sel(
+            lat=slice(maxy, miny),  # lat is descending (north → south)
+            lon=slice(minx, maxx),
+        )
+    
+    def _apply_polygon_mask(self, da, geometry: dict):
+        """
+        Mask pixels outside the GeoJSON geometry to NaN using regionmask.
+
+        regionmask.Regions([geom]).mask() returns a DataArray of region
+        indices (0 inside, NaN outside).  We keep pixels where mask == 0.
+        """
+        try:
+            import regionmask
+            from shapely.geometry import shape
+            
+            geom = shape(geometry)
+            regions = regionmask.Regions([geom])
+            mask = regions.mask(da)
+            return da.where(mask == 0)
+        
+        except ImportError:
+            # regionmask not installed — fall back to bbox only with a warning.
+            logger.warning(
+                "regionmask not installed — polygon masking skipped. "
+                "Install regionmask for precise polygon masking: "
+                "pip install regionmask"
+            )
+            return da
+    
+    @staticmethod
+    def _to_series(result, name: str) -> pd.Series:
+        """
+        Convert a 1-D time DataArray to a pandas Series.
+
+        Drops NaN values (masked nodata pixels outside the boundary) and
+        ensures a clean UTC DatetimeIndex with no timezone info attached
+        (consistent with how TimescaleDB returns timestamps).
+        """
+        series = result.to_series().rename(name)
+        
+        # Drop NaN — nodata values from masked pixels or missing timesteps
+        series = series.dropna()
+        
+        # Ensure the index is tz-naive UTC
+        if hasattr(series.index, "tz") and series.index.tz is not None:
+            series.index = series.index.tz_convert("UTC").tz_localize(None)
+        
+        return series

--- a/georiva/src/georiva/analysis/timeseries/tests.py
+++ b/georiva/src/georiva/analysis/timeseries/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/georiva/src/georiva/analysis/timeseries/urls.py
+++ b/georiva/src/georiva/analysis/timeseries/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import AreaTimeseriesView, PointTimeseriesView
+
+app_name = "timeseries"
+
+urlpatterns = [
+    path("point/", PointTimeseriesView.as_view(), name="point"),
+    path("area/",  AreaTimeseriesView.as_view(),  name="area"),
+]

--- a/georiva/src/georiva/analysis/timeseries/views.py
+++ b/georiva/src/georiva/analysis/timeseries/views.py
@@ -1,0 +1,184 @@
+"""
+
+Point and area timeseries API views.
+
+Point  — GET  /api/analysis/timeseries/point/
+Area   — POST /api/analysis/timeseries/area/
+
+Both endpoints resolve the variable from the natural key
+``catalog_slug/collection_slug/variable_slug`` and delegate
+extraction to TimeseriesService.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import (
+    AreaRequestSerializer,
+    AreaResponseSerializer,
+    PointRequestSerializer,
+    PointResponseSerializer,
+)
+from .service import ManifestNotReady, TimeseriesService
+
+logger = logging.getLogger(__name__)
+
+
+def _series_to_data(series) -> list[dict]:
+    """Convert a pandas Series to the [{time, value}] response format."""
+    return [
+        {"time": ts.isoformat() + "Z", "value": None if v != v else float(v)}
+        for ts, v in series.items()
+    ]
+
+
+class PointTimeseriesView(APIView):
+    """
+    Extract a point time series from a virtual Zarr manifest.
+
+    GET /api/analysis/timeseries/point/
+        ?variable=chirps/chirps-monthly/precipitation
+        &lat=-1.286389
+        &lon=36.817223
+        &time_start=2020-01-01        (optional)
+        &time_end=2024-12-31          (optional)
+
+    Returns the full time series for the nearest grid cell to (lat, lon).
+    """
+    
+    def get(self, request: Request) -> Response:
+        serializer = PointRequestSerializer(data=request.query_params)
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        
+        data = serializer.validated_data
+        variable = data["variable"]
+        lat = data["lat"]
+        lon = data["lon"]
+        time_start = data.get("time_start")
+        time_end = data.get("time_end")
+        
+        try:
+            service = TimeseriesService(internal=True)
+            series = service.point(
+                variable=variable,
+                lat=lat,
+                lon=lon,
+                time_start=time_start,
+                time_end=time_end,
+            )
+        except ManifestNotReady as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Point timeseries failed for %s @ (%.4f, %.4f)",
+                variable.slug, lat, lon,
+            )
+            return Response(
+                {"detail": "Timeseries extraction failed.", "error": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        
+        payload = {
+            "variable": variable.slug,
+            "units": variable.unit.symbol if variable.unit else "",
+            "lat": lat,
+            "lon": lon,
+            "time_start": series.index.min().isoformat() + "Z" if len(series) else None,
+            "time_end": series.index.max().isoformat() + "Z" if len(series) else None,
+            "count": len(series),
+            "data": _series_to_data(series),
+        }
+        
+        return Response(
+            PointResponseSerializer(payload).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class AreaTimeseriesView(APIView):
+    """
+    Zonal statistics over an arbitrary GeoJSON polygon.
+
+    POST /api/analysis/timeseries/area/
+    {
+        "variable":    "chirps/chirps-monthly/precipitation",
+        "geometry":    { "type": "Polygon", "coordinates": [...] },
+        "aggregation": "mean",
+        "time_start":  "2020-01-01",
+        "time_end":    "2024-12-31"
+    }
+
+    Runs synchronously.  For large areas or long time ranges, wrap this
+    in a Celery task and return a task_id instead (see tasks.py).
+    """
+    
+    def post(self, request: Request) -> Response:
+        serializer = AreaRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        
+        data = serializer.validated_data
+        variable = data["variable"]
+        geometry = data["geometry"]
+        aggregation = data["aggregation"]
+        time_start = data.get("time_start")
+        time_end = data.get("time_end")
+        
+        try:
+            service = TimeseriesService(internal=True)
+            series = service.area(
+                variable=variable,
+                geometry=geometry,
+                aggregation=aggregation,
+                time_start=time_start,
+                time_end=time_end,
+            )
+        except ManifestNotReady as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except ValueError as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Area timeseries failed for %s", variable.slug
+            )
+            return Response(
+                {"detail": "Timeseries extraction failed.", "error": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        
+        payload = {
+            "variable": variable.slug,
+            "units": variable.unit.symbol if variable.unit else "",
+            "aggregation": aggregation,
+            "time_start": series.index.min().isoformat() + "Z" if len(series) else None,
+            "time_end": series.index.max().isoformat() + "Z" if len(series) else None,
+            "count": len(series),
+            "data": _series_to_data(series),
+        }
+        
+        return Response(
+            AreaResponseSerializer(payload).data,
+            status=status.HTTP_200_OK,
+        )

--- a/georiva/src/georiva/analysis/urls.py
+++ b/georiva/src/georiva/analysis/urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("timeseries/", include("georiva.analysis.timeseries.urls")),
+]

--- a/georiva/src/georiva/api/urls.py
+++ b/georiva/src/georiva/api/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
         TileConfigView.as_view(),
         name='tile_config',
     ),
+    path("analysis/", include("georiva.analysis.urls")),
 ]

--- a/georiva/src/georiva/config/settings/base.py
+++ b/georiva/src/georiva/config/settings/base.py
@@ -66,7 +66,7 @@ INSTALLED_APPS = [
     "georiva.formats",
     "georiva.ingestion",
     "georiva.virtual_zarr",
-    "georiva.analysis",
+    "georiva.analysis.timeseries",
     "georiva.api",
     "georiva.stac",
     "georiva.edr",


### PR DESCRIPTION
- georiva/analysis/ namespace package with shared urls.py router
- georiva.analysis.timeseries Django app

- TimeseriesService.point() — nearest-neighbour point extraction from virtual Zarr manifest via xarray .sel()
- TimeseriesService.area() — zonal stats over arbitrary GeoJSON polygon
- VariablePathField resolves catalog_slug/collection_slug/variable_slug natural key to Variable instance in a single select_related query
- ManifestNotReady exception → 503 so callers know to retry later