### PR TITLE
feat(events): async SSE endpoint for ingestion events + switch to gunicorn-asgi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
         - DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX=${DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX:-}
         - GEORIVA_PLUGIN_GIT_REPOS=${GEORIVA_PLUGIN_GIT_REPOS}
     restart: unless-stopped
-    command: gunicorn-wsgi
+    command: gunicorn
     environment:
       <<: *backend-variables
       GEORIVA_DISABLE_PLUGIN_INSTALL_ON_STARTUP: "true"

--- a/georiva/src/georiva/config/settings/dev.py
+++ b/georiva/src/georiva/config/settings/dev.py
@@ -16,7 +16,7 @@ GEOS_LIBRARY_PATH = env.str('GEOS_LIBRARY_PATH', None)
 
 CORS_ALLOW_ALL_ORIGINS = True
 
-INSTALLED_APPS = INSTALLED_APPS + [
+INSTALLED_APPS = ["daphne"] + INSTALLED_APPS + [
     "wagtail.contrib.styleguide",
 ]
 

--- a/georiva/src/georiva/ingestion/snapshot.py
+++ b/georiva/src/georiva/ingestion/snapshot.py
@@ -1,0 +1,33 @@
+from asgiref.sync import sync_to_async
+
+
+@sync_to_async
+def _fetch_arrivals(limit: int) -> list[dict]:
+    from georiva.ingestion.models import DataArrival
+
+    arrivals = (
+        DataArrival.objects
+        .prefetch_related("file_ingestions")
+        .order_by("-created_at")[:limit]
+    )
+
+    result = []
+    for arrival in arrivals:
+        file_ingestions = [
+            {"id": fi.pk, "status": fi.status}
+            for fi in arrival.file_ingestions.all()
+        ]
+        result.append({
+            "id": arrival.pk,
+            "status": arrival.status,
+            "trigger": arrival.trigger,
+            "started_at": arrival.started_at.isoformat(),
+            "finished_at": arrival.finished_at.isoformat() if arrival.finished_at else None,
+            "file_ingestions": file_ingestions,
+        })
+    return result
+
+
+async def build_arrival_snapshot(limit: int = 50) -> list[dict]:
+    """Return the last `limit` DataArrivals with their FileIngestion summaries."""
+    return await _fetch_arrivals(limit)

--- a/georiva/src/georiva/ingestion/sse_views.py
+++ b/georiva/src/georiva/ingestion/sse_views.py
@@ -1,0 +1,56 @@
+import json
+import logging
+
+from django.http import StreamingHttpResponse
+
+logger = logging.getLogger(__name__)
+
+
+def ingestion_events_sse(request):
+    """
+    Async SSE endpoint streaming ingestion events to connected browsers.
+
+    Auth is enforced by Wagtail's require_admin_access before this view runs.
+    The outer function is intentionally sync so Wagtail's sync decorator chain
+    works correctly; the inner generator is async to use redis.asyncio under ASGI.
+    """
+    return StreamingHttpResponse(
+        _event_stream(),
+        content_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _event_stream():
+    from django.conf import settings
+    import redis.asyncio as aioredis
+
+    from .events import CHANNEL
+    from .snapshot import build_arrival_snapshot
+
+    snapshot = await build_arrival_snapshot()
+    yield f"event: snapshot\ndata: {json.dumps(snapshot)}\n\n"
+
+    r = aioredis.from_url(settings.REDIS_URL)
+    try:
+        pubsub = r.pubsub()
+        await pubsub.subscribe(CHANNEL)
+        try:
+            async for message in pubsub.listen():
+                if message["type"] == "message":
+                    raw = message["data"]
+                    data = raw.decode() if isinstance(raw, bytes) else raw
+                    try:
+                        payload = json.loads(data)
+                        event_type = payload.get("type", "ingestion")
+                    except (ValueError, AttributeError):
+                        event_type = "ingestion"
+                    yield f"event: {event_type}\ndata: {data}\n\n"
+        finally:
+            await pubsub.unsubscribe(CHANNEL)
+            await pubsub.aclose()
+    finally:
+        await r.aclose()

--- a/georiva/src/georiva/ingestion/tests.py
+++ b/georiva/src/georiva/ingestion/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/georiva/src/georiva/ingestion/tests/test_sse_views.py
+++ b/georiva/src/georiva/ingestion/tests/test_sse_views.py
@@ -1,0 +1,178 @@
+from asgiref.sync import async_to_sync
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+User = get_user_model()
+
+
+# =============================================================================
+# Cycle 1: Unauthenticated requests are rejected
+# =============================================================================
+
+class SSEAuthTests(TestCase):
+
+    def test_unauthenticated_is_rejected(self):
+        # Wagtail's require_admin_access wraps all admin URLs and redirects
+        # anonymous requests to login (302). XHR requests get a 403 instead.
+        response = self.client.get(
+            "/admin/api/ingestion/events/",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+# =============================================================================
+# Cycle 2: Snapshot data shape
+# =============================================================================
+
+class SnapshotShapeTests(TestCase):
+
+    def setUp(self):
+        from georiva.ingestion.models import DataArrival, FileIngestion
+
+        self.arrival = DataArrival.objects.create(
+            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+            status=DataArrival.Status.COMPLETED,
+        )
+        DataArrival.objects.create(
+            trigger=DataArrival.Trigger.SCHEDULED,
+            status=DataArrival.Status.PROCESSING,
+        )
+        FileIngestion.objects.create(
+            bucket="incoming",
+            file_path="cat/col/file.grib2",
+            status=FileIngestion.Status.COMPLETED,
+            data_arrival=self.arrival,
+        )
+
+    def test_snapshot_returns_list_of_arrival_dicts(self):
+        from georiva.ingestion.snapshot import build_arrival_snapshot
+
+        result = async_to_sync(build_arrival_snapshot)()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 2)
+
+    def test_snapshot_arrival_has_required_fields(self):
+        from georiva.ingestion.snapshot import build_arrival_snapshot
+
+        result = async_to_sync(build_arrival_snapshot)()
+        arrival_dict = next(r for r in result if r["id"] == self.arrival.pk)
+
+        for field in ("id", "status", "trigger", "started_at", "file_ingestions"):
+            self.assertIn(field, arrival_dict)
+
+    def test_snapshot_file_ingestions_have_id_and_status(self):
+        from georiva.ingestion.snapshot import build_arrival_snapshot
+
+        result = async_to_sync(build_arrival_snapshot)()
+        arrival_dict = next(r for r in result if r["id"] == self.arrival.pk)
+
+        self.assertEqual(len(arrival_dict["file_ingestions"]), 1)
+        fi = arrival_dict["file_ingestions"][0]
+        self.assertIn("id", fi)
+        self.assertIn("status", fi)
+
+    def test_snapshot_respects_limit(self):
+        from georiva.ingestion.snapshot import build_arrival_snapshot
+
+        result = async_to_sync(build_arrival_snapshot)(limit=1)
+        self.assertEqual(len(result), 1)
+
+
+# =============================================================================
+# Cycle 3: Authenticated connect delivers snapshot as first SSE message
+# =============================================================================
+
+class SSESnapshotOnConnectTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin", "admin@test.com", "pw")
+
+    @staticmethod
+    def _parse_sse_events(raw: bytes) -> list[dict]:
+        """Parse all SSE events from raw bytes; returns list of {event, data}."""
+        import json
+        events = []
+        current = {}
+        for line in raw.decode().splitlines():
+            if line.startswith("event:"):
+                current["event"] = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                current["data"] = json.loads(line[len("data:"):].strip())
+            elif line == "" and current:
+                events.append(current)
+                current = {}
+        return events
+
+    @staticmethod
+    async def _read_snapshot_chunk(response) -> bytes:
+        """Consume streaming_content until the snapshot event chunk is received."""
+        async for chunk in response.streaming_content:
+            if b"event: snapshot" in chunk:
+                return chunk
+        return b""
+
+    async def test_authenticated_connect_returns_streaming_response(self):
+        await self.async_client.aforce_login(self.user)
+        response = await self.async_client.get("/admin/api/ingestion/events/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("Content-Type"), "text/event-stream")
+
+    async def test_first_event_is_snapshot(self):
+        await self.async_client.aforce_login(self.user)
+        response = await self.async_client.get("/admin/api/ingestion/events/")
+
+        chunk = await self._read_snapshot_chunk(response)
+        events = self._parse_sse_events(chunk)
+
+        self.assertGreater(len(events), 0)
+        self.assertEqual(events[0]["event"], "snapshot")
+        self.assertIsInstance(events[0]["data"], list)
+
+
+# =============================================================================
+# Cycle 4: Live Redis events are forwarded as typed SSE messages
+# =============================================================================
+
+class SSELiveEventForwardingTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin2", "admin2@test.com", "pw")
+
+    async def test_published_event_appears_in_stream(self):
+        import asyncio
+        import json
+        import redis.asyncio as aioredis
+        from django.conf import settings
+        from georiva.ingestion.events import CHANNEL
+
+        await self.async_client.aforce_login(self.user)
+        response = await self.async_client.get("/admin/api/ingestion/events/")
+
+        # Consume the snapshot first, then publish a synthetic event and read it.
+        async def _collect_next_event_after_snapshot():
+            skipped_snapshot = False
+            async for chunk in response.streaming_content:
+                decoded = chunk.decode()
+                if not skipped_snapshot:
+                    if "event: snapshot" in decoded:
+                        skipped_snapshot = True
+                    continue
+                if decoded.strip():
+                    return decoded
+            return ""
+
+        async def _publish_after_delay():
+            await asyncio.sleep(0.1)
+            r = aioredis.from_url(settings.REDIS_URL)
+            payload = json.dumps({"type": "data_arrival.status_changed", "id": 99, "status": "completed"})
+            await r.publish(CHANNEL, payload)
+            await r.aclose()
+
+        _, chunk = await asyncio.gather(
+            _publish_after_delay(),
+            _collect_next_event_after_snapshot(),
+        )
+
+        self.assertIn("event: data_arrival.status_changed", chunk)
+        self.assertIn('"status": "completed"', chunk)

--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -13,8 +13,10 @@ def register_ingestion_dashboard_urls():
         collection_ingestion_logs_api,
         collection_ingestion_jobs_api,
     )
+    from .sse_views import ingestion_events_sse
 
     return [
+        path("api/ingestion/events/", ingestion_events_sse, name="ingestion_events_sse"),
         path("api/ingestion/dashboard/", ingestion_dashboard_api, name="ingestion_dashboard_api"),
         path("api/ingestion/collections/<int:collection_id>/arrivals/", collection_data_arrivals_api,
              name="collection_data_arrivals_api"),


### PR DESCRIPTION
## Summary

Closes #52.

- **New SSE endpoint** `GET /admin/api/ingestion/events/` — authenticated streaming endpoint registered under the Wagtail admin URL namespace. On connect it sends a `snapshot` event (last 50 `DataArrival` records with per-arrival `FileIngestion` id/status), then forwards every message published to the `ingestion:events` Redis pub/sub channel as a typed SSE message (event type preserved from the payload's `type` field).
- **`snapshot.py`** — new `build_arrival_snapshot()` helper (async, uses `sync_to_async` for ORM access) that the SSE view and future consumers can reuse.
- **ASGI switch** — production `docker-compose.yml` now runs `gunicorn` (UvicornWorker + ASGI) instead of `gunicorn-wsgi`; `daphne` added first in dev `INSTALLED_APPS` so `runserver` uses Daphne's ASGI server locally. Both are required for `StreamingHttpResponse` with async generators to work correctly.

## Design notes

The outer view function (`ingestion_events_sse`) is intentionally **sync** — Wagtail's `require_admin_access` decorator is sync and would return the coroutine unwrapped if the view were `async def`. The inner `_event_stream()` is an async generator, which Django's ASGI handler awaits correctly when iterating `StreamingHttpResponse.streaming_content`.

Unauthenticated requests are rejected by Wagtail's `require_admin_access` before the view runs (302 redirect for browser requests, 403 for XHR — consistent with every other admin endpoint).

## Test plan

- [x] `SSEAuthTests` — XHR request without login → 403
- [x] `SnapshotShapeTests` — `build_arrival_snapshot()` returns correct shape, respects limit
- [x] `SSESnapshotOnConnectTests` — authenticated connect returns `text/event-stream`; first SSE message is `event: snapshot` with a list payload
- [x] `SSELiveEventForwardingTests` — publish synthetic event to Redis after connect, assert it appears in the stream with the original `type` as the SSE event name
- [x] Full ingestion test suite (190 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)