### PR TITLE
refactor collection items listing

### DIFF
--- a/georiva/src/georiva/core/models/item.py
+++ b/georiva/src/georiva/core/models/item.py
@@ -155,6 +155,18 @@ class Item(TimescaleModel, TimeStampedModel, ClusterableModel):
     def thumbnail(self) -> 'Asset':
         """Get thumbnail asset."""
         return self.assets.filter(roles__contains=['thumbnail']).first()
+    
+    @property
+    def time_iso(self) -> str:
+        """ISO 8601 UTC string with Z suffix, for use in API URLs and templates."""
+        return self.time.strftime('%Y-%m-%dT%H:%M:%SZ')
+    
+    @property
+    def reference_time_iso(self) -> str | None:
+        """ISO 8601 UTC string with Z suffix for reference_time, or None."""
+        if self.reference_time:
+            return self.reference_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+        return None
 
 
 class Asset(TimeStampedModel, Orderable):
@@ -320,6 +332,16 @@ class Asset(TimeStampedModel, Orderable):
         """Get public URL to this asset."""
         from georiva.core.storage import storage
         return storage.assets.url(self.href)
+    
+    @property
+    def preview_url(self) -> str:
+        """TiTiler preview URL for this asset."""
+        from urllib.parse import urlencode
+        params = {'time': self.item.time_iso}
+        if self.item.reference_time:
+            params['reftime'] = self.item.reference_time_iso
+        qs = urlencode(params)
+        return f"/titiler/{self.item.collection.catalog.slug}/{self.item.collection.slug}/{self.variable.slug}/preview.webp?{qs}"
 
 
 # =============================================================================

--- a/georiva/src/georiva/core/templatetags/georiva_tags.py
+++ b/georiva/src/georiva/core/templatetags/georiva_tags.py
@@ -160,3 +160,34 @@ def query_params(filters, **kwargs):
     if 'page' not in kwargs:
         params.pop('page', None)
     return urlencode(params)
+
+
+@register.simple_tag(takes_context=True)
+def query_string_replace(context, key, value):
+    """
+    Return the current query string with `key` set to `value`.
+    All other parameters are preserved.
+ 
+    Usage:
+        <a href="?{% query_string_replace 'page' 3 %}">Page 3</a>
+    """
+    request = context.get('request')
+    params = request.GET.copy() if request else {}
+    params[key] = value
+    return params.urlencode()
+
+
+@register.simple_tag(takes_context=True)
+def query_string_drop(context, *keys):
+    """
+    Return the current query string with the given keys removed.
+    All other parameters are preserved.
+ 
+    Usage:
+        <a href="?{% query_string_drop 'date' 'page' %}">Clear date</a>
+    """
+    request = context.get('request')
+    params = request.GET.copy() if request else {}
+    for key in keys:
+        params.pop(key, None)
+    return params.urlencode()

--- a/georiva/src/georiva/pages/datasets/models.py
+++ b/georiva/src/georiva/pages/datasets/models.py
@@ -1,10 +1,15 @@
 from django.core.paginator import Paginator
 from django.db import models
+from django.shortcuts import get_object_or_404, render
+from django.utils.dateparse import parse_date, parse_datetime
+from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.contrib.routable_page.models import RoutablePageMixin, path
 from wagtail.models import Page
 
-from georiva.core.models import Catalog, Collection, Topic
+from georiva.core.models import Catalog, Collection, Topic, Item
+
+ITEMS_PER_PAGE = 24
 
 
 class DatasetsIndexPage(RoutablePageMixin, Page):
@@ -49,7 +54,6 @@ class DatasetsIndexPage(RoutablePageMixin, Page):
     @path('')
     def index(self, request):
         """All collections — filterable by topic, resolution, catalog. Paginated."""
-        from django.shortcuts import render
         
         collections = self._base_collections_qs()
         collections, filters = self._apply_filters(request, collections)
@@ -68,7 +72,6 @@ class DatasetsIndexPage(RoutablePageMixin, Page):
     @path('<slug:catalog_slug>/')
     def catalog_detail(self, request, catalog_slug):
         """Catalog landing page — shows catalog metadata + all its collections."""
-        from django.shortcuts import get_object_or_404, render
         
         catalog = get_object_or_404(Catalog, slug=catalog_slug, is_active=True)
         collections = (
@@ -84,8 +87,7 @@ class DatasetsIndexPage(RoutablePageMixin, Page):
     
     @path('<slug:catalog_slug>/<slug:collection_slug>/')
     def collection_detail(self, request, catalog_slug, collection_slug):
-        from django.shortcuts import get_object_or_404, render
-
+        
         catalog = get_object_or_404(Catalog, slug=catalog_slug, is_active=True)
         collection = get_object_or_404(
             Collection,
@@ -93,18 +95,76 @@ class DatasetsIndexPage(RoutablePageMixin, Page):
             slug=collection_slug,
             is_active=True,
         )
-
+        
+        variables = collection.variables.filter(is_active=True).order_by('sort_order')
+        
+        # --- Filters from GET params ---
+        selected_vars = request.GET.getlist('variable')
+        date_str = request.GET.get('date', '').strip()
+        run_str = request.GET.get('run', '').strip()
+        
+        filters = {
+            'variables': selected_vars,  # list of slugs; empty means "all"
+            'date': date_str,
+            'run': run_str,
+        }
+        
+        # --- Asset queryset ---
+        # Paginate Asset objects directly so that one page = exactly N cards.
+        # Each Asset is one (item, variable) pair — the natural unit for a card.
+        from georiva.core.models import Asset
+        assets_qs = (
+            Asset.objects
+            .filter(
+                item__collection=collection,
+                variable__is_active=True,
+            )
+            .select_related('item', 'item__collection__catalog', 'variable')
+            .order_by('-item__time', 'variable__sort_order')
+        )
+        
+        if selected_vars:
+            assets_qs = assets_qs.filter(variable__slug__in=selected_vars)
+        
+        if date_str:
+            parsed_date = parse_date(date_str)
+            if parsed_date:
+                assets_qs = assets_qs.filter(item__time__date=parsed_date)
+        
+        if run_str:
+            parsed_run = parse_datetime(run_str)
+            if parsed_run:
+                assets_qs = assets_qs.filter(item__reference_time=parsed_run)
+        
+        page_number = request.GET.get("p", 1)
+        paginator = WagtailPaginator(assets_qs, ITEMS_PER_PAGE)
+        items_page = paginator.get_page(page_number)
+        page_range = paginator.get_elided_page_range(items_page.number)
+        
+        # Forecast runs for the dropdown (only needed for forecast collections)
+        forecast_runs = []
+        if collection.is_forecast:
+            forecast_runs = (
+                Item.objects
+                .filter(collection=collection, reference_time__isnull=False)
+                .values_list('reference_time', flat=True)
+                .distinct()
+                .order_by('-reference_time')[:50]
+            )
         return render(request, 'datasets/collection_detail.html', {
             'page': self,
             'catalog': catalog,
             'collection': collection,
-            'variables': collection.variables.filter(is_active=True).order_by('sort_order'),
+            'variables': variables,
+            'items': items_page,
+            "page_range": page_range,
+            'filters': filters,
+            'forecast_runs': forecast_runs,
         })
-
+    
     @path('<slug:catalog_slug>/<slug:collection_slug>/items/<str:item_id>/')
     def item_detail(self, request, catalog_slug, collection_slug, item_id):
-        from django.shortcuts import get_object_or_404, render
-
+        
         catalog = get_object_or_404(Catalog, slug=catalog_slug, is_active=True)
         collection = get_object_or_404(
             Collection,
@@ -112,7 +172,7 @@ class DatasetsIndexPage(RoutablePageMixin, Page):
             slug=collection_slug,
             is_active=True,
         )
-
+        
         return render(request, 'datasets/item_detail.html', {
             'page': self,
             'catalog': catalog,

--- a/georiva/src/georiva/pages/datasets/static/css/georiva-pagination.css
+++ b/georiva/src/georiva/pages/datasets/static/css/georiva-pagination.css
@@ -1,0 +1,153 @@
+/* georiva-pagination.css
+   Matches the Wagtail admin pagination_nav.html markup structure,
+   using GeoRiva design tokens instead of --w-color-* variables.
+*/
+
+.pagination {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-top: 2rem;
+    text-align: center;
+}
+
+@media screen and (min-width: 50em) {
+    .pagination {
+        flex-wrap: nowrap;
+    }
+}
+
+.pagination__start,
+.pagination__end {
+    display: flex;
+    flex: 1;
+}
+
+@media screen and (max-width: 74.9375em) {
+    .pagination__start,
+    .pagination__end {
+        flex-basis: auto;
+    }
+}
+
+.pagination__end {
+    justify-content: end;
+}
+
+.pagination p {
+    color: var(--gr-text-3);
+    font-family: var(--gr-font-mono);
+    font-size: 0.8rem;
+    margin: 0;
+}
+
+/* ── List ── */
+
+.pagination ul {
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+    justify-content: center;
+    list-style-type: none;
+    margin: 0;
+    padding-inline-start: 0;
+}
+
+.pagination ul li {
+    align-items: center;
+    display: flex;
+    font-style: normal;
+    line-height: 1em;
+    list-style-type: none;
+}
+
+.pagination li a,
+.pagination li span {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+}
+
+/* ── Page number buttons ── */
+
+.pagination li.pagination__page-number a,
+.pagination li.pagination__page-number span {
+    font-family: var(--gr-font-mono);
+    font-size: 0.8rem;
+    font-weight: 500;
+    height: 2rem;
+    margin: 0.25rem;
+    min-width: 2rem;
+}
+
+.pagination li.pagination__page-number a {
+    border: 1px solid var(--gr-border);
+    border-radius: 0.25rem;
+    color: var(--gr-text-2);
+    padding: 0.25rem 0.5rem;
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.pagination li.pagination__page-number a:hover {
+    background-color: var(--gr-surface-2);
+    border-color: var(--gr-accent);
+    color: var(--gr-accent);
+}
+
+/* Current page */
+.pagination li.pagination__page-number--current a {
+    background-color: var(--gr-accent);
+    border-color: transparent;
+    color: #fff;
+}
+
+.pagination li.pagination__page-number--current a:hover {
+    background-color: var(--gr-accent);
+    color: #fff;
+}
+
+/* Ellipsis */
+.pagination li.pagination__page-number span {
+    color: var(--gr-text-3);
+    font-family: var(--gr-font-mono);
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+}
+
+/* ── Prev / Next ── */
+
+.pagination li.prev,
+.pagination li.next {
+    margin: 0 0.5rem;
+}
+
+.pagination li.prev a,
+.pagination li.next a {
+    align-items: center;
+    border: 1px solid var(--gr-border);
+    border-radius: 0.25rem;
+    color: var(--gr-text-2);
+    display: flex;
+    font-size: 0.8rem;
+    gap: 0.35rem;
+    padding: 0.25rem 0.75rem;
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.pagination li.prev a:hover,
+.pagination li.next a:hover {
+    background-color: var(--gr-surface-2);
+    border-color: var(--gr-accent);
+    color: var(--gr-accent);
+}
+
+/* Disabled — when the <a> has no href (matching Wagtail's pattern) */
+.pagination li.prev a:not([href]),
+.pagination li.next a:not([href]) {
+    cursor: default;
+    opacity: 0.35;
+    pointer-events: none;
+}

--- a/georiva/src/georiva/pages/datasets/templates/datasets/collection_detail.html
+++ b/georiva/src/georiva/pages/datasets/templates/datasets/collection_detail.html
@@ -7,16 +7,7 @@
     <link rel="stylesheet" href="{% static 'css/georiva-home.css' %}">
     <link rel="stylesheet" href="{% static 'css/georiva-catalog-detail.css' %}">
     <link rel="stylesheet" href="{% static 'css/georiva-collection-detail.css' %}">
-    <link href="https://unpkg.com/maplibre-gl@4.1.0/dist/maplibre-gl.css" rel="stylesheet"/>
-    <link rel="stylesheet" href="{% static 'css/datetime-selector.css' %}">
-    <style>
-        .gr-dts-selector {
-            position: absolute;
-            bottom: 1rem;
-            left: 1rem;
-            width: 270px;
-        }
-    </style>
+    <link rel="stylesheet" href="{% static 'css/georiva-pagination.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -152,193 +143,137 @@
         </div>
     </section>
 
-    {# ── Map ── #}
-    <div class="gr-map-section">
-        <div class="gr-container">
-            <div class="gr-map-shell">
-                <div class="gr-map-canvas" id="grMapCanvas">
-
-                    {# Left variables panel #}
-                    <aside class="gr-map-sidebar" id="grMapSidebar">
-                        <div class="gr-map-sidebar-header">
-                            <span class="gr-map-sidebar-label">Layers</span>
-                        </div>
-                        <div class="gr-map-sidebar-body" id="grVariableList">
-                            {% for variable in variables %}
-                                <button class="gr-map-var-btn {% if forloop.first %}gr-map-var-btn--active{% endif %}"
-                                        type="button"
-                                        data-variable-slug="{{ variable.slug }}"
-                                        data-variable-name="{{ variable.name }}"
-                                        data-variable-units="{{ variable.units|default:'' }}">
-                                    <span class="gr-map-var-dot"></span>
-                                    <span class="gr-map-var-name">{{ variable.name }}</span>
-                                    {% if variable.units %}
-                                        <span class="gr-map-var-unit gr-mono">{{ variable.units }}</span>
-                                    {% endif %}
-                                </button>
-                                {% empty %}
-                                <p class="gr-map-sidebar-empty">No variables</p>
-                            {% endfor %}
-                        </div>
-                    </aside>
-
-                    <div id="grMap"></div>
-
-                    {# Basemap selector #}
-                    <div class="gr-map-basemap-selector">
-                        <button class="gr-map-basemap-btn" id="grBasemapBtn" type="button">
-                            <i class="bi bi-layers-half"></i>
-                            <span id="grBasemapLabel">Dark</span>
-                            <i class="bi bi-chevron-down" style="font-size:0.6rem;opacity:0.6"></i>
-                        </button>
-                        <div class="gr-map-basemap-menu" id="grBasemapMenu">
-                            <div class="gr-map-basemap-option" data-basemap="dark">
-                                <span>Dark</span><i class="bi bi-check2 gr-bm-check"></i>
-                            </div>
-                            <div class="gr-map-basemap-option" data-basemap="light">
-                                <span>Light</span><i class="bi bi-check2 gr-bm-check"></i>
-                            </div>
-                            <div class="gr-map-basemap-option" data-basemap="satellite">
-                                <span>Satellite</span><i class="bi bi-check2 gr-bm-check"></i>
-                            </div>
-                            <div class="gr-map-basemap-option" data-basemap="osm">
-                                <span>OSM</span><i class="bi bi-check2 gr-bm-check"></i>
-                            </div>
-                        </div>
-                    </div>
-
-                    {# Legend panel — bottom left #}
-                    <div class="gr-map-legend" id="grLegend" style="display:none">
-                        <div class="gr-map-legend-title" id="grLegendTitle">—</div>
-                        <div class="gr-map-legend-scale" id="grLegendScale"></div>
-                        <div class="gr-map-legend-labels">
-                            <span id="grLegendMin">0</span>
-                            <span id="grLegendMax">100</span>
-                        </div>
-                        <div class="gr-map-legend-units" id="grLegendUnits"></div>
-                        <div class="gr-map-legend-opacity">
-                            <span>Opacity</span>
-                            <span id="grOpacityVal">100%</span>
-                        </div>
-                        <input type="range" class="gr-map-opacity-slider" id="grOpacitySlider"
-                               min="0" max="100" value="100">
-                    </div>
-
-                    {# Loading spinner #}
-                    <div class="gr-map-loading" id="grMapLoading" style="display:none">
-                        <div class="gr-map-spinner"></div>
-                        <span>Loading layer…</span>
-                    </div>
-
-                    {# Time selector #}
-                    <div class="gr-dts-selector" id="grDatetimeSelector"></div>
-
-                </div>
-                {# /gr-map-canvas #}
-            </div>
-            {# /gr-map-shell #}
-        </div>
-    </div>
-
     {# ── Items Browser ── #}
     <section class="gr-section gr-section--alt">
         <div class="gr-container">
 
             <div class="gr-section-header">
                 <h2 class="gr-section-title">Items</h2>
-                <span id="grItemsCount"
-                      style="font-family:var(--gr-font-mono);font-size:0.72rem;color:var(--gr-text-3)"></span>
+                {% if items.paginator.count %}
+                    <span style="font-family:var(--gr-font-mono);font-size:0.72rem;color:var(--gr-text-3)">
+                        {{ items.paginator.count }} item{{ items.paginator.count|pluralize }}
+                    </span>
+                {% endif %}
             </div>
 
             <div class="gr-datasets-layout gr-items-browser">
 
                 {# ── Sidebar filters ── #}
                 <aside class="gr-sidebar gr-items-sidebar">
+                    <form method="get" id="grItemsFilterForm">
 
-                    {# Variables #}
-                    {% if variables %}
-                        <div class="gr-sidebar-filter is-open" id="filter-variables">
-                            <div class="gr-sidebar-filter-header" onclick="toggleItemsFilter('filter-variables')">
-                                <span>Variables</span>
+                        {# Variables #}
+                        {% if variables %}
+                            <div class="gr-sidebar-filter is-open" id="filter-variables">
+                                <div class="gr-sidebar-filter-header" data-filter-toggle="filter-variables">
+                                    <span>Variables</span>
+                                    <i class="bi bi-chevron-down"></i>
+                                </div>
+                                <div class="gr-sidebar-filter-body">
+                                    {% for variable in variables %}
+                                        <label class="gr-items-var-checkbox">
+                                            <input type="checkbox" name="variable"
+                                                   value="{{ variable.slug }}"
+                                                   {% if variable.slug in filters.variables or not filters.variables %}checked{% endif %}>
+                                            <span class="gr-items-var-label">{{ variable.name }}</span>
+                                            {% if variable.units %}
+                                                <small class="gr-mono gr-items-var-unit">{{ variable.units }}</small>
+                                            {% endif %}
+                                        </label>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+
+                        {# Valid Date #}
+                        <div class="gr-sidebar-filter is-open" id="filter-date">
+                            <div class="gr-sidebar-filter-header" data-filter-toggle="filter-date">
+                                <span>Date</span>
                                 <i class="bi bi-chevron-down"></i>
                             </div>
                             <div class="gr-sidebar-filter-body">
-                                {% for variable in variables %}
-                                    <label class="gr-items-var-checkbox">
-                                        <input type="checkbox" name="variable"
-                                               value="{{ variable.slug }}"
-                                               data-sort="{{ forloop.counter0 }}"
-                                               data-name="{{ variable.name }}"
-                                               checked>
-                                        <span class="gr-items-var-label">{{ variable.name }}</span>
-                                        {% if variable.units %}
-                                            <small class="gr-mono gr-items-var-unit">{{ variable.units }}</small>
-                                        {% endif %}
-                                    </label>
-                                {% endfor %}
+                                <input type="date" name="date" id="grItemsDateFilter"
+                                       class="gr-items-date-input"
+                                       value="{{ filters.date }}"
+                                       aria-label="Filter by valid date">
+                                {% if filters.date %}
+                                    <a href="?{% query_string_drop 'date' 'page' %}" class="gr-items-date-clear">
+                                        <i class="bi bi-x"></i> Clear date
+                                    </a>
+                                {% endif %}
                             </div>
                         </div>
-                    {% endif %}
 
-                    {# Valid Date #}
-                    <div class="gr-sidebar-filter is-open" id="filter-date">
-                        <div class="gr-sidebar-filter-header" onclick="toggleItemsFilter('filter-date')">
-                            <span>Date</span>
-                            <i class="bi bi-chevron-down"></i>
-                        </div>
-                        <div class="gr-sidebar-filter-body">
-                            <input type="date" id="grItemsDateFilter" class="gr-items-date-input"
-                                   aria-label="Filter by valid date">
-                            <button id="grItemsDateClear" class="gr-items-date-clear" style="display:none"
-                                    type="button">
-                                <i class="bi bi-x"></i> Clear date
-                            </button>
-                        </div>
-                    </div>
-
-                    {# Forecast Run (only for forecast collections) #}
-                    {% if collection.is_forecast %}
-                        <div class="gr-sidebar-filter is-open" id="filter-reftime">
-                            <div class="gr-sidebar-filter-header" onclick="toggleItemsFilter('filter-reftime')">
-                                <span>Forecast Run</span>
-                                <i class="bi bi-chevron-down"></i>
+                        {# Forecast Run #}
+                        {% if collection.is_forecast and forecast_runs %}
+                            <div class="gr-sidebar-filter is-open" id="filter-reftime">
+                                <div class="gr-sidebar-filter-header" data-filter-toggle="filter-reftime">
+                                    <span>Forecast Run</span>
+                                    <i class="bi bi-chevron-down"></i>
+                                </div>
+                                <div class="gr-sidebar-filter-body">
+                                    <select name="run" id="grRefTimeFilter"
+                                            class="gr-items-ref-select"
+                                            aria-label="Filter by forecast run">
+                                        <option value="">All runs</option>
+                                        {% for run_dt in forecast_runs %}
+                                            <option value="{{ run_dt|date:"c" }}"
+                                                    {% if filters.run == run_dt|date:"c" %}selected{% endif %}>
+                                                {{ run_dt|date:"d M Y H:i" }} UTC
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
                             </div>
-                            <div class="gr-sidebar-filter-body">
-                                <select id="grRefTimeFilter" class="gr-items-ref-select"
-                                        aria-label="Filter by forecast run">
-                                    <option value="">All runs</option>
-                                </select>
-                            </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
+                    </form>
                 </aside>
 
                 {# ── Items grid ── #}
                 <div class="gr-items-main">
+                    {% if items %}
+                        <div class="gr-item-cards-grid">
+                            {% for asset in items %}
+                                <a href="{{ page.url }}{{ catalog.slug }}/{{ collection.slug }}/items/{{ asset.item.pk}}/"
+                                   class="gr-item-card">
+                                    <div class="gr-item-card-thumb">
+                                        <img src="{{ asset.preview_url }}"
+                                             alt="{{ asset.variable.name }}" loading="lazy">
+                                        <div class="gr-item-card-thumb-placeholder"><i class="bi bi-image"></i></div>
+                                    </div>
+                                    <div class="gr-item-card-body">
+                                        <div class="gr-item-card-date">{{ asset.item.time|date:"d M Y H:i" }} UTC</div>
+                                        <div class="gr-item-card-variable">{{ asset.variable.name }}</div>
+                                        {% if asset.item.reference_time %}
+                                            <span class="gr-item-card-meta">
+                                                <i class="bi bi-arrow-repeat"></i> Run: {{ asset.item.reference_time|date:"d M Y H:i" }} UTC
+                                            </span>
+                                        {% endif %}
+                                        {% if asset.item.horizon_hours %}
+                                            <span class="gr-item-card-meta">
+                                                <i class="bi bi-clock"></i> +{{ asset.item.horizon_hours|floatformat:0 }}h
+                                            </span>
+                                        {% endif %}
+                                    </div>
+                                </a>
+                            {% endfor %}
+                        </div>
 
-                    {# Loading state #}
-                    <div id="grItemsLoading" class="gr-items-loading" style="display:none">
-                        <div class="gr-map-spinner"></div>
-                        <span>Loading items…</span>
-                    </div>
+                        {# ── Pagination ── #}
+                        {% if items.paginator.num_pages > 1 %}
+                            <div style="margin-top:40px;">
+                                {% include "datasets/includes/pagination.html" with items=items page_range=page_range %}
+                            </div>
+                        {% endif %}
 
-                    {# Empty state #}
-                    <div id="grItemsEmpty" class="gr-empty-state" style="display:none">
-                        <i class="bi bi-inbox"></i>
-                        <p style="font-weight:600;margin-bottom:0.35rem">No items found</p>
-                        <p>Try adjusting the filters.</p>
-                    </div>
-
-                    {# Cards grid #}
-                    <div id="grItemsGrid" class="gr-item-cards-grid"></div>
-
-                    {# Load more #}
-                    <div id="grItemsLoadMore" style="display:none;justify-content:center;padding-top:1.5rem">
-                        <button id="grLoadMoreBtn" class="gr-btn gr-btn-ghost-dark" type="button">
-                            <i class="bi bi-arrow-down"></i> Load more
-                        </button>
-                    </div>
+                    {% else %}
+                        <div class="gr-empty-state">
+                            <i class="bi bi-inbox"></i>
+                            <p style="font-weight:600;margin-bottom:0.35rem">No items found</p>
+                            <p>Try adjusting the filters.</p>
+                        </div>
+                    {% endif %}
 
                 </div>
 
@@ -349,648 +284,27 @@
 {% endblock %}
 
 {% block extra_js %}
-    <script id="grMapConfig" type="application/json">
-        {
-            "collectionSlug": "{{ collection.slug }}",
-            "catalogSlug": "{{ catalog.slug }}",
-            "edrUrl": "/api/edr/collections/{{ collection.slug }}/",
-            "minioBase": "{{ MINIO_ASSETS_BASE_URL }}",
-            "isForecast": {% if collection.is_forecast %}true{% else %}false{% endif %},
-            "titilerBase": "/titiler",
-            "pageBase": "{{ page.url }}{{ catalog.slug }}/{{ collection.slug }}/",
-            "variables": [{% for variable in variables %}{"slug":"{{ variable.slug }}","name":"{{ variable.name|escapejs }}","sortOrder":{{ forloop.counter0 }}}{% if not forloop.last %},{% endif %}{% endfor %}]
-        }
-    </script>
-
-    <script src="https://unpkg.com/maplibre-gl@4.1.0/dist/maplibre-gl.js"></script>
-    <script src="https://unpkg.com/deck.gl@9.2.6/dist/dist.dev.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/weatherlayers-gl/dist/weatherlayers-deck.umd.min.js"></script>
-    <script src="{% static 'js/datetime-selector.js' %}"></script>
-
     <script>
-        (function () {
-            'use strict';
-
-            // ── Config ────────────────────────────────────────────────────────────────
-            const CONFIG = JSON.parse(document.getElementById('grMapConfig').textContent);
-
-            // ── Basemaps ──────────────────────────────────────────────────────────────
-            const BASEMAPS = {
-                dark: {
-                    name: 'Dark',
-                    style: {
-                        version: 8,
-                        sources: {
-                            carto: {
-                                type: 'raster',
-                                tileSize: 256,
-                                attribution: '© CARTO',
-                                tiles: ['https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png']
-                            }
-                        },
-                        layers: [{id: 'carto', type: 'raster', source: 'carto'}]
-                    }
-                },
-                light: {
-                    name: 'Light',
-                    style: {
-                        version: 8,
-                        sources: {
-                            carto: {
-                                type: 'raster',
-                                tileSize: 256,
-                                attribution: '© CARTO',
-                                tiles: ['https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png']
-                            }
-                        },
-                        layers: [{id: 'carto', type: 'raster', source: 'carto'}]
-                    }
-                },
-                satellite: {
-                    name: 'Satellite',
-                    style: {
-                        version: 8,
-                        sources: {
-                            satellite: {
-                                type: 'raster',
-                                tileSize: 256,
-                                attribution: '© Esri',
-                                tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}']
-                            }
-                        },
-                        layers: [{id: 'satellite', type: 'raster', source: 'satellite'}]
-                    }
-                },
-                osm: {
-                    name: 'OSM',
-                    style: {
-                        version: 8,
-                        sources: {
-                            osm: {
-                                type: 'raster',
-                                tileSize: 256,
-                                attribution: '© OpenStreetMap contributors',
-                                tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png']
-                            }
-                        },
-                        layers: [{id: 'osm', type: 'raster', source: 'osm'}]
-                    }
-                }
-            };
-
-            // ── Map State ─────────────────────────────────────────────────────────────
-            let map = null;
-            let deckOverlay = null;
-            let deckgl = null;
-            let tooltipControl = null;
-            let currentRasterLayer = null;
-            let currentPalette = null;
-            let currentBasemap = 'dark';
-            let currentVarSlug = null;
-            let grTimeSelector = null;
-            let edrData = null;
-            let validTimes = [];
-            let runsMap = {};
-            let parameterNames = {};
-
-            // ── Map Init (on page load) ───────────────────────────────────────────────
-            function initMap() {
-                map = new maplibregl.Map({
-                    container: 'grMap',
-                    style: BASEMAPS[currentBasemap].style,
-                    fitBoundsOptions: {padding: 60},
-                    attributionControl: false,
-                });
-
-                map.addControl(new maplibregl.NavigationControl({showCompass: false}), 'bottom-right');
-
-                map.on('load', async () => {
-                    deckOverlay = new deck.MapboxOverlay({interleaved: true, layers: []});
-                    map.addControl(deckOverlay);
-
-                    deckgl = await waitForDeck(() => deckOverlay._deck);
-
-                    setupBasemapSelector();
-                    setupOpacitySlider();
-                    setupVariableButtons();
-
-                    await loadCollectionMetadata();
-                });
-            }
-
-            function waitForDeck(getDeck) {
-                return new Promise(resolve => {
-                    (function wait() {
-                        const d = getDeck();
-                        if (d && d.getCanvas()) resolve(d);
-                        else setTimeout(wait, 100);
-                    })();
-                });
-            }
-
-            // ── Tooltip ───────────────────────────────────────────────────────────────
-            function initTooltipControl(units) {
-                if (tooltipControl) {
-                    try {
-                        tooltipControl.remove();
-                    } catch (e) {
-                    }
-                    tooltipControl = null;
-                }
-                tooltipControl = new WeatherLayers.TooltipControl({
-                    followCursor: true,
-                    unitFormat: {unit: units || ''},
-                });
-                deckgl.setProps({
-                    onLoad: () => {
-                        const canvas = deckgl.getCanvas();
-                        if (canvas) tooltipControl.addTo(canvas.parentElement);
-                    },
-                    onHover: (event) => tooltipControl.updatePickingInfo(event),
-                });
-                deckgl.props.onLoad();
-            }
-
-            // ── EDR metadata ──────────────────────────────────────────────────────────
-            async function loadCollectionMetadata() {
-                try {
-                    const res = await fetch(CONFIG.edrUrl);
-                    if (!res.ok) throw new Error(`EDR fetch failed: ${res.status}`);
-                    edrData = await res.json();
-                } catch (e) {
-                    console.error('Failed to load EDR metadata:', e);
-                    return;
-                }
-
-                const geo = edrData['x-georiva'] || {};
-                const temp = edrData.extent?.temporal || {};
-                parameterNames = edrData.parameter_names || {};
-
-                if (geo.has_reference_time && geo.runs?.length) {
-                    const latestRun = geo.runs[0];
-                    validTimes = latestRun.valid_times;
-                    runsMap = {};
-                    for (const run of geo.runs) {
-                        for (const vt of run.valid_times) {
-                            runsMap[vt] = run.reference_time;
-                        }
-                    }
-                } else {
-                    validTimes = temp.values || [];
-                    runsMap = {};
-                }
-
-                const bbox = edrData.extent?.spatial?.bbox?.[0];
-                if (bbox?.length === 4) {
-                    map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], {padding: 60, duration: 500});
-                }
-
-                validTimes = validTimes.map(t => new Date(t).toISOString());
-                const normalisedRunsMap = {};
-                for (const [k, v] of Object.entries(runsMap)) {
-                    normalisedRunsMap[new Date(k).toISOString()] = v;
-                }
-                runsMap = normalisedRunsMap;
-
-                if (validTimes.length > 0) {
-                    grTimeSelector = new DateTimeSelector('grDatetimeSelector', validTimes, {
-                        openDirection: "top",
-                        onChange: async () => {
-                            await loadLayer();
-                        }
-                    });
-                }
-
-                const firstBtn = document.querySelector('.gr-map-var-btn');
-                if (firstBtn) currentVarSlug = firstBtn.dataset.variableSlug;
-
-                if (currentVarSlug && validTimes.length > 0) {
-                    await loadLayer();
-                }
-
-                // Populate forecast run dropdown from EDR runs data
-                if (CONFIG.isForecast && geo.runs?.length) {
-                    populateRefTimeDropdown(geo.runs);
-                }
-
-                // Initial items load
-                await ItemsBrowser.fetch(true);
-            }
-
-            // ── Variable buttons ──────────────────────────────────────────────────────
-            function setupVariableButtons() {
-                document.querySelectorAll('.gr-map-var-btn').forEach(btn => {
-                    btn.addEventListener('click', async () => {
-                        if (btn.dataset.variableSlug === currentVarSlug) return;
-                        document.querySelectorAll('.gr-map-var-btn').forEach(b => b.classList.remove('gr-map-var-btn--active'));
-                        btn.classList.add('gr-map-var-btn--active');
-                        currentVarSlug = btn.dataset.variableSlug;
-                        await loadLayer();
-                    });
-                });
-            }
-
-            // ── Asset URL ─────────────────────────────────────────────────────────────
-            function buildAssetUrl(datetime) {
-                const dt = new Date(datetime);
-                const Y = dt.getUTCFullYear();
-                const m = String(dt.getUTCMonth() + 1).padStart(2, '0');
-                const d = String(dt.getUTCDate()).padStart(2, '0');
-                const HH = String(dt.getUTCHours()).padStart(2, '0');
-                const MM = String(dt.getUTCMinutes()).padStart(2, '0');
-                const SS = String(dt.getUTCSeconds()).padStart(2, '0');
-
-                const geo = edrData['x-georiva'] || {};
-                const catalog = geo.catalog_slug;
-                const coll = geo.collection_slug;
-                const variable = currentVarSlug;
-                let filename = `${variable}_${HH}${MM}${SS}`;
-
-                const refTime = runsMap[datetime];
-                if (refTime) {
-                    const rt = new Date(refTime);
-                    const refStr = [
-                        rt.getUTCFullYear(),
-                        String(rt.getUTCMonth() + 1).padStart(2, '0'),
-                        String(rt.getUTCDate()).padStart(2, '0'),
-                        'T',
-                        String(rt.getUTCHours()).padStart(2, '0'),
-                        String(rt.getUTCMinutes()).padStart(2, '0'),
-                        String(rt.getUTCSeconds()).padStart(2, '0'),
-                    ].join('');
-                    filename += `__ref${refStr}`;
-                }
-
-                return `${CONFIG.minioBase}/${catalog}/${coll}/${variable}/${Y}/${m}/${d}/${filename}.png`;
-            }
-
-            // ── WeatherLayers render ──────────────────────────────────────────────────
-            async function loadLayer() {
-                if (!deckOverlay || !currentVarSlug || validTimes.length === 0) return;
-
-                const datetime = grTimeSelector ? grTimeSelector.getDate() : validTimes[validTimes.length - 1];
-                const url = buildAssetUrl(datetime);
-                const param = parameterNames[currentVarSlug];
-                const xg = param?.['x-georiva'] || {};
-                const palette = xg.palette || [[0, [0, 0, 0]], [1, [255, 255, 255]]];
-                const paletteMin = xg.palette_min ?? xg.value_min ?? 0;
-                const paletteMax = xg.palette_max ?? xg.value_max ?? 1;
-                const units = param?.unit?.symbol || '';
-
-                showMapLoading(true);
-                clearLayer();
-
-                try {
-                    const image = await WeatherLayers.loadTextureData(url);
-                    const opacity = parseInt(document.getElementById('grOpacitySlider').value, 10) / 100;
-                    const bbox = edrData.extent?.spatial?.bbox?.[0] || [-180, -90, 180, 90];
-
-                    currentPalette = palette;
-                    currentRasterLayer = new WeatherLayers.RasterLayer({
-                        id: 'georiva-raster',
-                        image,
-                        bounds: [bbox[0], bbox[1], bbox[2], bbox[3]],
-                        imageSmoothing: true,
-                        imageInterpolation: 'LINEAR',
-                        imageUnscale: [paletteMin, paletteMax],
-                        palette,
-                        opacity,
-                        visible: true,
-                        pickable: true,
-                    });
-
-                    deckOverlay.setProps({layers: [currentRasterLayer]});
-                    initTooltipControl(units);
-                    updateLegend(param, xg, paletteMin, paletteMax);
-                } catch (err) {
-                    console.error('WeatherLayers load failed:', url, err);
-                    clearLayer();
-                } finally {
-                    map.once('idle', () => showMapLoading(false));
-                }
-            }
-
-            function clearLayer() {
-                currentRasterLayer = null;
-                currentPalette = null;
-                if (deckOverlay) deckOverlay.setProps({layers: []});
-                try {
-                    if (map.getLayer('asset-layer-fallback')) map.removeLayer('asset-layer-fallback');
-                    if (map.getSource('asset-source')) map.removeSource('asset-source');
-                } catch (e) {
-                }
-            }
-
-            // ── Legend ────────────────────────────────────────────────────────────────
-            function updateLegend(param, xg, paletteMin, paletteMax) {
-                document.getElementById('grLegend').style.display = 'block';
-                document.getElementById('grLegendTitle').textContent = param?.label || currentVarSlug;
-                document.getElementById('grLegendMin').textContent = Number(paletteMin).toFixed(1);
-                document.getElementById('grLegendMax').textContent = Number(paletteMax).toFixed(1);
-                document.getElementById('grLegendUnits').textContent = param?.unit?.symbol || '';
-                document.getElementById('grLegendScale').style.background = buildGradientCSS(xg.palette || [], paletteMin, paletteMax);
-            }
-
-            function buildGradientCSS(palette, paletteMin, paletteMax) {
-                if (!palette?.length) return 'linear-gradient(to right, #000, #fff)';
-                const range = paletteMax - paletteMin || 1;
-                const stops = palette.map(([val, color]) => {
-                    const pct = ((val - paletteMin) / range) * 100;
-                    const rgba = color.length === 4
-                        ? `rgba(${color[0]},${color[1]},${color[2]},${color[3] / 255})`
-                        : `rgb(${color[0]},${color[1]},${color[2]})`;
-                    return `${rgba} ${pct.toFixed(1)}%`;
-                });
-                return `linear-gradient(to right, ${stops.join(', ')})`;
-            }
-
-            // ── Opacity slider ────────────────────────────────────────────────────────
-            function setupOpacitySlider() {
-                const slider = document.getElementById('grOpacitySlider');
-                slider.addEventListener('input', async () => {
-                    document.getElementById('grOpacityVal').textContent = `${slider.value}%`;
-                    if (currentVarSlug && validTimes.length > 0) await loadLayer();
-                });
-            }
-
-            // ── Basemap selector ──────────────────────────────────────────────────────
-            function setupBasemapSelector() {
-                const btn = document.getElementById('grBasemapBtn');
-                const menu = document.getElementById('grBasemapMenu');
-
-                btn.addEventListener('click', e => {
-                    e.stopPropagation();
-                    menu.classList.toggle('gr-open');
-                });
-                document.addEventListener('click', () => menu.classList.remove('gr-open'));
-                menu.querySelector(`[data-basemap="${currentBasemap}"]`).classList.add('gr-bm-active');
-
-                menu.querySelectorAll('.gr-map-basemap-option').forEach(opt => {
-                    opt.addEventListener('click', e => {
-                        e.stopPropagation();
-                        const bm = opt.dataset.basemap;
-                        if (bm === currentBasemap) {
-                            menu.classList.remove('gr-open');
-                            return;
-                        }
-                        menu.querySelectorAll('.gr-map-basemap-option').forEach(o => o.classList.remove('gr-bm-active'));
-                        opt.classList.add('gr-bm-active');
-                        document.getElementById('grBasemapLabel').textContent = BASEMAPS[bm].name;
-                        currentBasemap = bm;
-                        menu.classList.remove('gr-open');
-                        map.setStyle(BASEMAPS[bm].style);
-                        map.once('style.load', () => {
-                            if (deckOverlay && currentRasterLayer) deckOverlay.setProps({layers: [currentRasterLayer]});
-                        });
-                    });
-                });
-            }
-
-            function showMapLoading(visible) {
-                document.getElementById('grMapLoading').style.display = visible ? 'flex' : 'none';
-            }
-
-            // =========================================================================
-            // Items Browser
-            // =========================================================================
-
-            const ItemsBrowser = {
-                nextTokens: {},   // { varSlug: token | null }
-                allItems: [],
-
-                getFilters() {
-                    const checkedVars = [...document.querySelectorAll('[name="variable"]:checked')]
-                        .map(cb => ({
-                            slug: cb.value,
-                            sortOrder: parseInt(cb.dataset.sort, 10),
-                            name: cb.dataset.name,
-                        }));
-                    const dateInput = document.getElementById('grItemsDateFilter');
-                    const refSelect = document.getElementById('grRefTimeFilter');
-                    return {
-                        vars: checkedVars,
-                        date: dateInput?.value || null,
-                        refTime: refSelect?.value || null,
-                    };
-                },
-
-                async fetch(replace) {
-                    const {vars, date, refTime} = this.getFilters();
-
-                    if (!vars.length) {
-                        this.allItems = [];
-                        this.render();
-                        return;
-                    }
-
-                    if (replace) {
-                        this.nextTokens = {};
-                        this.allItems = [];
-                    }
-
-                    this.showLoading(true);
-
-                    // Use larger limit when client-side ref time filtering is needed
-                    const limit = refTime ? 100 : 24;
-                    const fetches = vars.map(v => this.fetchVar(v, date, limit, replace));
-                    const results = await Promise.allSettled(fetches);
-
-                    let newItems = results
-                        .filter(r => r.status === 'fulfilled')
-                        .flatMap(r => r.value);
-
-                    if (refTime) {
-                        const refISO = new Date(refTime).toISOString();
-                        newItems = newItems.filter(item => {
-                            const itemRef = item.properties?.['forecast:reference_datetime'];
-                            return itemRef && new Date(itemRef).toISOString() === refISO;
-                        });
-                    }
-
-                    if (replace) {
-                        this.allItems = newItems;
-                    } else {
-                        // Deduplicate by id+var before appending
-                        const existingKeys = new Set(this.allItems.map(i => `${i.id}::${i._varSlug}`));
-                        this.allItems = [
-                            ...this.allItems,
-                            ...newItems.filter(i => !existingKeys.has(`${i.id}::${i._varSlug}`)),
-                        ];
-                    }
-
-                    // Sort: time DESC, then variable sort order ASC
-                    this.allItems.sort((a, b) => {
-                        const tDiff = new Date(b.properties.datetime) - new Date(a.properties.datetime);
-                        if (tDiff !== 0) return tDiff;
-                        return a._sortOrder - b._sortOrder;
-                    });
-
-                    this.render();
-                    this.showLoading(false);
-                },
-
-                async fetchVar(varObj, date, limit, replace) {
-                    const token = replace ? null : (this.nextTokens[varObj.slug] ?? null);
-                    // If we already know there's no next page, skip
-                    if (!replace && token === null && varObj.slug in this.nextTokens) return [];
-
-                    const params = new URLSearchParams();
-                    params.set('limit', limit);
-                    if (CONFIG.isForecast) params.set('include_past', 'true');
-                    if (date) params.set('datetime', `${date}T00:00:00Z/${date}T23:59:59Z`);
-                    if (token) params.set('token', token);
-
-                    const url = `/api/stac/collections/${CONFIG.catalogSlug}/${varObj.slug}/items?${params}`;
-
-                    const res = await fetch(url);
-                    if (!res.ok) throw new Error(`STAC fetch failed: ${res.status}`);
-                    const data = await res.json();
-
-                    // Extract next token from links
-                    const nextLink = (data.links || []).find(l => l.rel === 'next');
-                    if (nextLink) {
-                        try {
-                            this.nextTokens[varObj.slug] = new URL(nextLink.href).searchParams.get('token');
-                        } catch {
-                            this.nextTokens[varObj.slug] = null;
-                        }
-                    } else {
-                        this.nextTokens[varObj.slug] = null;
-                    }
-
-                    return (data.features || []).map(item => ({
-                        ...item,
-                        _varSlug: varObj.slug,
-                        _sortOrder: varObj.sortOrder,
-                        _varName: varObj.name,
-                    }));
-                },
-
-                buildThumbUrl(item) {
-                    const time = item.properties.datetime;
-                    const refTime = item.properties['forecast:reference_datetime'];
-                    let url = `${CONFIG.titilerBase}/${CONFIG.catalogSlug}/${CONFIG.collectionSlug}/${item._varSlug}/preview.webp?time=${encodeURIComponent(time)}`;
-                    if (refTime) url += `&reftime=${encodeURIComponent(refTime)}`;
-                    return url;
-                },
-
-                formatDate(isoStr) {
-                    return new Date(isoStr).toLocaleString('en', {
-                        year: 'numeric', month: 'short', day: 'numeric',
-                        hour: '2-digit', minute: '2-digit',
-                        timeZone: 'UTC', timeZoneName: 'short',
-                    });
-                },
-
-                render() {
-                    const grid = document.getElementById('grItemsGrid');
-                    const empty = document.getElementById('grItemsEmpty');
-                    const loadMore = document.getElementById('grItemsLoadMore');
-                    const countEl = document.getElementById('grItemsCount');
-
-                    if (!this.allItems.length) {
-                        grid.innerHTML = '';
-                        empty.style.display = 'flex';
-                        loadMore.style.display = 'none';
-                        countEl.textContent = '0 items';
-                        return;
-                    }
-
-                    empty.style.display = 'none';
-                    countEl.textContent = `${this.allItems.length} item${this.allItems.length !== 1 ? 's' : ''}`;
-
-                    grid.innerHTML = this.allItems.map(item => {
-                        const thumbUrl = this.buildThumbUrl(item);
-                        const date = this.formatDate(item.properties.datetime);
-                        const refTime = item.properties['forecast:reference_datetime'];
-                        const horizon = item.properties['forecast:horizon'];
-                        const href = `${CONFIG.pageBase}items/${encodeURIComponent(item.id)}/`;
-
-                        const metaLines = [];
-                        if (refTime) metaLines.push(`<span class="gr-item-card-meta"><i class="bi bi-arrow-repeat"></i> Run: ${this.formatDate(refTime)}</span>`);
-                        if (horizon) metaLines.push(`<span class="gr-item-card-meta"><i class="bi bi-clock"></i> ${horizon.replace('PT', '+').replace('H', 'h')}</span>`);
-
-                        return `<a href="${href}" class="gr-item-card">
-                            <div class="gr-item-card-thumb">
-                                <img src="${thumbUrl}" alt="${item._varName}" loading="lazy"
-                                     onerror="this.closest('.gr-item-card-thumb').classList.add('gr-item-card-thumb--error');this.remove()">
-                                <div class="gr-item-card-thumb-placeholder"><i class="bi bi-image"></i></div>
-                            </div>
-                            <div class="gr-item-card-body">
-                                <div class="gr-item-card-date">${date}</div>
-                                <div class="gr-item-card-variable">${item._varName}</div>
-                                ${metaLines.join('')}
-                            </div>
-                        </a>`;
-                    }).join('');
-
-                    // Show "Load more" if any variable still has a next page
-                    const hasMore = Object.values(this.nextTokens).some(t => t !== null);
-                    loadMore.style.display = hasMore ? 'flex' : 'none';
-                },
-
-                showLoading(visible) {
-                    document.getElementById('grItemsLoading').style.display = visible ? 'flex' : 'none';
-                },
-            };
-
-            // ── Items filter event bindings ───────────────────────────────────────────
-
-            document.querySelectorAll('[name="variable"]').forEach(cb => {
-                cb.addEventListener('change', () => ItemsBrowser.fetch(true));
+        // ── Filter accordion ──────────────────────────────────────────────────────
+        // Toggles .is-open on the parent .gr-sidebar-filter when a header is clicked.
+        // Driven by [data-filter-toggle] on the header element.
+
+        document.querySelectorAll('[data-filter-toggle]').forEach(function (header) {
+            header.addEventListener('click', function () {
+                const panel = document.getElementById(header.dataset.filterToggle);
+                if (panel) panel.classList.toggle('is-open');
             });
+        });
 
-            const dateInput = document.getElementById('grItemsDateFilter');
-            const dateClear = document.getElementById('grItemsDateClear');
+        // ── Auto-submit filter form ───────────────────────────────────────────────
+        // Submits #grItemsFilterForm whenever any input inside it changes.
+        // Covers checkboxes, the date input, and the forecast run select.
 
-            if (dateInput) {
-                dateInput.addEventListener('change', () => {
-                    dateClear.style.display = dateInput.value ? 'flex' : 'none';
-                    ItemsBrowser.fetch(true);
-                });
-            }
-
-            if (dateClear) {
-                dateClear.addEventListener('click', () => {
-                    dateInput.value = '';
-                    dateClear.style.display = 'none';
-                    ItemsBrowser.fetch(true);
-                });
-            }
-
-            const refTimeSelect = document.getElementById('grRefTimeFilter');
-            if (refTimeSelect) {
-                refTimeSelect.addEventListener('change', () => ItemsBrowser.fetch(true));
-            }
-
-            document.getElementById('grLoadMoreBtn')?.addEventListener('click', () => ItemsBrowser.fetch(false));
-
-            // ── Forecast run dropdown population ──────────────────────────────────────
-            function populateRefTimeDropdown(runs) {
-                const sel = document.getElementById('grRefTimeFilter');
-                if (!sel) return;
-                runs.forEach(run => {
-                    const dt = new Date(run.reference_time);
-                    const label = dt.toLocaleString('en', {
-                        year: 'numeric', month: 'short', day: 'numeric',
-                        hour: '2-digit', minute: '2-digit',
-                        timeZone: 'UTC', timeZoneName: 'short',
-                    });
-                    const opt = document.createElement('option');
-                    opt.value = run.reference_time;
-                    opt.textContent = label;
-                    sel.appendChild(opt);
-                });
-            }
-
-            // ── Sidebar filter accordion ──────────────────────────────────────────────
-            window.toggleItemsFilter = function (id) {
-                document.getElementById(id)?.classList.toggle('is-open');
-            };
-
-            // ── Start map ─────────────────────────────────────────────────────────────
-            initMap();
-
-        })();
+        const form = document.getElementById('grItemsFilterForm');
+        if (form) {
+            form.addEventListener('change', function () {
+                form.submit();
+            });
+        }
     </script>
 {% endblock %}

--- a/georiva/src/georiva/pages/datasets/templates/datasets/includes/pagination.html
+++ b/georiva/src/georiva/pages/datasets/templates/datasets/includes/pagination.html
@@ -1,0 +1,42 @@
+{% load i18n georiva_tags %}
+{% if items.paginator.num_pages > 1 %}
+<nav class="pagination" aria-label="{% trans 'Pagination' %}">
+
+    <div class="pagination__start">
+        <p>{% blocktrans trimmed with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}{% endblocktrans %}</p>
+    </div>
+
+    <ul>
+        <li class="prev">
+            <a{% if items.has_previous %} href="?{% query_string_replace 'p' items.previous_page_number %}"{% endif %}>
+                <i class="bi bi-arrow-left"></i>
+                {% trans "Previous" %}
+            </a>
+        </li>
+
+        {% for page_num in page_range %}
+            <li class="pagination__page-number{% if page_num == items.number %} pagination__page-number--current{% endif %}">
+                {% if page_num == items.paginator.ELLIPSIS %}
+                    <span>{{ page_num }}</span>
+                {% else %}
+                    <a href="?{% query_string_replace 'p' page_num %}"{% if page_num == items.number %} aria-current="page"{% endif %}>
+                        {{ page_num }}
+                    </a>
+                {% endif %}
+            </li>
+        {% endfor %}
+
+        <li class="next">
+            <a{% if items.has_next %} href="?{% query_string_replace 'p' items.next_page_number %}"{% endif %}>
+                {% trans "Next" %}
+                <i class="bi bi-arrow-right"></i>
+            </a>
+        </li>
+    </ul>
+
+    <div class="pagination__end">
+        <p>{{ items.paginator.count }} item{{ items.paginator.count|pluralize }}</p>
+    </div>
+
+</nav>
+{% endif %}


### PR DESCRIPTION

- Remove MapLibre, deck.gl, WeatherLayers, and DateTimeSelector from collection detail page
- Paginate Asset objects directly (one card = one asset)
- Switch items browser to Django form GET submission with auto-submit on filter change
- Add preview_url property on Asset for TiTiler thumbnail URLs
- Extract pagination into datasets/includes/pagination.html matching Wagtail admin markup structure (pagination_nav.html)
- Add georiva-pagination.css using gr design tokens
- Use existing query_string_replace/query_string_drop tags for pagination and filter URL construction; switch page param to p=