### PR TITLE
feat(#25): record_run() creates DataArrival for scheduled DataFeed runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LOG_ARGS ?= --tail 100
 	dev-up dev-down dev-stop dev-restart dev-build dev-ps dev-logs \
 	dev-app-logs dev-worker-logs dev-beat-logs \
 	dev-shell dev-worker-shell dev-beat-shell \
-	dev-migrate dev-makemigrations
+	dev-migrate dev-makemigrations dev-test
 
 # ======================
 # PROD (default)
@@ -143,3 +143,12 @@ dev-migrate:
 
 dev-makemigrations:
 	$(DEV_DC) exec $(APP) georiva makemigrations
+
+# Run tests bypassing PgBouncer (which cannot CREATE DATABASE).
+# Reads DB credentials from .env and connects directly to georiva-db.
+# Usage: make dev-test TEST_ARGS="georiva.ingestion.tests -v 2"
+dev-test:
+	@export $$(grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$$' | grep -v '^UID=' | xargs) && \
+	$(DEV_DC) exec \
+	  -e "DATABASE_URL=timescalegis://$$GEORIVA_DB_USER:$$GEORIVA_DB_PASSWORD@georiva-db:5432/$$GEORIVA_DB_NAME" \
+	  $(APP) georiva test --keepdb $(TEST_ARGS)

--- a/georiva/src/georiva/sources/job_types.py
+++ b/georiva/src/georiva/sources/job_types.py
@@ -119,7 +119,10 @@ class DataArrivalJobType(JobType):
             job.files_failed += result.files_failed
             job.save(update_fields=["files_skipped", "files_failed"])
 
-            data_feed.record_run(result, collection)
+            arrival = data_feed.record_run(result, collection)
+            if arrival and not job.data_arrival_id:
+                job.data_arrival = arrival
+                job.save(update_fields=["data_arrival"])
 
             logger.info(
                 "DataArrivalJob %d (%s): %s",

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -190,34 +190,41 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
     # =========================================================================
     
     def record_run(self, result, collection):
-        """Record data feed run result."""
+        """Record data feed run result. Returns the created DataArrival."""
         from django.utils import timezone
         from georiva.core.storage import BucketType
-        from georiva.ingestion.models import FileIngestion
-        
-        data_feed_run = DataFeedRun.objects.create(
-            collection=collection,
+        from georiva.ingestion.models import DataArrival, FileIngestion
+
+        _status_map = {
+            'success': DataArrival.Status.COMPLETED,
+            'partial': DataArrival.Status.PARTIAL,
+            'failed': DataArrival.Status.FAILED,
+            'empty': DataArrival.Status.EMPTY,
+            'queued': DataArrival.Status.PENDING,
+        }
+
+        arrival = DataArrival.objects.create(
+            trigger=DataArrival.Trigger.SCHEDULED,
+            status=_status_map.get(result.status, DataArrival.Status.PENDING),
             data_feed=self,
-            started_at=result.started_at,
-            finished_at=result.finished_at,
-            status=result.status,
+            collection=collection,
             files_requested=result.files_requested,
             files_fetched=result.files_fetched,
             files_skipped=result.files_skipped,
             files_failed=result.files_failed,
             files_queued=result.files_queued,
             bytes_transferred=result.bytes_transferred,
-            run_time=result.run_time,
-            errors=result.errors,
+            started_at=result.started_at,
+            finished_at=result.finished_at,
         )
-        
+
         if result.stored_paths:
             FileIngestion.objects.filter(
                 file_path__in=result.stored_paths,
                 bucket=BucketType.SOURCES,
-                data_feed_run__isnull=True,
-            ).update(data_feed_run=data_feed_run)
-        
+                data_arrival__isnull=True,
+            ).update(data_arrival=arrival)
+
         now = timezone.now()
         
         # Update per-collection link's last_run_at for independent scheduling
@@ -232,12 +239,14 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
         
         if result.success:
             self.last_success_at = self.last_run_at
-        
+
         self.save(update_fields=[
             'last_run_at', 'last_run_status', 'last_run_message',
             'last_success_at', 'total_runs', 'total_files_fetched',
             'total_bytes_transferred',
         ])
+
+        return arrival
     
     def is_due(self) -> bool:
         """Check if data feed is due to run."""

--- a/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
+++ b/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+
+from georiva.core.models import Catalog, Collection
+from georiva.core.storage import BucketType
+from georiva.ingestion.models import DataArrival, FileIngestion
+from georiva.sources.loader import LoaderRunResult
+from georiva.sources.models import DataFeed
+
+
+def _make_feed():
+    return DataFeed.objects.create(name="Test Feed")
+
+
+def _make_collection():
+    catalog = Catalog.objects.create(name="Test", slug="test-cat", file_format="grib2")
+    return Collection.objects.create(name="Test Col", slug="test-col", catalog=catalog)
+
+
+class RecordRunCreatesDataArrivalTests(TestCase):
+    def setUp(self):
+        self.feed = _make_feed()
+        self.collection = _make_collection()
+
+    def test_successful_run_creates_scheduled_data_arrival(self):
+        result = LoaderRunResult(
+            files_requested=4,
+            files_fetched=3,
+            files_skipped=1,
+            files_failed=0,
+            bytes_transferred=2048,
+        )
+        result.finish()
+
+        self.feed.record_run(result, self.collection)
+
+        arrival = DataArrival.objects.get(
+            trigger=DataArrival.Trigger.SCHEDULED,
+            data_feed=self.feed,
+        )
+        self.assertEqual(arrival.status, DataArrival.Status.COMPLETED)
+        self.assertEqual(arrival.files_requested, 4)
+        self.assertEqual(arrival.files_fetched, 3)
+        self.assertEqual(arrival.files_skipped, 1)
+        self.assertEqual(arrival.files_failed, 0)
+        self.assertEqual(arrival.bytes_transferred, 2048)
+        self.assertEqual(arrival.collection, self.collection)
+
+    def test_record_run_links_file_ingestions_to_arrival(self):
+        paths = [
+            "test-cat/test-col/file_a.grib2",
+            "test-cat/test-col/file_b.grib2",
+        ]
+        for path in paths:
+            FileIngestion.objects.create(
+                bucket=BucketType.SOURCES,
+                file_path=path,
+                catalog_slug="test-cat",
+                collection_slug="test-col",
+            )
+
+        result = LoaderRunResult(files_fetched=2, stored_paths=paths)
+        result.finish()
+
+        self.feed.record_run(result, self.collection)
+
+        arrival = DataArrival.objects.get(trigger=DataArrival.Trigger.SCHEDULED)
+        linked = FileIngestion.objects.filter(data_arrival=arrival)
+        self.assertEqual(linked.count(), 2)
+        self.assertSetEqual(set(linked.values_list("file_path", flat=True)), set(paths))


### PR DESCRIPTION
## Summary

- `DataFeed.record_run()` now creates a `DataArrival(trigger=scheduled)` instead of a `DataFeedRun`
- Status is mapped from `LoaderRunResult.status`: `success→completed`, `partial→partial`, `failed→failed`, `empty→empty`, `queued→pending`
- `FileIngestion` records from the run are linked via `data_arrival` FK instead of `data_feed_run`
- `record_run()` returns the `DataArrival` so `DataArrivalJobType.run()` can set `job.data_arrival`
- `DataFeed` denormalized fields (`last_run_at`, `last_run_status`, etc.) are unchanged
- `DataFeedRun` model is **not** deleted — that happens in the migration slice (#27)

Closes #25.

## Test plan

- [ ] `make dev-test TEST_ARGS="georiva.ingestion.tests georiva.sources.tests -v 2"` — all 6 tests pass
- [ ] Triggering a DataFeed run via the admin produces a `DataArrival` with `trigger=scheduled` in the database
- [ ] `FileIngestion` records created during the run have `data_arrival` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)