### PR TITLE
feat(events): Redis pub/sub event publishing for ingestion pipeline

### DIFF
--- a/georiva/src/georiva/ingestion/apps.py
+++ b/georiva/src/georiva/ingestion/apps.py
@@ -12,3 +12,5 @@ class IngestionConfig(AppConfig):
         from .job_types import FileIngestionJobType
 
         job_type_registry.register(FileIngestionJobType())
+
+        import georiva.ingestion.signals  # noqa: F401 — registers signal handlers

--- a/georiva/src/georiva/ingestion/events.py
+++ b/georiva/src/georiva/ingestion/events.py
@@ -1,0 +1,21 @@
+import json
+import logging
+
+import redis
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "ingestion:events"
+
+
+def _get_redis():
+    return redis.from_url(settings.REDIS_URL)
+
+
+def publish_event(event: dict) -> None:
+    try:
+        r = _get_redis()
+        r.publish(CHANNEL, json.dumps(event))
+    except Exception as e:
+        logger.warning("Ingestion event publish failed: %s", e)

--- a/georiva/src/georiva/ingestion/job_types.py
+++ b/georiva/src/georiva/ingestion/job_types.py
@@ -74,7 +74,7 @@ class FileIngestionJobType(JobType):
         # ── Step 2: run the ingestion pipeline ────────────────────────────────
         from georiva.ingestion.progress import PublishingProgress
 
-        pub_progress = PublishingProgress(total=100)
+        pub_progress = PublishingProgress(total=100, job_id=job.pk)
         service = IngestionService()
         result = service.process_file(
             file_path=job.file_path,

--- a/georiva/src/georiva/ingestion/progress.py
+++ b/georiva/src/georiva/ingestion/progress.py
@@ -4,13 +4,26 @@ from task_ferry.progress import Progress
 class PublishingProgress(Progress):
     """
     Progress subclass that publishes each increment to a Redis pub/sub channel.
-    Redis wiring is added in slice 2; this slice gets the increment() calls
-    in the right places with the right state strings.
+
+    Pass job_id to tie events to a specific FileIngestionJob. Without job_id
+    no events are published (safe for callers that don't need tracking).
     """
+
+    def __init__(self, total: int, *, job_id: int = None, **kwargs) -> None:
+        super().__init__(total, **kwargs)
+        self._job_id = job_id
 
     def increment(self, by: float = 1.0, state: str = "") -> None:
         super().increment(by=by, state=state)
         self._publish(state)
 
     def _publish(self, state: str) -> None:
-        pass  # wired to Redis in slice 2
+        if self._job_id is None:
+            return
+        from georiva.ingestion.events import publish_event
+        publish_event({
+            "type": "job.progress_updated",
+            "job_id": self._job_id,
+            "state": state,
+            "percentage": self.percentage,
+        })

--- a/georiva/src/georiva/ingestion/signals.py
+++ b/georiva/src/georiva/ingestion/signals.py
@@ -1,0 +1,44 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+
+@receiver(post_save, sender="georivaingestion.DataArrival")
+def _data_arrival_status_changed(sender, instance, created, update_fields, **kwargs):
+    if created:
+        return
+    if update_fields is None or "status" not in update_fields:
+        return
+    from georiva.ingestion.events import publish_event
+    publish_event({
+        "type": "data_arrival.status_changed",
+        "id": instance.pk,
+        "status": instance.status,
+    })
+
+
+@receiver(post_save, sender="georivaingestion.FileIngestion")
+def _file_ingestion_status_changed(sender, instance, created, update_fields, **kwargs):
+    if created:
+        return
+    if update_fields is None or "status" not in update_fields:
+        return
+    from georiva.ingestion.events import publish_event
+    publish_event({
+        "type": "file_ingestion.status_changed",
+        "id": instance.pk,
+        "status": instance.status,
+    })
+
+
+@receiver(post_save, sender="georivaingestion.FileIngestionJob")
+def _file_ingestion_job_state_changed(sender, instance, created, update_fields, **kwargs):
+    if created:
+        return
+    if update_fields is None or "state" not in update_fields:
+        return
+    from georiva.ingestion.events import publish_event
+    publish_event({
+        "type": "job.state_changed",
+        "id": instance.pk,
+        "state": instance.state,
+    })

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
@@ -1,0 +1,190 @@
+import json
+
+import redis
+from django.conf import settings
+from django.test import TestCase
+
+from georiva.ingestion.events import CHANNEL
+
+# =============================================================================
+# Shared test base — subscribes to ingestion:events before each test
+# =============================================================================
+
+class IngestionEventsTestCase(TestCase):
+
+    def setUp(self):
+        self.r = redis.from_url(settings.REDIS_URL)
+        self.pubsub = self.r.pubsub()
+        self.pubsub.subscribe(CHANNEL)
+        # Wait for the subscribe confirmation so we don't race with publish calls.
+        for _ in range(20):
+            msg = self.pubsub.get_message(timeout=0.1)
+            if msg and msg.get("type") == "subscribe":
+                break
+
+    def tearDown(self):
+        self.pubsub.unsubscribe()
+        self.pubsub.close()
+
+    def _drain(self):
+        while self.pubsub.get_message(ignore_subscribe_messages=True):
+            pass
+
+    def _next_event(self, timeout=2.0):
+        msg = self.pubsub.get_message(ignore_subscribe_messages=True, timeout=timeout)
+        if msg is None:
+            return None
+        return json.loads(msg["data"])
+
+
+# =============================================================================
+# Cycle 1: publish_event() delivers to the channel
+# =============================================================================
+
+class PublishEventTests(IngestionEventsTestCase):
+
+    def test_published_event_is_received_on_channel(self):
+        from georiva.ingestion.events import publish_event
+
+        publish_event({"type": "test.ping", "value": 42})
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "test.ping")
+        self.assertEqual(event["value"], 42)
+
+
+# =============================================================================
+# Cycle 2: DataArrival status changes publish an event
+# =============================================================================
+
+class DataArrivalStatusEventTests(IngestionEventsTestCase):
+
+    def _make_arrival(self, status="pending"):
+        from georiva.ingestion.models import DataArrival
+        return DataArrival.objects.create(
+            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+            status=status,
+        )
+
+    def test_status_change_publishes_event(self):
+        arrival = self._make_arrival()
+        self._drain()  # discard any creation events
+
+        arrival.status = "processing"
+        arrival.save(update_fields=["status"])
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "data_arrival.status_changed")
+        self.assertEqual(event["id"], arrival.pk)
+        self.assertEqual(event["status"], "processing")
+
+    def test_creation_does_not_publish_status_event(self):
+        self._make_arrival()
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)
+
+
+# =============================================================================
+# Cycle 3: FileIngestion status changes publish an event
+# =============================================================================
+
+class FileIngestionStatusEventTests(IngestionEventsTestCase):
+
+    def _make_file_ingestion(self):
+        from georiva.ingestion.models import DataArrival, FileIngestion
+        arrival = DataArrival.objects.create(trigger=DataArrival.Trigger.MANUAL_UPLOAD)
+        fi, _ = FileIngestion.register(
+            bucket="incoming",
+            file_path="catalog/somefile.grib2",
+            catalog_slug="catalog",
+            collection_slug="",
+            data_arrival=arrival,
+        )
+        return fi
+
+    def test_status_change_publishes_event(self):
+        fi = self._make_file_ingestion()
+        self._drain()
+
+        fi.status = "processing"
+        fi.save(update_fields=["status"])
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "file_ingestion.status_changed")
+        self.assertEqual(event["id"], fi.pk)
+        self.assertEqual(event["status"], "processing")
+
+    def test_creation_does_not_publish_event(self):
+        self._make_file_ingestion()
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)
+
+
+# =============================================================================
+# Cycle 4: FileIngestionJob state changes publish an event
+# =============================================================================
+
+class FileIngestionJobStateEventTests(IngestionEventsTestCase):
+
+    def _make_job(self):
+        from django.contrib.contenttypes.models import ContentType
+        from georiva.ingestion.models import FileIngestionJob
+        ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
+        return FileIngestionJob.objects.create(
+            user=None,
+            content_type=ct,
+            file_path="catalog/somefile.grib2",
+            bucket="incoming",
+        )
+
+    def test_state_change_publishes_event(self):
+        job = self._make_job()
+        self._drain()
+
+        job.mark_started()
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "job.state_changed")
+        self.assertEqual(event["id"], job.pk)
+        self.assertEqual(event["state"], "started")
+
+    def test_creation_does_not_publish_event(self):
+        self._make_job()
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)
+
+
+# =============================================================================
+# Cycle 5: PublishingProgress._publish() emits a job.progress_updated event
+# =============================================================================
+
+class PublishingProgressEventTests(IngestionEventsTestCase):
+
+    def test_increment_publishes_progress_event(self):
+        from georiva.ingestion.progress import PublishingProgress
+
+        progress = PublishingProgress(total=100, job_id=42)
+        progress.increment(by=10, state="file opened")
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "job.progress_updated")
+        self.assertEqual(event["job_id"], 42)
+        self.assertEqual(event["state"], "file opened")
+        self.assertIn("percentage", event)
+
+    def test_no_job_id_does_not_publish(self):
+        from georiva.ingestion.progress import PublishingProgress
+
+        progress = PublishingProgress(total=100)
+        progress.increment(by=10, state="file opened")
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)


### PR DESCRIPTION
## Summary

- Adds `georiva/ingestion/events.py` with `publish_event()` helper and `CHANNEL = "ingestion:events"`
- Adds `georiva/ingestion/signals.py` with `post_save` handlers for `DataArrival`, `FileIngestion`, and `FileIngestionJob` — each publishes a typed event only when `status`/`state` is in `update_fields` (creation is silent)
- Wires `PublishingProgress._publish()` to call `publish_event()` when a `job_id` is provided; `FileIngestionJobType` now passes `job_id=job.pk`
- Registers signal handlers in `IngestionConfig.ready()`

## Event schema

| Event type | Trigger |
|---|---|
| `data_arrival.status_changed` | `DataArrival.save(update_fields=["status"])` |
| `file_ingestion.status_changed` | `FileIngestion.save(update_fields=["status"])` |
| `job.state_changed` | `FileIngestionJob.mark_started/finished/failed()` |
| `job.progress_updated` | `PublishingProgress.increment()` with a `job_id` |

## Test plan

- [x] `PublishEventTests` — tracer bullet: published events arrive on the channel
- [x] `DataArrivalStatusEventTests` — status change fires event; creation does not
- [x] `FileIngestionStatusEventTests` — same for FileIngestion
- [x] `FileIngestionJobStateEventTests` — same for Job state transitions
- [x] `PublishingProgressEventTests` — increment with `job_id` publishes; without `job_id` is silent
- [x] Full regression: all 43 tests in `test_ingestion_progress` + `test_upload_page` pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)