### PR TITLE
feat(#36): add time extraction utility for manual upload filenames

### DIFF
--- a/georiva/src/georiva/ingestion/tests/test_time_extraction.py
+++ b/georiva/src/georiva/ingestion/tests/test_time_extraction.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from georiva.ingestion.time_extraction import extract_times
+
+
+class GRPrefixExtractionTests(SimpleTestCase):
+
+    def test_gr_prefix_yields_reference_time(self):
+        result = extract_times("GR--20250115T0600--20250115.grib2", "YYYYMMDD")
+        self.assertEqual(result["reference_time"], datetime(2025, 1, 15, 6, 0, tzinfo=timezone.utc))
+
+    def test_no_gr_prefix_yields_no_reference_time(self):
+        result = extract_times("20250115.grib2", "YYYYMMDD")
+        self.assertNotIn("reference_time", result)
+
+    def test_gr_prefix_and_valid_time_both_extracted(self):
+        result = extract_times("GR--20250115T0600--20250116.grib2", "YYYYMMDD")
+        self.assertEqual(result["reference_time"], datetime(2025, 1, 15, 6, 0, tzinfo=timezone.utc))
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 16, 0, 0, tzinfo=timezone.utc))
+
+
+class ValidTimeStemParsingTests(SimpleTestCase):
+
+    def test_YYYYMMDD(self):
+        result = extract_times("20250115.grib2", "YYYYMMDD")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, tzinfo=timezone.utc))
+
+    def test_DDMMYYYY(self):
+        result = extract_times("15012025.grib2", "DDMMYYYY")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, tzinfo=timezone.utc))
+
+    def test_YYYYMMDDHH(self):
+        result = extract_times("2025011506.grib2", "YYYYMMDDHH")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, 6, tzinfo=timezone.utc))
+
+    def test_YYYYMMDDHHMM(self):
+        result = extract_times("202501150630.grib2", "YYYYMMDDHHMM")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, 6, 30, tzinfo=timezone.utc))
+
+    def test_DDMMYY(self):
+        result = extract_times("150125.grib2", "DDMMYY")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, tzinfo=timezone.utc))
+
+    def test_YYMMDD(self):
+        result = extract_times("250115.grib2", "YYMMDD")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, tzinfo=timezone.utc))
+
+    def test_path_with_directories_uses_filename_stem(self):
+        result = extract_times("catalog/collection/20250115.grib2", "YYYYMMDD")
+        self.assertEqual(result["valid_time"], datetime(2025, 1, 15, tzinfo=timezone.utc))
+
+
+class EmptyResultTests(SimpleTestCase):
+
+    def test_unrecognisable_stem_returns_empty_dict(self):
+        result = extract_times("chirps-v2.0.grib2", "YYYYMMDD")
+        self.assertEqual(result, {})
+
+    def test_unknown_format_choice_returns_empty_dict(self):
+        result = extract_times("20250115.grib2", "UNKNOWN")
+        self.assertEqual(result, {})
+
+    def test_no_exception_on_garbage_filename(self):
+        result = extract_times("not-a-date-at-all.tif", "YYYYMMDD")
+        self.assertIsInstance(result, dict)
+
+
+class ContentFallbackTests(SimpleTestCase):
+
+    def test_valid_time_read_from_grib_content_when_stem_unrecognised(self):
+        expected_ts = datetime(2025, 1, 15, 6, 0, tzinfo=timezone.utc)
+        mock_plugin = MagicMock()
+        mock_plugin.list_variables.return_value = [{"name": "2t"}]
+        mock_plugin.get_timestamps.return_value = [expected_ts]
+
+        with patch("georiva.ingestion.time_extraction.format_registry") as mock_registry:
+            mock_registry.get_plugin_for.return_value = mock_plugin
+            result = extract_times("unrecognised.grib2", "YYYYMMDD", file_obj=BytesIO(b"fake"))
+
+        self.assertEqual(result["valid_time"], expected_ts)
+
+    def test_non_grib_netcdf_file_obj_ignored_for_content_fallback(self):
+        with patch("georiva.ingestion.time_extraction.format_registry") as mock_registry:
+            result = extract_times("file.tif", "YYYYMMDD", file_obj=BytesIO(b"fake"))
+
+        mock_registry.get_plugin_for.assert_not_called()
+        self.assertEqual(result, {})
+
+    def test_content_fallback_not_called_when_both_fields_resolved_from_filename(self):
+        with patch("georiva.ingestion.time_extraction.format_registry") as mock_registry:
+            result = extract_times("GR--20250115T0600--20250116.grib2", "YYYYMMDD", file_obj=BytesIO(b"fake"))
+
+        mock_registry.get_plugin_for.assert_not_called()
+        self.assertIn("reference_time", result)
+        self.assertIn("valid_time", result)
+
+    def test_no_exception_when_plugin_raises(self):
+        with patch("georiva.ingestion.time_extraction.format_registry") as mock_registry:
+            mock_registry.get_plugin_for.side_effect = RuntimeError("plugin error")
+            result = extract_times("unrecognised.grib2", "YYYYMMDD", file_obj=BytesIO(b"fake"))
+
+        self.assertIsInstance(result, dict)

--- a/georiva/src/georiva/ingestion/time_extraction.py
+++ b/georiva/src/georiva/ingestion/time_extraction.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytz
+
+from georiva.core.filename import parse_filename
+from georiva.formats.registry import format_registry
+
+_FORMAT_PATTERNS = {
+    "YYYYMMDD":   "%Y%m%d",
+    "DDMMYYYY":   "%d%m%Y",
+    "YYYYMMDDHH": "%Y%m%d%H",
+    "YYYYMMDDHHMM": "%Y%m%d%H%M",
+    "DDMMYY":     "%d%m%y",
+    "YYMMDD":     "%y%m%d",
+}
+
+
+def extract_times(filename: str, format_choice: str, file_obj=None) -> dict:
+    """
+    Determine reference_time and valid_time from a filename and optional file content.
+
+    Extraction order:
+      1. GR--{reftime}-- prefix in filename → reference_time
+      2. Stem of original filename parsed with format_choice → valid_time
+      3. File content via format plugin (GRIB/NetCDF only, requires file_obj)
+
+    Never raises. Returns a partial or empty dict when fields cannot be resolved.
+    """
+    result = {}
+
+    parsed = parse_filename(Path(filename).name)
+    if parsed["reference_time"] is not None:
+        result["reference_time"] = parsed["reference_time"]
+
+    original_name = parsed["original_name"]
+    stem = Path(original_name).stem
+    valid_time = _parse_stem(stem, format_choice)
+    if valid_time is not None:
+        result["valid_time"] = valid_time
+
+    if file_obj is not None and len(result) < 2:
+        _fill_from_content(filename, file_obj, result)
+
+    return result
+
+
+def _parse_stem(stem: str, format_choice: str):
+    pattern = _FORMAT_PATTERNS.get(format_choice)
+    if not pattern:
+        return None
+    from datetime import datetime
+    try:
+        dt = datetime.strptime(stem, pattern)
+        return pytz.utc.localize(dt)
+    except ValueError:
+        return None
+
+
+def _fill_from_content(filename: str, file_obj, result: dict):
+    import tempfile
+
+    ext = Path(filename).suffix.lower()
+    content_formats = {".grib", ".grib2", ".grb", ".grb2", ".nc", ".nc4", ".netcdf"}
+    if ext not in content_formats:
+        return
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+            tmp.write(file_obj.read())
+            tmp_path = tmp.name
+
+        plugin = format_registry.get_plugin_for(tmp_path)
+        if plugin is None:
+            return
+
+        variables = plugin.list_variables(tmp_path)
+        if not variables:
+            return
+
+        first_var = variables[0]
+        var_name = first_var.get("name") or first_var.get("key")
+        if not var_name:
+            return
+
+        timestamps = plugin.get_timestamps(tmp_path, var_name)
+        if timestamps and "valid_time" not in result:
+            result["valid_time"] = timestamps[0]
+
+    except Exception:
+        pass
+    finally:
+        if tmp_path:
+            try:
+                import os
+                os.unlink(tmp_path)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

- Adds `extract_times(filename, format_choice, file_obj=None) → dict` in `georiva/ingestion/time_extraction.py`
- Extracts `reference_time` from the `GR--{reftime}--` filename prefix (reusing `core.filename.parse_filename`)
- Extracts `valid_time` by parsing the filename stem against one of 6 predefined format tokens (`YYYYMMDD`, `DDMMYYYY`, `YYYYMMDDHH`, `YYYYMMDDHHMM`, `DDMMYY`, `YYMMDD`)
- Falls back to file content via the format registry for GRIB/NetCDF when `file_obj` is provided and filename extraction is incomplete; silently skipped for GeoTIFF and other formats
- Never raises — returns a partial or empty dict when fields cannot be resolved

## Test plan

- [x] `GR--` prefix yields `reference_time`
- [x] No prefix → no `reference_time` in result
- [x] Both `reference_time` and `valid_time` extracted when both sources present
- [x] All 6 format tokens parse correctly to UTC datetime
- [x] Path with directories uses only the filename stem
- [x] Unrecognisable stem returns empty dict
- [x] Unknown `format_choice` returns empty dict
- [x] No exception on garbage filename
- [x] Content fallback reads `valid_time` from GRIB plugin (mocked registry)
- [x] Non-GRIB/NetCDF `file_obj` is ignored (registry never called)
- [x] Content fallback skipped when both fields already resolved from filename
- [x] No exception when format plugin raises
- [x] Full ingestion suite passes (51 tests)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)