### PR TITLE
feat(#24): consumer creates DataArrival for every bucket event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LOG_ARGS ?= --tail 100
 	dev-up dev-down dev-stop dev-restart dev-build dev-ps dev-logs \
 	dev-app-logs dev-worker-logs dev-beat-logs \
 	dev-shell dev-worker-shell dev-beat-shell \
-	dev-migrate dev-makemigrations
+	dev-migrate dev-makemigrations dev-test
 
 # ======================
 # PROD (default)
@@ -143,3 +143,12 @@ dev-migrate:
 
 dev-makemigrations:
 	$(DEV_DC) exec $(APP) georiva makemigrations
+
+# Run tests bypassing PgBouncer (which cannot CREATE DATABASE).
+# Reads DB credentials from .env and connects directly to georiva-db.
+# Usage: make dev-test TEST_ARGS="georiva.ingestion.tests -v 2"
+dev-test:
+	@export $$(grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$$' | grep -v '^UID=' | xargs) && \
+	$(DEV_DC) exec \
+	  -e "DATABASE_URL=timescalegis://$$GEORIVA_DB_USER:$$GEORIVA_DB_PASSWORD@georiva-db:5432/$$GEORIVA_DB_NAME" \
+	  $(APP) georiva test --keepdb $(TEST_ARGS)

--- a/georiva/src/georiva/ingestion/consumer.py
+++ b/georiva/src/georiva/ingestion/consumer.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from georiva.core.filename import validate_path
 from georiva.core.models import Catalog
 from georiva.core.storage import BucketType, get_bucket_config
-from georiva.ingestion.models import FileIngestion
+from georiva.ingestion.models import DataArrival, FileIngestion
 from georiva.ingestion.tasks import process_incoming_file
 
 logger = logging.getLogger(__name__)
@@ -71,12 +71,21 @@ def _handle_event(ev: dict):
         logger.warning("Unknown catalog '%s': %s", catalog_slug, key)
         return
     
+    arrival, arrival_created = DataArrival.find_or_create(
+        file_path=key,
+        trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+    )
+    if not arrival_created and arrival.status == DataArrival.Status.UPLOADING:
+        arrival.status = DataArrival.Status.PENDING
+        arrival.save(update_fields=['status', 'updated_at'])
+
     log, created = FileIngestion.register(
         bucket=origin_bucket,
         file_path=key,
         catalog_slug=catalog_slug,
         collection_slug=collection_slug or "",
         reference_time=meta.get("reference_time"),
+        data_arrival=arrival,
     )
     
     if not created:

--- a/georiva/src/georiva/ingestion/tests/test_consumer.py
+++ b/georiva/src/georiva/ingestion/tests/test_consumer.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from georiva.core.models import Catalog
+from georiva.core.storage import BucketType
+from georiva.ingestion.consumer import _handle_event
+from georiva.ingestion.models import DataArrival, FileIngestion
+
+
+def _make_event(bucket_name: str, key: str) -> dict:
+    return {"s3": {"bucket": {"name": bucket_name}, "object": {"key": key}}}
+
+
+def _run(ev, catalog_slug="test-catalog", collection_slug="test-collection"):
+    with (
+        patch("georiva.ingestion.consumer.validate_path") as mock_vp,
+        patch("georiva.ingestion.consumer._resolve_origin", return_value=BucketType.SOURCES),
+        patch("georiva.ingestion.consumer.process_incoming_file") as mock_task,
+    ):
+        mock_vp.return_value = {
+            "catalog": catalog_slug,
+            "collection": collection_slug,
+            "reference_time": None,
+        }
+        mock_task.delay = MagicMock()
+        _handle_event(ev)
+
+
+class ConsumerCreatesDataArrivalTests(TestCase):
+    def setUp(self):
+        Catalog.objects.create(name="Test", slug="test-catalog", file_format="grib2")
+        self.file_path = "test-catalog/test-collection/somefile.grib2"
+        self.ev = _make_event("georiva-sources", self.file_path)
+
+    def test_direct_drop_creates_data_arrival_and_linked_file_ingestion(self):
+        _run(self.ev)
+
+        arrival = DataArrival.objects.get(file_path=self.file_path)
+        self.assertEqual(arrival.trigger, DataArrival.Trigger.MANUAL_UPLOAD)
+        self.assertEqual(arrival.status, DataArrival.Status.PENDING)
+
+        log = FileIngestion.objects.get(file_path=self.file_path)
+        self.assertEqual(log.data_arrival_id, arrival.pk)
+
+    def test_pre_registered_uploading_arrival_transitions_to_pending(self):
+        existing = DataArrival.objects.create(
+            file_path=self.file_path,
+            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+            status=DataArrival.Status.UPLOADING,
+        )
+
+        _run(self.ev)
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.status, DataArrival.Status.PENDING)
+        self.assertEqual(DataArrival.objects.filter(file_path=self.file_path).count(), 1)
+
+        log = FileIngestion.objects.get(file_path=self.file_path)
+        self.assertEqual(log.data_arrival_id, existing.pk)


### PR DESCRIPTION
## Summary

- `consumer._handle_event()` now calls `DataArrival.find_or_create()` before `FileIngestion.register()`
- Pre-registered arrivals (`status=uploading`, created by the future admin upload interface) are transitioned to `pending` when the bucket event fires — no duplicate `DataArrival` created
- `FileIngestion.data_arrival` FK is populated on every consumer-created record
- Adds `make dev-test TEST_ARGS="..."` Makefile target that bypasses PgBouncer for test DB creation

Closes #24.

## Test plan

- [ ] `make dev-test TEST_ARGS="georiva.ingestion.tests -v 2"` — all 6 tests pass
- [ ] Direct MinIO drop creates a `DataArrival(trigger=manual_upload, status=pending)` and linked `FileIngestion`
- [ ] Pre-creating a `DataArrival(status=uploading)` before the drop transitions it to `pending`, no duplicate created

🤖 Generated with [Claude Code](https://claude.com/claude-code)