### PR TITLE
feat(ingestion): pre-create FileIngestionJob on upload submit and return job_id

### DIFF
--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -29,6 +29,7 @@ def process_incoming_file(
         file_path: str,
         origin_bucket: str,
         reference_time: str = None,  # kept for backwards compat; IngestionService resolves it
+        job_id: int = None,
 ):
     """
     Process a single incoming file.
@@ -48,14 +49,17 @@ def process_incoming_file(
     from georiva.ingestion.models import FileIngestionJob
     
     logger.info("process_incoming_file: %s/%s", origin_bucket, file_path)
-    
-    ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
-    job = FileIngestionJob.objects.create(
-        user=None,
-        content_type=ct,
-        file_path=file_path,
-        bucket=origin_bucket,
-    )
+
+    if job_id is not None:
+        job = FileIngestionJob.objects.get(pk=job_id)
+    else:
+        ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
+        job = FileIngestionJob.objects.create(
+            user=None,
+            content_type=ct,
+            file_path=file_path,
+            bucket=origin_bucket,
+        )
     
     # Run in-place — we are already inside a Celery worker, so bypass the
     # executor and call JobHandler.run() directly.  This gives us the full

--- a/georiva/src/georiva/ingestion/tests/test_upload_page.py
+++ b/georiva/src/georiva/ingestion/tests/test_upload_page.py
@@ -8,6 +8,7 @@ from georiva.core.models import Catalog, Collection
 from georiva.ingestion.models import (
     DataArrival,
     FileIngestion,
+    FileIngestionJob,
     ManualUploadConfig,
     ManualUploadConfigVariable,
 )
@@ -153,11 +154,11 @@ class UploadSubmitTests(TestCase):
         self.assertEqual(fi.collection_slug, "ndvi")
         self.assertEqual(fi.data_arrival, arrival)
 
-        mock_task.delay.assert_called_once_with(
-            file_path=expected_path,
-            origin_bucket="incoming",
-            reference_time=None,
-        )
+        call_kwargs = mock_task.delay.call_args.kwargs
+        self.assertEqual(call_kwargs["file_path"], expected_path)
+        self.assertEqual(call_kwargs["origin_bucket"], "incoming")
+        self.assertIsNone(call_kwargs["reference_time"])
+        self.assertIsInstance(call_kwargs["job_id"], int)
 
     def test_geotiff_date_from_form_when_filename_unparseable(self, mock_incoming, mock_task):
         mock_incoming.return_value = _mock_incoming_bucket()
@@ -294,6 +295,35 @@ class UploadSubmitTests(TestCase):
         self.assertIn("minio down", arrival.error_message)
         mock_task.delay.assert_not_called()
 
+    def test_submit_response_includes_job_id(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_id": variable.pk,
+            "time": "",
+            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+        })
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("job_id", data)
+        self.assertIsNotNone(data["job_id"])
+
+    def test_file_ingestion_job_exists_before_task_is_enqueued(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_id": variable.pk,
+            "time": "",
+            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+        })
+
+        self.assertEqual(response.status_code, 200)
+        job_id = response.json()["job_id"]
+        self.assertTrue(FileIngestionJob.objects.filter(pk=job_id).exists())
+
 
 @patch("georiva.ingestion.consumer.process_incoming_file")
 class DirectDropTimeValidationTests(TestCase):
@@ -362,3 +392,44 @@ class DirectDropTimeValidationTests(TestCase):
         fi = FileIngestion.objects.get(file_path="imagery/operator_named.tif")
         self.assertNotEqual(fi.status, FileIngestion.Status.FAILED)
         mock_task.delay.assert_called_once()
+
+
+# =============================================================================
+# process_incoming_file task — job_id wiring
+# =============================================================================
+
+@patch("task_ferry.handler.JobHandler.run")
+class ProcessIncomingFileJobIdTests(TestCase):
+
+    def _make_job(self, file_path="chirps/rainfall/2024/01/15/file.tif", bucket="incoming"):
+        from django.contrib.contenttypes.models import ContentType
+        ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
+        return FileIngestionJob.objects.create(
+            user=None,
+            content_type=ct,
+            file_path=file_path,
+            bucket=bucket,
+        )
+
+    def test_task_reuses_existing_job_when_job_id_provided(self, mock_run):
+        from georiva.ingestion.tasks import process_incoming_file
+        job = self._make_job()
+
+        process_incoming_file.run(
+            file_path=job.file_path,
+            origin_bucket=job.bucket,
+            job_id=job.pk,
+        )
+
+        self.assertEqual(FileIngestionJob.objects.count(), 1)
+        mock_run.assert_called_once_with(job)
+
+    def test_task_creates_new_job_when_no_job_id(self, mock_run):
+        from georiva.ingestion.tasks import process_incoming_file
+
+        process_incoming_file.run(
+            file_path="chirps/rainfall/2024/01/15/file.tif",
+            origin_bucket="incoming",
+        )
+
+        self.assertEqual(FileIngestionJob.objects.count(), 1)

--- a/georiva/src/georiva/ingestion/upload_views.py
+++ b/georiva/src/georiva/ingestion/upload_views.py
@@ -157,8 +157,10 @@ def manual_upload_extract_times(request, pk):
 
 
 def manual_upload_submit(request, pk):
+    from django.contrib.contenttypes.models import ContentType
+
     from georiva.core.storage import BucketType, storage
-    from georiva.ingestion.models import DataArrival, FileIngestion, ManualUploadConfig
+    from georiva.ingestion.models import DataArrival, FileIngestion, FileIngestionJob, ManualUploadConfig
     from georiva.ingestion.tasks import process_incoming_file
 
     if request.method != "POST":
@@ -254,10 +256,19 @@ def manual_upload_submit(request, pk):
         FileIngestion.reset_for_reingest(BucketType.INCOMING, saved_path)
         FileIngestion.objects.filter(pk=log.pk).update(data_arrival=arrival)
 
+    ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
+    job = FileIngestionJob.objects.create(
+        user=None,
+        content_type=ct,
+        file_path=saved_path,
+        bucket=BucketType.INCOMING,
+    )
+
     process_incoming_file.delay(
         file_path=saved_path,
         origin_bucket=BucketType.INCOMING,
         reference_time=reference_time.isoformat() if reference_time else None,
+        job_id=job.pk,
     )
 
-    return JsonResponse({"data_arrival_id": arrival.pk})
+    return JsonResponse({"data_arrival_id": arrival.pk, "job_id": job.pk})


### PR DESCRIPTION
## Summary

- `manual_upload_submit()` now creates a `FileIngestionJob` record before calling `process_incoming_file.delay()`, so the browser gets a `job_id` in the JSON response immediately after submit
- `process_incoming_file` accepts an optional `job_id` kwarg; when provided it reuses the pre-created record instead of creating a new one
- Callers without `job_id` (sweep, consumer) are unaffected — the task still creates the job internally as before

## Test plan

- [ ] `test_submit_response_includes_job_id` — POST returns JSON with `job_id`
- [ ] `test_file_ingestion_job_exists_before_task_is_enqueued` — `FileIngestionJob` in DB before task runs
- [ ] `test_task_reuses_existing_job_when_job_id_provided` — no second record created
- [ ] `test_task_creates_new_job_when_no_job_id` — backwards-compat path still works
- [ ] All 173 existing ingestion tests pass

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)