### PR TITLE
feat(ingestion): thread granular progress through IngestionService and IngestionHandler

### DIFF
--- a/georiva/src/georiva/ingestion/handlers/ingestion_handler.py
+++ b/georiva/src/georiva/ingestion/handlers/ingestion_handler.py
@@ -55,6 +55,7 @@ class IngestionHandler:
             local_path: Path,
             timestamp: datetime,
             source_file: str,
+            progress=None,
     ) -> tuple[Optional[Item], list[Asset], dict, list[str]]:
         """
         Process all Variables for *collection* at *timestamp*.
@@ -148,12 +149,16 @@ class IngestionHandler:
                     clip_window=clip_window,
                 )
                 assets.extend(variable_assets)
+                if progress is not None:
+                    progress.increment(state=f"{variable.slug}: succeeded")
             except Exception as e:
                 logger.error(
                     "Variable %s failed: %s\n%s",
                     variable.slug, e, traceback.format_exc(),
                 )
                 failed_variables.append(variable.slug)
+                if progress is not None:
+                    progress.increment(state=f"{variable.slug}: failed — {e}")
         
         # ── Extent update ─────────────────────────────────────────────────────
         self.extent_handler.expand(collection, ts_utc, bounds)

--- a/georiva/src/georiva/ingestion/job_types.py
+++ b/georiva/src/georiva/ingestion/job_types.py
@@ -64,15 +64,17 @@ class FileIngestionJobType(JobType):
         progress.increment(10, state="Lock acquired — starting ingestion")
 
         # ── Step 2: run the ingestion pipeline ────────────────────────────────
-        ingest_stage = progress.create_child(represents=75, total=1)
+        from georiva.ingestion.progress import PublishingProgress
 
+        pub_progress = PublishingProgress(total=100)
         service = IngestionService()
         result = service.process_file(
             file_path=job.file_path,
             origin_bucket=job.bucket,
+            progress=pub_progress,
         )
 
-        ingest_stage.increment(1, state="Pipeline complete")
+        progress.increment(75, state="Pipeline complete")
 
         # ── Step 3: record result ─────────────────────────────────────────────
         if result and result.success:

--- a/georiva/src/georiva/ingestion/progress.py
+++ b/georiva/src/georiva/ingestion/progress.py
@@ -1,0 +1,16 @@
+from task_ferry.progress import Progress
+
+
+class PublishingProgress(Progress):
+    """
+    Progress subclass that publishes each increment to a Redis pub/sub channel.
+    Redis wiring is added in slice 2; this slice gets the increment() calls
+    in the right places with the right state strings.
+    """
+
+    def increment(self, by: float = 1.0, state: str = "") -> None:
+        super().increment(by=by, state=state)
+        self._publish(state)
+
+    def _publish(self, state: str) -> None:
+        pass  # wired to Redis in slice 2

--- a/georiva/src/georiva/ingestion/service.py
+++ b/georiva/src/georiva/ingestion/service.py
@@ -80,6 +80,7 @@ class IngestionService:
             file_path: str,
             origin_bucket: str = BucketType.INCOMING,
             reference_time: datetime = None,
+            progress=None,
     ) -> IngestionResult:
         """
         Process a single incoming geospatial file end-to-end.
@@ -101,6 +102,10 @@ class IngestionService:
         Returns:
             IngestionResult summarising what was created and any errors.
         """
+        from task_ferry.progress import Progress
+        if progress is None:
+            progress = Progress(total=100)
+
         origin = storage.bucket(origin_bucket)
         self.logger.info("Processing: %s/%s", origin.bucket_name, file_path)
         
@@ -189,7 +194,9 @@ class IngestionService:
                 ingestion_log=ingestion_log,
             )
             handler = IngestionHandler(ctx)
-            
+
+            progress.increment(by=10, state="file opened")
+
             # ── Process ───────────────────────────────────────────────────────
             try:
                 sfm = self._source_file_manager
@@ -201,7 +208,7 @@ class IngestionService:
                                 f"No active variables for: {collection.slug}"
                             )
                             continue
-                        
+
                         timestamps = plugin.get_timestamps(
                             local_path, first_variable_name
                         )
@@ -210,14 +217,28 @@ class IngestionService:
                                 f"No timestamps found in: {file_path}"
                             )
                             continue
-                        
+
                         self.logger.info(
                             "Found %d timestamp(s) for %s",
                             len(timestamps), collection.slug,
                         )
                         result.collection_slug = collection.slug
-                        
+
+                        progress.increment(
+                            by=5,
+                            state=f"{collection.slug}: {len(timestamps)} timestamps found",
+                        )
+                        n_vars = len(
+                            [v for v in collection.variables.all() if v.is_active]
+                        )
+                        loop = progress.create_child(
+                            represents=70, total=max(1, len(timestamps))
+                        )
+
                         for ts in timestamps:
+                            ts_slot = loop.create_child(
+                                represents=1, total=max(1, n_vars)
+                            )
                             try:
                                 item, assets, clip_info, failed_vars = (
                                     handler.process_timestamp(
@@ -225,6 +246,7 @@ class IngestionService:
                                         local_path=local_path,
                                         timestamp=ts,
                                         source_file=f"{origin_bucket}:{file_path}",
+                                        progress=ts_slot,
                                     )
                                 )
                                 
@@ -259,8 +281,11 @@ class IngestionService:
                     plugin.clear_cache()
             
             # ── Archive + cleanup ─────────────────────────────────────────────
+            progress.increment(by=10, state="archiving")
             self._source_file_manager.cleanup(origin, file_path, catalog, result)
-            
+
+            progress.increment(by=5, state="done")
+
             if result.clipped and result.size_reduction_percent:
                 self.logger.info(
                     "Clipping reduced data size by %.1f%%",

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_progress.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_progress.py
@@ -1,0 +1,210 @@
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytz
+from django.test import TestCase
+from task_ferry.progress import Progress
+
+from georiva.core.models import Catalog, Collection
+from georiva.ingestion.handlers.ingestion_handler import IngestionHandler
+from georiva.ingestion.progress import PublishingProgress
+from georiva.ingestion.service import IngestionService
+
+
+# =============================================================================
+# PublishingProgress unit tests
+# =============================================================================
+
+class PublishingProgressTests(TestCase):
+
+    def test_is_progress_subclass(self):
+        pub = PublishingProgress(total=10)
+        self.assertIsInstance(pub, Progress)
+
+    def test_increment_advances_percentage(self):
+        pub = PublishingProgress(total=10)
+        pub.increment(5, state="testing")
+        self.assertEqual(pub.percentage, 50)
+
+
+# =============================================================================
+# IngestionService.process_file() progress checkpoints
+# =============================================================================
+
+class ProcessFileProgressTests(TestCase):
+
+    def setUp(self):
+        catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff",
+            is_active=True, clip_mode="none",
+        )
+        Collection.objects.create(
+            catalog=catalog, name="Rainfall", slug="rainfall", is_active=True,
+        )
+
+    def _run(self):
+        mock_progress = MagicMock(spec=Progress)
+        loop_progress = MagicMock(spec=Progress)
+        ts_slot = MagicMock(spec=Progress)
+        loop_progress.create_child.return_value = ts_slot
+        mock_progress.create_child.return_value = loop_progress
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_timestamps.return_value = [datetime(2024, 1, 15, tzinfo=pytz.utc)]
+
+        mock_item = MagicMock()
+        mock_item.pk = "item-1"
+
+        with (
+            patch("georiva.ingestion.service.format_registry") as mock_registry,
+            patch("georiva.ingestion.service.storage") as mock_storage,
+            patch("georiva.ingestion.service.IngestionHandler") as mock_handler_cls,
+            patch.object(IngestionService, "_get_first_variable_name", return_value="temperature"),
+        ):
+            mock_registry.get.return_value = mock_plugin
+            mock_storage.assets = MagicMock()
+            mock_storage.bucket.return_value = MagicMock()
+
+            mock_handler = MagicMock()
+            mock_handler.process_timestamp.return_value = (mock_item, [MagicMock()], {}, [])
+            mock_handler_cls.return_value = mock_handler
+
+            service = IngestionService()
+            mock_sfm = MagicMock()
+            ctx_mgr = MagicMock()
+            ctx_mgr.__enter__ = MagicMock(return_value="/tmp/chirps.tif")
+            ctx_mgr.__exit__ = MagicMock(return_value=False)
+            mock_sfm.download_to_temp.return_value = ctx_mgr
+            service._source_file_manager = mock_sfm
+
+            service.process_file(
+                "chirps/rainfall/2024/01/15/file.tif",
+                progress=mock_progress,
+            )
+
+        return mock_progress
+
+    def _states(self, mock_progress):
+        return [
+            c.kwargs.get("state", c.args[1] if len(c.args) > 1 else "")
+            for c in mock_progress.increment.call_args_list
+        ]
+
+    def test_emits_file_opened_checkpoint(self):
+        states = self._states(self._run())
+        self.assertTrue(
+            any("open" in s.lower() or "variable" in s.lower() for s in states),
+            f"Expected file-opened checkpoint in: {states}",
+        )
+
+    def test_emits_timestamps_checkpoint(self):
+        states = self._states(self._run())
+        self.assertTrue(
+            any("timestamp" in s.lower() for s in states),
+            f"Expected timestamps checkpoint in: {states}",
+        )
+
+    def test_creates_child_for_timestamp_loop(self):
+        mock_progress = self._run()
+        mock_progress.create_child.assert_called()
+
+    def test_emits_archiving_and_done_checkpoints(self):
+        states = self._states(self._run())
+        self.assertTrue(
+            any("archiv" in s.lower() for s in states),
+            f"Expected archiving checkpoint in: {states}",
+        )
+        self.assertTrue(
+            any("done" in s.lower() for s in states),
+            f"Expected done checkpoint in: {states}",
+        )
+
+
+# =============================================================================
+# IngestionHandler.process_timestamp() progress checkpoints
+# =============================================================================
+
+class ProcessTimestampProgressTests(TestCase):
+
+    def _make_handler(self):
+        ctx = MagicMock()
+        ctx.clipper.is_active = False
+        ctx.reference_time = None
+        ctx.ingestion_log = None
+        ctx.extractor.get_metadata.return_value = {
+            "width": 720, "height": 360,
+            "bounds": (-180.0, -90.0, 180.0, 90.0),
+            "crs": "EPSG:4326",
+        }
+        handler = IngestionHandler(ctx)
+        mock_item = MagicMock()
+        mock_item.pk = "item-1"
+        handler.item_handler = MagicMock()
+        handler.item_handler.get_or_create.return_value = (mock_item, True)
+        handler.asset_handler = MagicMock()
+        handler.asset_handler.process_variable.return_value = [MagicMock()]
+        handler.extent_handler = MagicMock()
+        return handler
+
+    def _make_collection(self, *var_slugs):
+        mock_col = MagicMock()
+        mock_col.slug = "test-collection"
+        mock_col.crs = "EPSG:4326"
+        vars_ = []
+        for slug in var_slugs:
+            v = MagicMock()
+            v.is_active = True
+            v.slug = slug
+            vars_.append(v)
+        mock_col.variables.all.return_value = vars_
+        return mock_col, vars_
+
+    def test_one_increment_per_variable_at_outcome(self):
+        handler = self._make_handler()
+        collection, variables = self._make_collection("temperature", "rainfall")
+        mock_progress = MagicMock(spec=Progress)
+
+        handler.process_timestamp(
+            collection=collection,
+            local_path=Path("/tmp/file.tif"),
+            timestamp=datetime(2024, 1, 15, tzinfo=pytz.utc),
+            source_file="sources:chirps/file.tif",
+            progress=mock_progress,
+        )
+
+        self.assertEqual(mock_progress.increment.call_count, len(variables))
+
+    def test_successful_variable_state_contains_slug(self):
+        handler = self._make_handler()
+        collection, variables = self._make_collection("temperature")
+        mock_progress = MagicMock(spec=Progress)
+
+        handler.process_timestamp(
+            collection=collection,
+            local_path=Path("/tmp/file.tif"),
+            timestamp=datetime(2024, 1, 15, tzinfo=pytz.utc),
+            source_file="sources:chirps/file.tif",
+            progress=mock_progress,
+        )
+
+        state = mock_progress.increment.call_args.kwargs.get("state", "")
+        self.assertIn("temperature", state)
+
+    def test_failed_variable_state_contains_slug_and_reason(self):
+        handler = self._make_handler()
+        handler.asset_handler.process_variable.side_effect = RuntimeError("band missing")
+        collection, variables = self._make_collection("temperature")
+        mock_progress = MagicMock(spec=Progress)
+
+        handler.process_timestamp(
+            collection=collection,
+            local_path=Path("/tmp/file.tif"),
+            timestamp=datetime(2024, 1, 15, tzinfo=pytz.utc),
+            source_file="sources:chirps/file.tif",
+            progress=mock_progress,
+        )
+
+        state = mock_progress.increment.call_args.kwargs.get("state", "")
+        self.assertIn("temperature", state)
+        self.assertIn("band missing", state)


### PR DESCRIPTION
## Summary

- Introduces `PublishingProgress` (`georiva/ingestion/progress.py`) — a thin `task_ferry.Progress` subclass that overrides `increment()` to call `super()` then `_publish()` (no-op stub; Redis wiring comes in the next slice)
- `IngestionService.process_file()` gains an optional `progress` parameter with checkpoints at: file opened, timestamps found per collection, per-timestamp child progress (bubbles per-variable increments), archiving, and done
- `IngestionHandler.process_timestamp()` gains an optional `progress` parameter and emits one increment per variable at outcome (`"{slug}: succeeded"` or `"{slug}: failed — {reason}"`)
- `FileIngestionJobType.run()` creates a `PublishingProgress(total=100)` and passes it into `process_file()`

## Test plan

- [ ] `PublishingProgressTests` — subclass check, increment advances percentage
- [ ] `ProcessFileProgressTests` — file-opened, timestamps, child-for-loop, archiving/done checkpoints all asserted via mock progress
- [ ] `ProcessTimestampProgressTests` — one increment per variable at outcome; state contains slug; failed state contains error reason
- [ ] All 143 existing ingestion tests still pass

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)