### PR TITLE
feat(ingestion): Ingestion Activity Feed page with live SSE feed

### DIFF
--- a/georiva/src/georiva/ingestion/activity_views.py
+++ b/georiva/src/georiva/ingestion/activity_views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import render
+from django.urls import reverse
+
+
+def ingestion_activity_feed(request):
+    return render(request, "georivaingestion/activity_feed.html", {
+        "breadcrumbs_items": [
+            {"url": reverse("wagtailadmin_home"), "label": "Home"},
+            {"url": "", "label": "Ingestion Activity"},
+        ],
+    })

--- a/georiva/src/georiva/ingestion/panels.py
+++ b/georiva/src/georiva/ingestion/panels.py
@@ -6,14 +6,11 @@ class IngestionActivityPanel(Component):
     name = "ingestion_activity"
     template_name = "ingestion/dashboard_panel.html"
     order = 200
-    
+
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
-        
-        api_url = reverse("ingestion_dashboard_api")
-        
         context.update({
-            "api_url": api_url,
+            "api_url": reverse("ingestion_dashboard_api"),
+            "activity_feed_url": reverse("ingestion_activity_feed"),
         })
-        
         return context

--- a/georiva/src/georiva/ingestion/snapshot.py
+++ b/georiva/src/georiva/ingestion/snapshot.py
@@ -7,20 +7,31 @@ def _fetch_arrivals(limit: int) -> list[dict]:
 
     arrivals = (
         DataArrival.objects
-        .prefetch_related("file_ingestions")
+        .select_related("collection__catalog")
+        .prefetch_related("file_ingestions__jobs")
         .order_by("-created_at")[:limit]
     )
 
     result = []
     for arrival in arrivals:
-        file_ingestions = [
-            {"id": fi.pk, "status": fi.status}
-            for fi in arrival.file_ingestions.all()
-        ]
+        file_ingestions = []
+        for fi in arrival.file_ingestions.all():
+            latest_job = fi.jobs.order_by("-created_at").first()
+            file_ingestions.append({
+                "id": fi.pk,
+                "status": fi.status,
+                "job_id": latest_job.pk if latest_job else None,
+                "job_state": latest_job.state if latest_job else None,
+            })
+
+        collection = arrival.collection
         result.append({
             "id": arrival.pk,
             "status": arrival.status,
             "trigger": arrival.trigger,
+            "file_path": arrival.file_path,
+            "collection_name": collection.name if collection else None,
+            "catalog_name": collection.catalog.name if collection else None,
             "started_at": arrival.started_at.isoformat(),
             "finished_at": arrival.finished_at.isoformat() if arrival.finished_at else None,
             "file_ingestions": file_ingestions,
@@ -29,5 +40,5 @@ def _fetch_arrivals(limit: int) -> list[dict]:
 
 
 async def build_arrival_snapshot(limit: int = 50) -> list[dict]:
-    """Return the last `limit` DataArrivals with their FileIngestion summaries."""
+    """Return the last `limit` DataArrivals with their FileIngestion and job summaries."""
     return await _fetch_arrivals(limit)

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
@@ -1,0 +1,245 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% trans "Ingestion Activity" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+    .iaf-empty {
+        padding: 2em 0; text-align: center;
+        color: var(--w-color-grey-400); font-size: 0.95em;
+    }
+    .iaf-card {
+        border: 1px solid var(--w-color-border-furniture);
+        border-radius: 4px; background: var(--w-color-surface-page);
+        margin-bottom: 1em; overflow: hidden;
+    }
+    .iaf-card-header {
+        display: flex; align-items: center; gap: 0.75em;
+        padding: 0.65em 1em;
+        background: var(--w-color-grey-50);
+        border-bottom: 1px solid var(--w-color-border-furniture);
+        font-size: 0.88em;
+    }
+    .iaf-trigger {
+        font-weight: 600; color: var(--w-color-text-label);
+        text-transform: capitalize;
+    }
+    .iaf-collection {
+        color: var(--w-color-grey-400);
+    }
+    .iaf-time {
+        margin-left: auto; color: var(--w-color-grey-400); font-size: 0.85em;
+    }
+    .iaf-status-pill {
+        padding: 0.1em 0.6em; border-radius: 1em;
+        font-size: 0.8em; font-weight: 600;
+        background: var(--w-color-grey-100); color: var(--w-color-text-label);
+    }
+    .iaf-status-pill--processing  { background: var(--w-color-info-100);     color: var(--w-color-white); }
+    .iaf-status-pill--completed   { background: var(--w-color-positive-100); color: var(--w-color-white); }
+    .iaf-status-pill--failed      { background: var(--w-color-critical-200); color: var(--w-color-white); }
+    .iaf-status-pill--partial     { background: var(--w-color-warning-100);  color: var(--w-color-text-label); }
+    .iaf-card-body { padding: 0.6em 1em 0.8em; }
+    .iaf-filepath {
+        font-family: monospace; font-size: 0.82em;
+        color: var(--w-color-grey-400); word-break: break-all;
+        margin-bottom: 0.5em;
+    }
+
+    /* Inline progress log (reuses mup-log styles via shared classes) */
+    .iaf-log-steps {
+        list-style: none; margin: 0.3em 0 0; padding: 0;
+        font-size: 0.85em; line-height: 1.8;
+        color: var(--w-color-text-label);
+    }
+    .iaf-log-steps li::before { content: "›  "; color: var(--w-color-grey-400); }
+    .iaf-log-summary { font-size: 0.85em; margin-top: 0.4em; }
+    .iaf-log-summary--success { color: var(--w-color-positive-100); font-weight: 600; }
+    .iaf-log-summary--error   { color: var(--w-color-critical-200); }
+</style>
+{% endblock %}
+
+{% block content %}
+{% include "wagtailadmin/shared/header.html" with title=_("Ingestion Activity") icon="history" breadcrumbs=breadcrumbs_items %}
+
+<div class="nice-padding">
+    <div id="activity-feed">
+        <div class="iaf-empty" id="feed-empty">{% trans "Connecting…" %}</div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+
+    const SSE_URL   = '/admin/api/ingestion/events/';
+    const feedEl    = document.getElementById('activity-feed');
+    const emptyEl   = document.getElementById('feed-empty');
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    function fmtTime(iso) {
+        if (!iso) return '';
+        try {
+            return new Date(iso).toLocaleString();
+        } catch (e) { return iso; }
+    }
+
+    function pillClass(status) {
+        const map = { processing: '--processing', completed: '--completed',
+                      failed: '--failed', partial: '--partial' };
+        return 'iaf-status-pill' + (map[status] || '');
+    }
+
+    // ── Card builder ───────────────────────────────────────────────────────
+
+    function buildCard(arrival) {
+        const card = document.createElement('div');
+        card.className = 'iaf-card';
+        card.dataset.arrivalId = arrival.id;
+
+        const collection = arrival.collection_name
+            ? (arrival.catalog_name ? arrival.catalog_name + ' / ' : '') + arrival.collection_name
+            : (arrival.catalog_name || '');
+
+        card.innerHTML =
+            '<div class="iaf-card-header">' +
+                '<span class="iaf-trigger">' + (arrival.trigger || '') + '</span>' +
+                (collection ? '<span class="iaf-collection">' + collection + '</span>' : '') +
+                '<span class="' + pillClass(arrival.status) + '" data-status-pill>' +
+                    arrival.status +
+                '</span>' +
+                '<span class="iaf-time">' + fmtTime(arrival.started_at) + '</span>' +
+            '</div>' +
+            '<div class="iaf-card-body">' +
+                (arrival.file_path
+                    ? '<div class="iaf-filepath">' + arrival.file_path + '</div>'
+                    : '') +
+                '<ul class="iaf-log-steps" data-log-steps></ul>' +
+                '<div class="iaf-log-summary" data-log-summary></div>' +
+            '</div>';
+
+        // Attach inline progress log for in-flight jobs
+        arrival.file_ingestions.forEach(function (fi) {
+            if (fi.job_id && fi.job_state !== 'finished' && fi.job_state !== 'failed') {
+                attachJobLog(card, fi.job_id);
+            } else if (fi.job_summary) {
+                const sumEl = card.querySelector('[data-log-summary]');
+                sumEl.textContent = fi.job_summary;
+                sumEl.className = 'iaf-log-summary iaf-log-summary--success';
+            }
+        });
+
+        return card;
+    }
+
+    // ── Inline job progress log ────────────────────────────────────────────
+
+    function attachJobLog(card, jobId) {
+        card.dataset.jobId = jobId;
+    }
+
+    function appendStep(card, state) {
+        const list = card.querySelector('[data-log-steps]');
+        if (!list) return;
+        const li = document.createElement('li');
+        li.textContent = state;
+        list.appendChild(li);
+    }
+
+    function finishJobOnCard(card, summaryText, isError) {
+        const sumEl = card.querySelector('[data-log-summary]');
+        if (!sumEl) return;
+        sumEl.textContent = summaryText;
+        sumEl.className = 'iaf-log-summary ' +
+            (isError ? 'iaf-log-summary--error' : 'iaf-log-summary--success');
+        delete card.dataset.jobId;
+    }
+
+    // ── Card registry ──────────────────────────────────────────────────────
+
+    function cardByArrival(id) {
+        return feedEl.querySelector('[data-arrival-id="' + id + '"]');
+    }
+
+    function cardByJob(id) {
+        return feedEl.querySelector('[data-job-id="' + id + '"]');
+    }
+
+    // ── Snapshot render ────────────────────────────────────────────────────
+
+    function renderSnapshot(arrivals) {
+        emptyEl.style.display = 'none';
+        if (!arrivals.length) {
+            emptyEl.textContent = '{% trans "No arrivals yet." %}';
+            emptyEl.style.display = '';
+            return;
+        }
+        arrivals.forEach(function (arrival) {
+            feedEl.appendChild(buildCard(arrival));
+        });
+    }
+
+    // ── SSE event handlers ─────────────────────────────────────────────────
+
+    function onSnapshot(arrivals) {
+        renderSnapshot(arrivals);
+    }
+
+    function onArrivalStatusChanged(data) {
+        const card = cardByArrival(data.id);
+        if (!card) return;
+        const pill = card.querySelector('[data-status-pill]');
+        if (pill) {
+            pill.textContent = data.status;
+            pill.className = pillClass(data.status);
+        }
+    }
+
+    function onJobProgressUpdated(data) {
+        const card = cardByJob(data.job_id);
+        if (!card) return;
+        if (data.state) appendStep(card, data.state);
+    }
+
+    function onJobStateChanged(data) {
+        const card = cardByJob(data.id);
+        if (!card) return;
+        if (data.state === 'finished') {
+            finishJobOnCard(card, '{% trans "Items and assets created successfully." %}', false);
+        } else if (data.state === 'failed' || data.state === 'cancelled') {
+            finishJobOnCard(card, data.error || '{% trans "Ingestion failed." %}', true);
+        }
+    }
+
+    // ── SSE connection ─────────────────────────────────────────────────────
+
+    const es = new EventSource(SSE_URL);
+
+    es.addEventListener('snapshot', function (ev) {
+        onSnapshot(JSON.parse(ev.data));
+    });
+
+    es.addEventListener('data_arrival.status_changed', function (ev) {
+        onArrivalStatusChanged(JSON.parse(ev.data));
+    });
+
+    es.addEventListener('job.progress_updated', function (ev) {
+        onJobProgressUpdated(JSON.parse(ev.data));
+    });
+
+    es.addEventListener('job.state_changed', function (ev) {
+        onJobStateChanged(JSON.parse(ev.data));
+    });
+
+    es.onerror = function () {
+        emptyEl.textContent = '{% trans "Connection lost. Reconnecting…" %}';
+        emptyEl.style.display = '';
+    };
+
+});
+</script>
+{% endblock %}

--- a/georiva/src/georiva/ingestion/templates/ingestion/dashboard_panel.html
+++ b/georiva/src/georiva/ingestion/templates/ingestion/dashboard_panel.html
@@ -1,8 +1,11 @@
 {% load wagtailadmin_tags i18n vue_utils static %}
 
+<div style="display:flex; justify-content:flex-end; margin-bottom:0.5em;">
+    <a href="{{ activity_feed_url }}" style="font-size:0.85em;">{% trans "View all" %} →</a>
+</div>
+
 <div id="ingestion-dashboard" data-api-url="{{ api_url }}" style="margin-bottom: 40px">
 </div>
 
 
 <script type="module" crossorigin src="{% vue_bundle_url 'ingestion-dashboard' %}"></script>
-

--- a/georiva/src/georiva/ingestion/tests/test_activity_feed.py
+++ b/georiva/src/georiva/ingestion/tests/test_activity_feed.py
@@ -1,0 +1,59 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+User = get_user_model()
+
+ACTIVITY_URL = "/admin/ingestion/activity/"
+
+
+# =============================================================================
+# Cycle 1: Activity page renders for authenticated users
+# =============================================================================
+
+class ActivityPageRenderTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_af", "af@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_page_returns_200(self):
+        response = self.client.get(ACTIVITY_URL)
+        self.assertEqual(response.status_code, 200)
+
+    def test_page_contains_sse_url(self):
+        response = self.client.get(ACTIVITY_URL)
+        self.assertContains(response, "/admin/api/ingestion/events/")
+
+    def test_page_has_feed_container(self):
+        response = self.client.get(ACTIVITY_URL)
+        self.assertContains(response, 'id="activity-feed"')
+
+    def test_unauthenticated_is_rejected(self):
+        self.client.logout()
+        response = self.client.get(ACTIVITY_URL, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        self.assertEqual(response.status_code, 403)
+
+
+# =============================================================================
+# Cycle 3: Dashboard panel has "View all" link to the activity feed
+# =============================================================================
+
+class DashboardPanelViewAllTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_dp", "dp@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_dashboard_panel_has_view_all_link(self):
+        # The "View all →" link must be in the panel template itself,
+        # not just in the sidebar menu.
+        from django.template.loader import render_to_string
+        from django.test import RequestFactory
+        from georiva.ingestion.panels import IngestionActivityPanel
+
+        request = RequestFactory().get("/admin/")
+        request.user = self.user
+        panel = IngestionActivityPanel()
+        ctx = panel.get_context_data({"request": request})
+        html = render_to_string(panel.template_name, ctx)
+        self.assertIn("/admin/ingestion/activity/", html)

--- a/georiva/src/georiva/ingestion/tests/test_sse_views.py
+++ b/georiva/src/georiva/ingestion/tests/test_sse_views.py
@@ -61,7 +61,16 @@ class SnapshotShapeTests(TestCase):
         for field in ("id", "status", "trigger", "started_at", "file_ingestions"):
             self.assertIn(field, arrival_dict)
 
-    def test_snapshot_file_ingestions_have_id_and_status(self):
+    def test_snapshot_arrival_has_activity_feed_fields(self):
+        from georiva.ingestion.snapshot import build_arrival_snapshot
+
+        result = async_to_sync(build_arrival_snapshot)()
+        arrival_dict = next(r for r in result if r["id"] == self.arrival.pk)
+
+        for field in ("file_path", "collection_name", "catalog_name"):
+            self.assertIn(field, arrival_dict)
+
+    def test_snapshot_file_ingestions_have_id_status_and_job_fields(self):
         from georiva.ingestion.snapshot import build_arrival_snapshot
 
         result = async_to_sync(build_arrival_snapshot)()
@@ -69,8 +78,8 @@ class SnapshotShapeTests(TestCase):
 
         self.assertEqual(len(arrival_dict["file_ingestions"]), 1)
         fi = arrival_dict["file_ingestions"][0]
-        self.assertIn("id", fi)
-        self.assertIn("status", fi)
+        for field in ("id", "status", "job_id", "job_state"):
+            self.assertIn(field, fi)
 
     def test_snapshot_respects_limit(self):
         from georiva.ingestion.snapshot import build_arrival_snapshot

--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -5,8 +5,20 @@ from wagtail.admin.menu import MenuItem
 from .panels import IngestionActivityPanel
 
 
+@hooks.register("register_admin_menu_item")
+def register_ingestion_activity_menu():
+    from django.utils.translation import gettext as _
+    return MenuItem(
+        _("Ingestion Activity"),
+        reverse_lazy("ingestion_activity_feed"),
+        icon_name="history",
+        order=840,
+    )
+
+
 @hooks.register("register_admin_urls")
 def register_ingestion_dashboard_urls():
+    from .activity_views import ingestion_activity_feed
     from .dashboard_views import (
         ingestion_dashboard_api,
         collection_data_arrivals_api,
@@ -16,6 +28,7 @@ def register_ingestion_dashboard_urls():
     from .sse_views import ingestion_events_sse
 
     return [
+        path("ingestion/activity/", ingestion_activity_feed, name="ingestion_activity_feed"),
         path("api/ingestion/events/", ingestion_events_sse, name="ingestion_events_sse"),
         path("api/ingestion/dashboard/", ingestion_dashboard_api, name="ingestion_dashboard_api"),
         path("api/ingestion/collections/<int:collection_id>/arrivals/", collection_data_arrivals_api,


### PR DESCRIPTION
## Summary

Closes #54. Depends on #52 and #53 (both merged).

- **New page** `GET /admin/ingestion/activity/` — server-rendered shell that opens an SSE connection on load, renders arrival cards from the `snapshot` event, then keeps them live. Handles `data_arrival.status_changed` (updates status pill in-place), `job.progress_updated` (appends step to inline log), and `job.state_changed` (closes job log with summary or error).
- **Snapshot extended** — `build_arrival_snapshot()` now includes `file_path`, `collection_name`, `catalog_name`, and per-`FileIngestion` `job_id`/`job_state` so the activity feed can render complete cards from the initial payload.
- **Sidebar navigation** — "Ingestion Activity" menu item at order 840 (just above "Manual Uploads").
- **Dashboard panel** — "View all →" link added to the Collection Health Panel header; `activity_feed_url` passed through `IngestionActivityPanel.get_context_data()`.

## Test plan

- [x] `ActivityPageRenderTests` — 200 for authenticated users, contains SSE_URL and `#activity-feed` container, 403 for XHR unauthenticated
- [x] `SnapshotShapeTests` — extended to verify `file_path`, `collection_name`, `catalog_name`, `job_id`, `job_state` present in snapshot payload
- [x] `DashboardPanelViewAllTests` — panel template renders with `/admin/ingestion/activity/` link
- [x] Full ingestion suite (199 tests) passes with no regressions
- [ ] Manual end-to-end: open activity feed, trigger an upload, observe card appearing and step log updating live

🤖 Generated with [Claude Code](https://claude.com/claude-code)