### PR TITLE
feat(#40): Manual upload page with ingestion status tracking

### DIFF
--- a/georiva/src/georiva/formats/netcdf.py
+++ b/georiva/src/georiva/formats/netcdf.py
@@ -125,7 +125,13 @@ class NetCDFFormatPlugin(BaseFormatPlugin):
             # Time selection (lazy)
             time_dim = self._time_dim(var)
             if timestamp is not None and time_dim:
-                var = var.sel({time_dim: timestamp}, method="nearest")
+                sel_ts = timestamp
+                # If the file's time axis is tz-naive but our timestamp is tz-aware,
+                # strip tzinfo before selection — pandas refuses to compare the two.
+                coord_tz = getattr(var.coords[time_dim].dtype, "tz", None)
+                if coord_tz is None and getattr(timestamp, "tzinfo", None) is not None:
+                    sel_ts = timestamp.replace(tzinfo=None)
+                var = var.sel({time_dim: sel_ts}, method="nearest")
             elif time_dim and var[time_dim].size > 0:
                 var = var.isel({time_dim: 0})
             

--- a/georiva/src/georiva/ingestion/job_types.py
+++ b/georiva/src/georiva/ingestion/job_types.py
@@ -8,8 +8,9 @@ FileIngestionJob is the operator-visible layer on top.
 
 import logging
 
+from django.utils import timezone as dj_timezone
 from task_ferry.registry import JobType
-from .models import FileIngestionJob, FileIngestion
+from .models import DataArrival, FileIngestionJob, FileIngestion
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,19 @@ class FileIngestionJobType(JobType):
             return
 
         # Link the Job to the FileIngestion record now that we hold the lock.
+        fi = None
         try:
             fi = FileIngestion.objects.get(bucket=job.bucket, file_path=job.file_path)
             job.file_ingestion = fi
             job.save(update_fields=["file_ingestion"])
         except FileIngestion.DoesNotExist:
             pass  # very unlikely; carry on without the FK
+
+        arrival_id = fi.data_arrival_id if fi else None
+        if arrival_id:
+            DataArrival.objects.filter(pk=arrival_id).update(
+                status=DataArrival.Status.PROCESSING,
+            )
 
         progress.increment(10, state="Lock acquired — starting ingestion")
 
@@ -86,6 +94,15 @@ class FileIngestionJobType(JobType):
             job.items_created = len(result.items_created)
             job.assets_created = len(result.assets_created)
             job.save(update_fields=["items_created", "assets_created"])
+            if arrival_id:
+                arrival_status = (
+                    DataArrival.Status.PARTIAL if result.errors
+                    else DataArrival.Status.COMPLETED
+                )
+                DataArrival.objects.filter(pk=arrival_id).update(
+                    status=arrival_status,
+                    finished_at=dj_timezone.now(),
+                )
             progress.increment(10, state=(
                 f"Done — {len(result.items_created)} items, "
                 f"{len(result.assets_created)} assets created"
@@ -102,6 +119,12 @@ class FileIngestionJobType(JobType):
                 file_path=job.file_path,
                 error=error_msg,
             )
+            if arrival_id:
+                DataArrival.objects.filter(pk=arrival_id).update(
+                    status=DataArrival.Status.FAILED,
+                    error_message=error_msg[:2000],
+                    finished_at=dj_timezone.now(),
+                )
             raise RuntimeError(error_msg)
 
     def on_error(self, job: FileIngestionJob, exc: Exception) -> None:
@@ -126,6 +149,26 @@ class FileIngestionJobType(JobType):
             locked_by="",
             error=str(exc)[:2000],
         )
+        # Propagate failure to the DataArrival for arrivals still in a live
+        # state. The curated path (mark_failed + raise in run()) already
+        # transitioned the arrival, so this only fires on unexpected crashes.
+        if job.file_ingestion_id:
+            try:
+                fi = FileIngestion.objects.get(pk=job.file_ingestion_id)
+                if fi.data_arrival_id:
+                    DataArrival.objects.filter(
+                        pk=fi.data_arrival_id,
+                        status__in=[
+                            DataArrival.Status.PENDING,
+                            DataArrival.Status.PROCESSING,
+                        ],
+                    ).update(
+                        status=DataArrival.Status.FAILED,
+                        error_message=str(exc)[:2000],
+                        finished_at=dj_timezone.now(),
+                    )
+            except FileIngestion.DoesNotExist:
+                pass
 
     def on_cancelled(self, job: FileIngestionJob) -> None:
         # Release the FileIngestion lock so sweep can retry the file.

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/manual_upload_page.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/manual_upload_page.html
@@ -16,6 +16,10 @@
     }
     .mup-meta-label { color: var(--w-color-grey-400); }
     .mup-actions { display: flex; gap: 1em; margin-top: 1.5em; align-items: center; }
+    .mup-collections {
+        margin: 0.4em 0 0 0; padding-left: 1.3em; line-height: 1.9;
+    }
+    .mup-collections li { color: var(--w-color-text-label); }
     .mup-error {
         display: none; color: var(--w-color-critical-200);
         font-size: 0.95em; margin-top: 1em;
@@ -68,6 +72,7 @@
     <form id="upload-form" class="mup-form">
         {% csrf_token %}
 
+        {% if is_geotiff %}
         <div class="w-field__wrapper mup-field">
             <label class="w-field__label" for="variable-select">{% trans "Variable" %} <sup>*</sup></label>
             <select id="variable-select" class="w-field__input" required>
@@ -78,6 +83,17 @@
                 {% endfor %}
             </select>
         </div>
+        {% else %}
+        <div class="mup-field">
+            <div class="w-field__label">{% trans "Collections to be processed" %}</div>
+            <ul class="mup-collections">
+                {% for collection in affected_collections %}
+                <li>{{ collection.name }}</li>
+                {% endfor %}
+            </ul>
+            <div class="mup-help">{% trans "All active variables in these collections will be extracted from the uploaded file." %}</div>
+        </div>
+        {% endif %}
 
         <div class="w-field__wrapper mup-field">
             <label class="w-field__label" for="time-input">
@@ -138,7 +154,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const form        = document.getElementById('upload-form');
     const fileInput   = document.getElementById('file-input');
     const timeInput   = document.getElementById('time-input');
-    const variableSel = document.getElementById('variable-select');
+    const variableSel = document.getElementById('variable-select'); // null for GRIB/NetCDF
     const submitBtn   = document.getElementById('submit-btn');
     const formError   = document.getElementById('form-error');
     const panel       = document.getElementById('progress-panel');
@@ -216,7 +232,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const fd = new FormData();
         fd.append('csrfmiddlewaretoken', CSRF_TOKEN);
-        fd.append('variable_id', variableSel.value);
+        if (variableSel) fd.append('variable_id', variableSel.value);
         fd.append('time', timeInput.value);
         fd.append('file', fileInput.files[0]);
 

--- a/georiva/src/georiva/ingestion/upload_views.py
+++ b/georiva/src/georiva/ingestion/upload_views.py
@@ -98,6 +98,17 @@ def manual_upload_page(request, pk):
         "long_name", "variable_name"
     )
     file_format = config.catalog.file_format
+    is_geotiff = file_format == "geotiff"
+
+    # For GRIB/NetCDF: deduplicate collections so the template can show
+    # "these collections will be processed" without a variable picker.
+    affected_collections = []
+    if not is_geotiff:
+        seen = set()
+        for v in variables:
+            if v.collection_id not in seen:
+                seen.add(v.collection_id)
+                affected_collections.append(v.collection)
 
     return render(request, "georivaingestion/manual_upload_page.html", {
         "breadcrumbs_items": [
@@ -110,10 +121,12 @@ def manual_upload_page(request, pk):
         # by the time extra_js renders.
         "upload_config": config,
         "variables": variables,
+        "is_geotiff": is_geotiff,
+        "affected_collections": affected_collections,
         "accept_extensions": _CATALOG_FORMAT_ACCEPT.get(file_format, ""),
         "format_label": _CATALOG_FORMAT_LABEL.get(file_format, file_format),
         "time_label": _("Model run time") if config.is_forecast else _("Observation date"),
-        "time_required": config.is_forecast or file_format == "geotiff",
+        "time_required": config.is_forecast or is_geotiff,
     })
 
 
@@ -159,6 +172,8 @@ def manual_upload_submit(request, pk):
     variable_id = request.POST.get("variable_id")
     operator_time = _parse_datetime_local(request.POST.get("time", ""))
 
+    is_geotiff = config.catalog.file_format == "geotiff"
+
     errors = []
     if not uploaded:
         errors.append(str(_("Please choose a file to upload.")))
@@ -166,7 +181,7 @@ def manual_upload_submit(request, pk):
     variable = None
     if variable_id:
         variable = config.variables.select_related("collection").filter(pk=variable_id).first()
-    if variable is None:
+    if is_geotiff and variable is None:
         errors.append(str(_("Please choose a variable.")))
 
     if errors:
@@ -194,7 +209,7 @@ def manual_upload_submit(request, pk):
         trigger=DataArrival.Trigger.MANUAL_UPLOAD,
         status=DataArrival.Status.UPLOADING,
         file_path=file_path,
-        collection=variable.collection if config.catalog.file_format == "geotiff" else None,
+        collection=variable.collection if is_geotiff else None,
         files_requested=1,
     )
 
@@ -229,7 +244,7 @@ def manual_upload_submit(request, pk):
         bucket=BucketType.INCOMING,
         file_path=saved_path,
         catalog_slug=config.catalog.slug,
-        collection_slug=variable.collection.slug if config.catalog.file_format == "geotiff" else "",
+        collection_slug=variable.collection.slug if is_geotiff else "",
         reference_time=reference_time,
         data_arrival=arrival,
     )


### PR DESCRIPTION
## Summary

- Adds a **Manual Upload Page** (`/admin/manual-upload/<pk>/`) where operators can upload GRIB, NetCDF, or GeoTIFF files against a `ManualUploadConfig` and track ingestion progress in real time
- Fixes several bugs discovered during integration testing of the upload wizard

## Changes

### Feature: Manual Upload Page (#40)
- Upload form with file picker, time input (pre-filled from filename), and variable selector (GeoTIFF) or collections list (GRIB/NetCDF)
- Submits file to MinIO incoming bucket, creates `DataArrival` + `FileIngestion`, enqueues `process_incoming_file`
- Frontend polls `GET /api/arrivals/<id>/status/` and displays live status pill + spinner until terminal state

### Bug fixes (#28)
- **`DataArrival.status` stuck on `pending`** — `FileIngestionJobType.run()` never transitioned `DataArrival` after the Celery job ran; now drives it through `processing → completed / partial / failed`; `on_error()` covers unexpected crashes
- **`FileIngestion` CASCADE on Item deletion** — changed to `SET_NULL` so the lock/audit record survives `ItemHandler.delete_orphan()`
- **`FileIngestionJob` OneToOne → FK** — retries and re-ingests create a new job per invocation; `OneToOne` prevented that
- **Lock not released on worker crash** — `on_error()` now scoped to the owning worker ID so it releases the `FileIngestion` lock without clobbering concurrent runs
- **NetCDF tz-naive/tz-aware dtype mismatch** — `datetime64[ns]` file axis vs `datetime64[us, UTC]` from `ensure_utc()` raised `TypeError` in xarray `.sel()`; strip `tzinfo` when coordinate has no timezone
- **Variable selector shown for GRIB/NetCDF** — selection was required but silently discarded (file fans out to all collections regardless); replaced with a read-only "Collections to be processed" list; `variable_id` only required for GeoTIFF

## Test plan

- [ ] Upload a GeoTIFF file — variable selector shown, ingestion scoped to selected collection
- [ ] Upload a NetCDF file — collections list shown (no selector), all active collections processed
- [ ] Upload a GRIB file — same as NetCDF
- [ ] Confirm status pill advances: `uploading → pending → processing → completed`
- [ ] Upload a file that triggers a partial failure — status shows `partial`
- [ ] Re-upload a previously ingested file — `FileIngestion.reset_for_reingest` runs, file is reprocessed
- [ ] Worker crash mid-ingest — `DataArrival` reaches `failed`, lock is released for sweep retry
- [ ] Run unit tests: `make dev-test TEST_ARGS="ingestion"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)