### PR TITLE
Fix STAC MultipleObjectsReturned by adding collection slug to URL

### DIFF
--- a/georiva/src/georiva/stac/openapi.py
+++ b/georiva/src/georiva/stac/openapi.py
@@ -90,7 +90,7 @@ def get_openapi_schema(request: Request) -> dict:
                     }
                 }
             },
-            "/collections/{catalogId}/{collectionId}": {
+            "/collections/{catalogId}/{collectionId}/{variableId}": {
                 "get": {
                     "tags": ["Collections"],
                     "summary": "Get Collection",
@@ -98,6 +98,7 @@ def get_openapi_schema(request: Request) -> dict:
                     "parameters": [
                         {"$ref": "#/components/parameters/catalogId"},
                         {"$ref": "#/components/parameters/collectionId"},
+                        {"$ref": "#/components/parameters/variableId"},
                     ],
                     "responses": {
                         "200": {
@@ -112,7 +113,7 @@ def get_openapi_schema(request: Request) -> dict:
                     }
                 }
             },
-            "/collections/{catalogId}/{collectionId}/items": {
+            "/collections/{catalogId}/{collectionId}/{variableId}/items": {
                 "get": {
                     "tags": ["Items"],
                     "summary": "List Items",
@@ -120,6 +121,7 @@ def get_openapi_schema(request: Request) -> dict:
                     "parameters": [
                         {"$ref": "#/components/parameters/catalogId"},
                         {"$ref": "#/components/parameters/collectionId"},
+                        {"$ref": "#/components/parameters/variableId"},
                         {"$ref": "#/components/parameters/limit"},
                         {"$ref": "#/components/parameters/datetime"},
                         {"$ref": "#/components/parameters/bbox"},
@@ -137,7 +139,7 @@ def get_openapi_schema(request: Request) -> dict:
                     }
                 }
             },
-            "/collections/{catalogId}/{collectionId}/items/{itemId}": {
+            "/collections/{catalogId}/{collectionId}/{variableId}/items/{itemId}": {
                 "get": {
                     "tags": ["Items"],
                     "summary": "Get Item",
@@ -145,6 +147,7 @@ def get_openapi_schema(request: Request) -> dict:
                     "parameters": [
                         {"$ref": "#/components/parameters/catalogId"},
                         {"$ref": "#/components/parameters/collectionId"},
+                        {"$ref": "#/components/parameters/variableId"},
                         {"$ref": "#/components/parameters/itemId"},
                     ],
                     "responses": {
@@ -222,7 +225,14 @@ def get_openapi_schema(request: Request) -> dict:
                     "in": "path",
                     "required": True,
                     "schema": {"type": "string"},
-                    "description": "Collection identifier (slug)",
+                    "description": "GeoRiva Collection slug",
+                },
+                "variableId": {
+                    "name": "variableId",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                    "description": "Variable slug within the Collection",
                 },
                 "itemId": {
                     "name": "itemId",

--- a/georiva/src/georiva/stac/serializers.py
+++ b/georiva/src/georiva/stac/serializers.py
@@ -9,8 +9,8 @@ STAC hierarchy:
               └── Assets (for that variable only)
 
 Each GeoRiva Variable becomes a STAC Collection.
-STAC Collection ID = variable.slug
-STAC Collection URL = /collections/{catalog.slug}/{variable.slug}
+STAC Collection ID = {collection.slug}/{variable.slug}
+STAC Collection URL = /collections/{catalog.slug}/{collection.slug}/{variable.slug}
 
 If a GeoRiva Collection has 4 variables, it appears as 4 STAC Collections.
 If it has 1 variable, it appears as 1 STAC Collection.
@@ -208,12 +208,15 @@ class STACItemSerializer(serializers.Serializer, STACBaseURLMixin):
         base_url = self._get_base_url()
         variable = self._get_variable()
         catalog_slug = obj.collection.catalog.slug
-        variable_slug = variable.slug if variable else obj.collection.slug
+        collection_slug = obj.collection.slug
+        variable_slug = variable.slug if variable else collection_slug
         item_id = self.get_id(obj)
-        
-        collection_url = f"{base_url}collections/{catalog_slug}/{variable_slug}"
-        item_url = f"{collection_url}/items/{item_id}"
-        
+
+        collection_url = (
+            f"{base_url}collections/{catalog_slug}/{collection_slug}/{variable_slug}/"
+        )
+        item_url = f"{collection_url}items/{item_id}/"
+
         return [
             {"rel": "self", "href": item_url, "type": "application/geo+json"},
             {"rel": "parent", "href": collection_url, "type": "application/json"},
@@ -238,9 +241,9 @@ class STACItemSerializer(serializers.Serializer, STACBaseURLMixin):
     
     def get_collection(self, obj):
         variable = self._get_variable()
-        catalog_slug = obj.collection.catalog.slug
-        variable_slug = variable.slug if variable else obj.collection.slug
-        return f"{catalog_slug}/{variable_slug}"
+        collection_slug = obj.collection.slug
+        variable_slug = variable.slug if variable else collection_slug
+        return f"{collection_slug}/{variable_slug}"
 
 
 # =============================================================================
@@ -289,7 +292,7 @@ class STACVariableCollectionSerializer(serializers.Serializer, STACBaseURLMixin)
         return extensions
     
     def get_id(self, obj):
-        return obj.slug
+        return f"{obj.collection.slug}/{obj.slug}"
     
     def get_title(self, obj):
         collection = obj.collection
@@ -382,27 +385,27 @@ class STACVariableCollectionSerializer(serializers.Serializer, STACBaseURLMixin)
     def get_links(self, obj):
         base_url = self._get_base_url()
         catalog_slug = obj.collection.catalog.slug
-        
-        catalog_url = f"{base_url}collections/{catalog_slug}"
-        collection_url = f"{catalog_url}/{obj.slug}"
-        
+        collection_slug = obj.collection.slug
+
+        catalog_url = f"{base_url}collections/{catalog_slug}/"
+        collection_url = f"{base_url}collections/{catalog_slug}/{collection_slug}/{obj.slug}/"
+
         links = [
             {"rel": "self", "href": collection_url, "type": "application/json"},
             {"rel": "parent", "href": catalog_url, "type": "application/json",
              "title": obj.collection.catalog.name},
             {"rel": "root", "href": base_url, "type": "application/json"},
-            {"rel": "items", "href": f"{collection_url}/items",
+            {"rel": "items", "href": f"{collection_url}items/",
              "type": "application/geo+json"},
         ]
-        
-        # License link
+
         if obj.collection.catalog.provider_url:
             links.append({
                 "rel": "license",
                 "href": obj.collection.catalog.provider_url,
                 "title": "Data Provider",
             })
-        
+
         return links
     
     def get_providers(self, obj):
@@ -507,15 +510,15 @@ class STACCatalogAsCollectionSerializer(serializers.Serializer, STACBaseURLMixin
     
     def get_links(self, obj):
         base_url = self._get_base_url()
-        catalog_url = f"{base_url}collections/{obj.slug}"
-        
+        catalog_url = f"{base_url}collections/{obj.slug}/"
+
         links = [
             {"rel": "self", "href": catalog_url, "type": "application/json"},
             {"rel": "parent", "href": f"{base_url}collections/",
              "type": "application/json"},
             {"rel": "root", "href": base_url, "type": "application/json"},
         ]
-        
+
         # Child links — one per variable across all collections
         for collection in obj.collections.filter(is_active=True):
             active_variables = list(collection.variables.filter(is_active=True))
@@ -524,7 +527,7 @@ class STACCatalogAsCollectionSerializer(serializers.Serializer, STACBaseURLMixin
                 title = f"{collection.name} - {variable.name}" if variable_count > 1 else variable.name
                 links.append({
                     "rel": "child",
-                    "href": f"{catalog_url}/{variable.slug}",
+                    "href": f"{base_url}collections/{obj.slug}/{collection.slug}/{variable.slug}/",
                     "type": "application/json",
                     "title": title,
                 })
@@ -630,7 +633,7 @@ class STACRootCatalogSerializer(serializers.Serializer, STACBaseURLMixin):
             if catalog.is_active:
                 links.append({
                     "rel": "child",
-                    "href": f"{base_url}collections/{catalog.slug}",
+                    "href": f"{base_url}collections/{catalog.slug}/",
                     "type": "application/json",
                     "title": catalog.name,
                 })
@@ -683,10 +686,10 @@ class STACVariableCollectionListSerializer(serializers.Serializer, STACBaseURLMi
     def get_links(self, obj):
         base_url = self._get_base_url()
         catalog = obj.get('catalog')
-        catalog_url = f"{base_url}collections/{catalog.slug}" if catalog else base_url
-        
+        catalog_url = f"{base_url}collections/{catalog.slug}/" if catalog else base_url
+
         return [
-            {"rel": "self", "href": f"{catalog_url}/",
+            {"rel": "self", "href": f"{catalog_url}collections/",
              "type": "application/json"},
             {"rel": "parent", "href": catalog_url,
              "type": "application/json"},
@@ -739,7 +742,7 @@ class STACItemCollectionSerializer(serializers.Serializer):
                 base_url = request.build_absolute_uri('/api/stac/')
                 collection_url = (
                     f"{base_url}collections/"
-                    f"{collection.catalog.slug}/{variable.slug}"
+                    f"{collection.catalog.slug}/{collection.slug}/{variable.slug}/"
                 )
                 links.append({
                     "rel": "collection", "href": collection_url,

--- a/georiva/src/georiva/stac/urls.py
+++ b/georiva/src/georiva/stac/urls.py
@@ -8,30 +8,31 @@ urlpatterns = [
     # Root
     path('', views.STACLandingPageView.as_view(), name='landing'),
     path('conformance/', views.STACConformanceView.as_view(), name='conformance'),
-    
+
     # Search
     path('search/', views.STACSearchView.as_view(), name='search'),
-    
+
     # Global queryables
     path('queryables/', views.STACQueryablesView.as_view(), name='queryables'),
-    
+
     # Catalogs (top-level collections)
     path('collections/', views.STACCatalogListView.as_view(), name='catalog-list'),
     path('collections/<slug:catalog_slug>/', views.STACCatalogDetailView.as_view(), name='catalog-detail'),
     path('collections/<slug:catalog_slug>/queryables/', views.STACQueryablesView.as_view(), name='catalog-queryables'),
-    
+
     # Variable collections within a Catalog
     path('collections/<slug:catalog_slug>/collections/', views.STACCollectionListView.as_view(),
          name='collection-list'),
-    
-    # Variable as Collection
-    path('collections/<slug:catalog_slug>/<slug:variable_slug>/', views.STACCollectionDetailView.as_view(),
-         name='collection-detail'),
-    path('collections/<slug:catalog_slug>/<slug:variable_slug>/queryables/', views.STACQueryablesView.as_view(),
-         name='collection-queryables'),
-    
+
+    # Variable as Collection — URL includes collection_slug to disambiguate variables with the same slug
+    path('collections/<slug:catalog_slug>/<slug:collection_slug>/<slug:variable_slug>/',
+         views.STACCollectionDetailView.as_view(), name='collection-detail'),
+    path('collections/<slug:catalog_slug>/<slug:collection_slug>/<slug:variable_slug>/queryables/',
+         views.STACQueryablesView.as_view(), name='collection-queryables'),
+
     # Items
-    path('collections/<slug:catalog_slug>/<slug:variable_slug>/items/', views.STACItemsView.as_view(), name='items'),
-    path('collections/<slug:catalog_slug>/<slug:variable_slug>/items/<str:item_id>/', views.STACItemDetailView.as_view(),
-         name='item-detail'),
+    path('collections/<slug:catalog_slug>/<slug:collection_slug>/<slug:variable_slug>/items/',
+         views.STACItemsView.as_view(), name='items'),
+    path('collections/<slug:catalog_slug>/<slug:collection_slug>/<slug:variable_slug>/items/<str:item_id>/',
+         views.STACItemDetailView.as_view(), name='item-detail'),
 ]

--- a/georiva/src/georiva/stac/views.py
+++ b/georiva/src/georiva/stac/views.py
@@ -2,17 +2,21 @@
 GeoRiva STAC API Views
 
 Hierarchical structure:
-- GET /stac/                                              → Root Catalog
-- GET /stac/collections/                                  → List Catalogs (as Collections)
-- GET /stac/collections/{catalog}/                        → Catalog detail (as Collection)
-- GET /stac/collections/{catalog}/{variable}              → Variable as Collection
-- GET /stac/collections/{catalog}/{variable}/items        → List Items (filtered to variable)
-- GET /stac/collections/{catalog}/{variable}/items/{id}   → Item detail (filtered to variable)
-- GET/POST /stac/search                                   → Cross-collection search
+- GET /stac/                                                              → Root Catalog
+- GET /stac/collections/                                                  → List Catalogs (as Collections)
+- GET /stac/collections/{catalog}/                                        → Catalog detail (as Collection)
+- GET /stac/collections/{catalog}/{collection}/{variable}                 → Variable as Collection
+- GET /stac/collections/{catalog}/{collection}/{variable}/items           → List Items (filtered to variable)
+- GET /stac/collections/{catalog}/{collection}/{variable}/items/{id}      → Item detail (filtered to variable)
+- GET/POST /stac/search                                                   → Cross-collection search
 
-STAC Collection = (Catalog, Variable)
-STAC Collection ID = variable.slug
-URL pattern: /collections/{catalog.slug}/{variable.slug}
+STAC Collection = (Catalog, Collection, Variable)
+STAC Collection ID = {collection.slug}/{variable.slug}
+URL pattern: /collections/{catalog.slug}/{collection.slug}/{variable.slug}
+
+The collection slug is required in the URL because multiple GeoRiva collections within
+the same catalog can contain variables with identical slugs (e.g. 'precip' in both
+chirps-monthly and chirps-dekadal).
 
 Implements STAC API v1.0.0
 """
@@ -46,19 +50,17 @@ from .serializers import (
 # Helpers
 # =============================================================================
 
-def _resolve_variable(catalog_slug: str, variable_slug: str) -> Variable:
-    """
-    Resolve a Variable from a catalog slug and variable slug.
-
-    Looks up the variable across all active collections in the catalog.
-    Variable slugs must be unique within a catalog.
-    """
+def _resolve_variable(
+        catalog_slug: str, collection_slug: str, variable_slug: str
+) -> Variable:
+    """Resolve a Variable from its full three-part address."""
     return get_object_or_404(
         Variable.objects.select_related(
             'collection', 'collection__catalog'
         ).filter(
             collection__catalog__slug=catalog_slug,
             collection__catalog__is_active=True,
+            collection__slug=collection_slug,
             collection__is_active=True,
             is_active=True,
         ),
@@ -227,16 +229,17 @@ class STACCollectionDetailView(STACAPIView):
     """
     Get a variable as a STAC Collection.
 
-    GET /stac/collections/{catalog_slug}/{variable_slug}
+    GET /stac/collections/{catalog_slug}/{collection_slug}/{variable_slug}
     """
-    
+
     def get(
             self,
             request: Request,
             catalog_slug: str,
+            collection_slug: str,
             variable_slug: str,
     ) -> Response:
-        variable = _resolve_variable(catalog_slug, variable_slug)
+        variable = _resolve_variable(catalog_slug, collection_slug, variable_slug)
         
         data = STACVariableCollectionSerializer(
             variable,
@@ -254,7 +257,7 @@ class STACItemsView(STACGeoAPIView):
     """
     List Items in a variable collection.
 
-    GET /stac/collections/{catalog_slug}/{variable_slug}/items
+    GET /stac/collections/{catalog_slug}/{collection_slug}/{variable_slug}/items
 
     Items are from the variable's parent Collection, with assets
     filtered to only this variable.
@@ -265,17 +268,18 @@ class STACItemsView(STACGeoAPIView):
         - bbox: Bounding box filter [west,south,east,north]
         - token: Pagination token (datetime of last item)
     """
-    
+
     DEFAULT_LIMIT = 100
     MAX_LIMIT = 1000
-    
+
     def get(
             self,
             request: Request,
             catalog_slug: str,
+            collection_slug: str,
             variable_slug: str,
     ) -> Response:
-        variable = _resolve_variable(catalog_slug, variable_slug)
+        variable = _resolve_variable(catalog_slug, collection_slug, variable_slug)
         collection = variable.collection
         
         # Parse query parameters
@@ -407,7 +411,7 @@ class STACItemDetailView(STACGeoAPIView):
     """
     Get a specific STAC Item.
 
-    GET /stac/collections/{catalog_slug}/{variable_slug}/items/{item_id}
+    GET /stac/collections/{catalog_slug}/{collection_slug}/{variable_slug}/items/{item_id}
 
     Assets are filtered to the specified variable only.
 
@@ -415,15 +419,16 @@ class STACItemDetailView(STACGeoAPIView):
         - Non-forecast: {YYYYMMDDTHHMMSSz}
         - Forecast: {ref_time}_{valid_time}
     """
-    
+
     def get(
             self,
             request: Request,
             catalog_slug: str,
+            collection_slug: str,
             variable_slug: str,
             item_id: str,
     ) -> Response:
-        variable = _resolve_variable(catalog_slug, variable_slug)
+        variable = _resolve_variable(catalog_slug, collection_slug, variable_slug)
         collection = variable.collection
         
         item = self._find_item(collection, item_id)
@@ -592,39 +597,52 @@ class STACSearchView(STACGeoAPIView):
         """
         Filter by collection IDs.
 
-        Collection IDs are in the format {catalog}/{variable}.
-        Resolves to the parent GeoRiva Collection and filters
-        assets to the specified variable.
+        Collection IDs are in the format {catalog}/{collection}/{variable}.
+        Resolves to the GeoRiva Variable and filters items to its parent Collection.
 
         Returns (queryset, variable) — variable is set when filtering
         by a single collection (for asset filtering in serializer).
         """
         if not collections:
             return queryset, None
-        
+
         q_filter = Q()
         resolved_variable = None
-        
+
         for coll_id in collections:
-            if '/' in coll_id:
-                catalog_slug, variable_slug = coll_id.split('/', 1)
+            parts = coll_id.split('/')
+            if len(parts) == 3:
+                catalog_slug, collection_slug, variable_slug = parts
                 try:
                     var = Variable.objects.select_related(
                         'collection', 'collection__catalog'
                     ).get(
                         collection__catalog__slug=catalog_slug,
+                        collection__slug=collection_slug,
                         slug=variable_slug,
                         collection__is_active=True,
                         is_active=True,
                     )
                     q_filter |= Q(collection=var.collection)
-                    # Track variable for single-collection queries
                     if len(collections) == 1:
                         resolved_variable = var
                 except Variable.DoesNotExist:
                     continue
+            elif len(parts) == 2:
+                # Legacy format {catalog}/{variable} — kept for backward compatibility
+                catalog_slug, variable_slug = parts
+                variables = Variable.objects.filter(
+                    collection__catalog__slug=catalog_slug,
+                    slug=variable_slug,
+                    collection__is_active=True,
+                    is_active=True,
+                ).select_related('collection', 'collection__catalog')
+                for var in variables:
+                    q_filter |= Q(collection=var.collection)
+                if len(collections) == 1 and variables.count() == 1:
+                    resolved_variable = variables.first()
             else:
-                # Just variable slug — match across catalogs
+                # Bare variable slug — match across all catalogs
                 variables = Variable.objects.filter(
                     slug=coll_id,
                     collection__is_active=True,
@@ -634,10 +652,10 @@ class STACSearchView(STACGeoAPIView):
                     q_filter |= Q(collection=var.collection)
                 if len(collections) == 1 and variables.count() == 1:
                     resolved_variable = variables.first()
-        
+
         if q_filter:
             queryset = queryset.filter(q_filter)
-        
+
         return queryset, resolved_variable
     
     def _apply_ids_filter(self, queryset, ids: list):
@@ -783,13 +801,14 @@ class STACQueryablesView(STACAPIView):
 
     GET /stac/queryables
     GET /stac/collections/{catalog_slug}/queryables
-    GET /stac/collections/{catalog_slug}/{variable_slug}/queryables
+    GET /stac/collections/{catalog_slug}/{collection_slug}/{variable_slug}/queryables
     """
-    
+
     def get(
             self,
             request: Request,
             catalog_slug: str = None,
+            collection_slug: str = None,
             variable_slug: str = None,
     ) -> Response:
         base_url = request.build_absolute_uri()
@@ -839,8 +858,8 @@ class STACQueryablesView(STACAPIView):
             ]
         
         # Variable-level: add forecast queryables if applicable
-        if catalog_slug and variable_slug:
-            variable = _resolve_variable(catalog_slug, variable_slug)
+        if catalog_slug and collection_slug and variable_slug:
+            variable = _resolve_variable(catalog_slug, collection_slug, variable_slug)
             collection = variable.collection
             
             # Variable info


### PR DESCRIPTION
The old two-part URL /collections/{catalog}/{variable} assumed variable slugs were unique per catalog, but multiple collections within the same catalog (e.g. chirps-monthly and chirps-dekadal) can share the same variable slug (e.g. 'precip'), causing get() to return multiple objects.

URLs are now three-part: /collections/{catalog}/{collection}/{variable}, matching the actual Catalog→Collection→Variable data model. The STAC Collection ID changes from variable.slug to {collection.slug}/{variable.slug} for global uniqueness. All generated hrefs updated to include trailing slashes.