### PR TITLE
feat(ingestion): real-time ingestion activity feed (closes #48)

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -75,6 +75,24 @@ http {
 
         resolver 127.0.0.11 valid=30s;
 
+        location /admin/api/ingestion/events/ {
+            set $upstream georiva:8000;
+
+            proxy_pass http://$upstream;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Port $server_port;
+        }
+
         location / {
             set $upstream georiva:8000;
 

--- a/docs/adr/0001-sse-for-ingestion-activity-feed.md
+++ b/docs/adr/0001-sse-for-ingestion-activity-feed.md
@@ -1,0 +1,22 @@
+# SSE for the Ingestion Activity Feed
+
+The Ingestion Activity Feed needs real-time push from server to browser. We chose Server-Sent Events (SSE)
+over polling and over WebSockets.
+
+Polling was rejected because it loses intermediate `progress_state` steps — the step-by-step log accumulates
+values between polls, so any state emitted and replaced before the next poll is silently dropped. SSE pushes
+every event as it happens.
+
+WebSockets were rejected because the data flow is strictly one-way (server → browser). Actions like cancel/retry
+are standard HTTP POSTs; no bidirectional socket is needed. WebSockets would require Django Channels + ASGI
+channel layer for a problem SSE solves with a plain async Django view.
+
+## Consequences
+
+- The web service must run under `gunicorn-asgi` (not `gunicorn-wsgi`). The `gunicorn-asgi` entrypoint already
+  exists in `docker-entrypoint.sh`; this is a config switch, not new infrastructure.
+- The ingestion pipeline must publish typed events to a Redis pub/sub channel (`ingestion:events`) at key
+  transitions. Model-level events use Django signals on `DataArrival` and `FileIngestion`. Job-level progress
+  events use a `PublishingProgress` wrapper (a `Progress` subclass) created in `FileIngestionJobType.run()`
+  and threaded through `IngestionService` and `IngestionHandler` — this is how intermediate steps reach the
+  browser without modifying the task_ferry package.

--- a/georiva/src/georiva/ingestion/job_types.py
+++ b/georiva/src/georiva/ingestion/job_types.py
@@ -15,6 +15,11 @@ from .models import DataArrival, FileIngestionJob, FileIngestion
 logger = logging.getLogger(__name__)
 
 
+def _publish_arrival_status(arrival_id: int, status: str) -> None:
+    from georiva.ingestion.events import publish_event
+    publish_event({"type": "data_arrival.status_changed", "id": arrival_id, "status": status})
+
+
 class FileIngestionJobType(JobType):
     type = "file_ingestion"
     model_class = FileIngestionJob
@@ -68,6 +73,7 @@ class FileIngestionJobType(JobType):
             DataArrival.objects.filter(pk=arrival_id).update(
                 status=DataArrival.Status.PROCESSING,
             )
+            _publish_arrival_status(arrival_id, DataArrival.Status.PROCESSING)
 
         progress.increment(10, state="Lock acquired — starting ingestion")
 
@@ -105,6 +111,7 @@ class FileIngestionJobType(JobType):
                     status=arrival_status,
                     finished_at=dj_timezone.now(),
                 )
+                _publish_arrival_status(arrival_id, arrival_status)
             progress.increment(10, state=(
                 f"Done — {len(result.items_created)} items, "
                 f"{len(result.assets_created)} assets created"
@@ -127,6 +134,7 @@ class FileIngestionJobType(JobType):
                     error_message=error_msg[:2000],
                     finished_at=dj_timezone.now(),
                 )
+                _publish_arrival_status(arrival_id, DataArrival.Status.FAILED)
             raise RuntimeError(error_msg)
 
     def on_error(self, job: FileIngestionJob, exc: Exception) -> None:

--- a/georiva/src/georiva/ingestion/signals.py
+++ b/georiva/src/georiva/ingestion/signals.py
@@ -3,12 +3,32 @@ from django.dispatch import receiver
 
 
 @receiver(post_save, sender="georivaingestion.DataArrival")
-def _data_arrival_status_changed(sender, instance, created, update_fields, **kwargs):
+def _data_arrival_post_save(sender, instance, created, update_fields, **kwargs):
+    from georiva.ingestion.events import publish_event
     if created:
+        collection_name = None
+        catalog_name = None
+        try:
+            if instance.collection_id:
+                col = instance.collection
+                collection_name = col.name if col else None
+                catalog_name = col.catalog.name if col and col.catalog_id else None
+        except Exception:
+            pass
+        publish_event({
+            "type": "data_arrival.created",
+            "id": instance.pk,
+            "trigger": instance.trigger,
+            "status": instance.status,
+            "file_path": instance.file_path,
+            "started_at": instance.started_at.isoformat() if instance.started_at else None,
+            "collection_name": collection_name,
+            "catalog_name": catalog_name,
+            "file_ingestions": [],
+        })
         return
     if update_fields is None or "status" not in update_fields:
         return
-    from georiva.ingestion.events import publish_event
     publish_event({
         "type": "data_arrival.status_changed",
         "id": instance.pk,

--- a/georiva/src/georiva/ingestion/snapshot.py
+++ b/georiva/src/georiva/ingestion/snapshot.py
@@ -1,44 +1,50 @@
 from asgiref.sync import sync_to_async
 
+TERMINAL_STATUSES = frozenset(["completed", "failed", "partial", "empty"])
+
+
+def _build_arrival_dict(arrival) -> dict:
+    file_ingestions = []
+    for fi in arrival.file_ingestions.all():
+        latest_job = fi.jobs.order_by("-created_at").first()
+        file_ingestions.append({
+            "id": fi.pk,
+            "status": fi.status,
+            "job_id": latest_job.pk if latest_job else None,
+            "job_state": latest_job.state if latest_job else None,
+        })
+    collection = arrival.collection
+    return {
+        "id": arrival.pk,
+        "status": arrival.status,
+        "trigger": arrival.trigger,
+        "file_path": arrival.file_path,
+        "collection_name": collection.name if collection else None,
+        "catalog_name": collection.catalog.name if collection else None,
+        "started_at": arrival.started_at.isoformat(),
+        "finished_at": arrival.finished_at.isoformat() if arrival.finished_at else None,
+        "file_ingestions": file_ingestions,
+    }
+
 
 @sync_to_async
-def _fetch_arrivals(limit: int) -> list[dict]:
+def _fetch_arrivals(terminal_limit: int) -> list[dict]:
     from georiva.ingestion.models import DataArrival
 
-    arrivals = (
+    base = (
         DataArrival.objects
         .select_related("collection__catalog")
         .prefetch_related("file_ingestions__jobs")
-        .order_by("-created_at")[:limit]
     )
+    # All active arrivals (no cap — operator needs to see everything in flight).
+    active = list(base.exclude(status__in=TERMINAL_STATUSES).order_by("-created_at"))
+    # Only the most recent N terminal arrivals to keep the list manageable.
+    terminal = list(base.filter(status__in=TERMINAL_STATUSES).order_by("-created_at")[:terminal_limit])
 
-    result = []
-    for arrival in arrivals:
-        file_ingestions = []
-        for fi in arrival.file_ingestions.all():
-            latest_job = fi.jobs.order_by("-created_at").first()
-            file_ingestions.append({
-                "id": fi.pk,
-                "status": fi.status,
-                "job_id": latest_job.pk if latest_job else None,
-                "job_state": latest_job.state if latest_job else None,
-            })
-
-        collection = arrival.collection
-        result.append({
-            "id": arrival.pk,
-            "status": arrival.status,
-            "trigger": arrival.trigger,
-            "file_path": arrival.file_path,
-            "collection_name": collection.name if collection else None,
-            "catalog_name": collection.catalog.name if collection else None,
-            "started_at": arrival.started_at.isoformat(),
-            "finished_at": arrival.finished_at.isoformat() if arrival.finished_at else None,
-            "file_ingestions": file_ingestions,
-        })
-    return result
+    combined = sorted(active + terminal, key=lambda a: a.created_at, reverse=True)
+    return [_build_arrival_dict(a) for a in combined]
 
 
-async def build_arrival_snapshot(limit: int = 50) -> list[dict]:
-    """Return the last `limit` DataArrivals with their FileIngestion and job summaries."""
-    return await _fetch_arrivals(limit)
+async def build_arrival_snapshot(terminal_limit: int = 10) -> list[dict]:
+    """Return all active arrivals plus the last `terminal_limit` completed/failed ones."""
+    return await _fetch_arrivals(terminal_limit)

--- a/georiva/src/georiva/ingestion/sse_views.py
+++ b/georiva/src/georiva/ingestion/sse_views.py
@@ -5,6 +5,8 @@ from django.http import StreamingHttpResponse
 
 logger = logging.getLogger(__name__)
 
+_KEEPALIVE_SECS = 25
+
 
 def ingestion_events_sse(request):
     """
@@ -42,16 +44,27 @@ async def _event_stream():
         yield f"event: snapshot\ndata: {json.dumps(snapshot)}\n\n"
 
         try:
-            async for message in pubsub.listen():
-                if message["type"] == "message":
-                    raw = message["data"]
-                    data = raw.decode() if isinstance(raw, bytes) else raw
-                    try:
-                        payload = json.loads(data)
-                        event_type = payload.get("type", "ingestion")
-                    except (ValueError, AttributeError):
-                        event_type = "ingestion"
-                    yield f"event: {event_type}\ndata: {data}\n\n"
+            while True:
+                # get_message with a timeout is used instead of pubsub.listen() so that:
+                # 1. We can send periodic keepalive comments to prevent proxy timeouts.
+                # 2. We avoid the block=True socket read inside listen() which can stall
+                #    under some ASGI event loop configurations (Daphne/Uvicorn).
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=_KEEPALIVE_SECS,
+                )
+                if message is None:
+                    yield ": keepalive\n\n"
+                    continue
+
+                raw = message["data"]
+                data = raw.decode() if isinstance(raw, bytes) else raw
+                try:
+                    payload = json.loads(data)
+                    event_type = payload.get("type", "ingestion")
+                except (ValueError, AttributeError):
+                    event_type = "ingestion"
+                yield f"event: {event_type}\ndata: {data}\n\n"
         finally:
             await pubsub.unsubscribe(CHANNEL)
             await pubsub.aclose()

--- a/georiva/src/georiva/ingestion/sse_views.py
+++ b/georiva/src/georiva/ingestion/sse_views.py
@@ -31,13 +31,16 @@ async def _event_stream():
     from .events import CHANNEL
     from .snapshot import build_arrival_snapshot
 
-    snapshot = await build_arrival_snapshot()
-    yield f"event: snapshot\ndata: {json.dumps(snapshot)}\n\n"
-
+    # Subscribe to Redis BEFORE fetching the snapshot so that events published
+    # during the snapshot query are queued in pubsub and not lost.
     r = aioredis.from_url(settings.REDIS_URL)
     try:
         pubsub = r.pubsub()
         await pubsub.subscribe(CHANNEL)
+
+        snapshot = await build_arrival_snapshot()
+        yield f"event: snapshot\ndata: {json.dumps(snapshot)}\n\n"
+
         try:
             async for message in pubsub.listen():
                 if message["type"] == "message":

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
@@ -4,279 +4,364 @@
 {% block titletag %}{% trans "Ingestion Activity" %}{% endblock %}
 
 {% block extra_css %}
-<style>
-    .iaf-empty {
-        padding: 2em 0; text-align: center;
-        color: var(--w-color-grey-400); font-size: 0.95em;
-    }
-    .iaf-card {
-        border: 1px solid var(--w-color-border-furniture);
-        border-radius: 4px; background: var(--w-color-surface-page);
-        margin-bottom: 1em; overflow: hidden;
-    }
-    .iaf-card-header {
-        display: flex; align-items: center; gap: 0.75em;
-        padding: 0.65em 1em;
-        background: var(--w-color-grey-50);
-        border-bottom: 1px solid var(--w-color-border-furniture);
-        font-size: 0.88em;
-    }
-    .iaf-trigger {
-        font-weight: 600; color: var(--w-color-text-label);
-        text-transform: capitalize;
-    }
-    .iaf-collection { color: var(--w-color-grey-400); }
-    .iaf-time { margin-left: auto; color: var(--w-color-grey-400); font-size: 0.85em; }
-    .iaf-status-pill {
-        padding: 0.1em 0.6em; border-radius: 1em;
-        font-size: 0.8em; font-weight: 600;
-        background: var(--w-color-grey-100); color: var(--w-color-text-label);
-    }
-    .iaf-status-pill--processing  { background: var(--w-color-info-100);     color: var(--w-color-white); }
-    .iaf-status-pill--completed   { background: var(--w-color-positive-100); color: var(--w-color-white); }
-    .iaf-status-pill--failed      { background: var(--w-color-critical-200); color: var(--w-color-white); }
-    .iaf-status-pill--partial     { background: var(--w-color-warning-100);  color: var(--w-color-text-label); }
-    .iaf-card-body { padding: 0.6em 1em 0.8em; }
-    .iaf-filepath {
-        font-family: monospace; font-size: 0.82em;
-        color: var(--w-color-grey-400); word-break: break-all;
-        margin-bottom: 0.5em;
-    }
-    .iaf-log-steps {
-        list-style: none; margin: 0.3em 0 0; padding: 0;
-        font-size: 0.85em; line-height: 1.8;
-        color: var(--w-color-text-label);
-    }
-    .iaf-log-steps li::before { content: "›  "; color: var(--w-color-grey-400); }
-    .iaf-log-summary { font-size: 0.85em; margin-top: 0.4em; }
-    .iaf-log-summary--success { color: var(--w-color-positive-100); font-weight: 600; }
-    .iaf-log-summary--error   { color: var(--w-color-critical-200); }
-    .iaf-cancel-btn {
-        margin-left: 0.5em; padding: 0.1em 0.7em;
-        font-size: 0.8em; border-radius: 3px; cursor: pointer;
-        border: 1px solid var(--w-color-critical-200);
-        color: var(--w-color-critical-200);
-        background: transparent;
-    }
-    .iaf-cancel-btn:disabled { opacity: 0.45; cursor: not-allowed; }
-</style>
+    <style>
+        .iaf-empty {
+            padding: 2em 0;
+            text-align: center;
+            color: var(--w-color-grey-400);
+            font-size: 0.95em;
+        }
+
+        .iaf-card {
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 4px;
+            background: var(--w-color-surface-page);
+            margin-bottom: 1em;
+            overflow: hidden;
+        }
+
+        .iaf-card-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75em;
+            padding: 0.65em 1em;
+            background: var(--w-color-grey-50);
+            border-bottom: 1px solid var(--w-color-border-furniture);
+            font-size: 0.88em;
+        }
+
+        .iaf-trigger {
+            font-weight: 600;
+            color: var(--w-color-text-label);
+            text-transform: capitalize;
+        }
+
+        .iaf-collection {
+            color: var(--w-color-grey-400);
+        }
+
+        .iaf-time {
+            margin-left: auto;
+            color: var(--w-color-grey-400);
+            font-size: 0.85em;
+        }
+
+        .iaf-status-pill {
+            padding: 0.1em 0.6em;
+            border-radius: 1em;
+            font-size: 0.8em;
+            font-weight: 600;
+            background: var(--w-color-grey-100);
+            color: var(--w-color-text-label);
+        }
+
+        .iaf-status-pill--processing {
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+        }
+
+        .iaf-status-pill--completed {
+            background: var(--w-color-positive-100);
+            color: var(--w-color-white);
+        }
+
+        .iaf-status-pill--failed {
+            background: var(--w-color-critical-200);
+            color: var(--w-color-white);
+        }
+
+        .iaf-status-pill--partial {
+            background: var(--w-color-warning-100);
+            color: var(--w-color-text-label);
+        }
+
+        .iaf-card-body {
+            padding: 0.6em 1em 0.8em;
+        }
+
+        .iaf-filepath {
+            font-family: monospace;
+            font-size: 0.82em;
+            color: var(--w-color-grey-400);
+            word-break: break-all;
+            margin-bottom: 0.5em;
+        }
+
+        .iaf-log-steps {
+            list-style: none;
+            margin: 0.3em 0 0;
+            padding: 0;
+            font-size: 0.85em;
+            line-height: 1.8;
+            color: var(--w-color-text-label);
+        }
+
+        .iaf-log-steps li::before {
+            content: "›  ";
+            color: var(--w-color-grey-400);
+        }
+
+        .iaf-log-summary {
+            font-size: 0.85em;
+            margin-top: 0.4em;
+        }
+
+        .iaf-log-summary--success {
+            color: var(--w-color-positive-100);
+            font-weight: 600;
+        }
+
+        .iaf-log-summary--error {
+            color: var(--w-color-critical-200);
+        }
+
+        .iaf-cancel-btn {
+            margin-left: 0.5em;
+            padding: 0.1em 0.7em;
+            font-size: 0.8em;
+            border-radius: 3px;
+            cursor: pointer;
+            border: 1px solid var(--w-color-critical-200);
+            color: var(--w-color-critical-200);
+            background: transparent;
+        }
+
+        .iaf-cancel-btn:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+    </style>
 {% endblock %}
 
 {% block content %}
-{% include "wagtailadmin/shared/header.html" with title=_("Ingestion Activity") icon="history" breadcrumbs=breadcrumbs_items %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Ingestion Activity") icon="history" breadcrumbs=breadcrumbs_items %}
 
-<div class="nice-padding">
-    <div id="activity-feed">
-        <div class="iaf-empty" id="feed-empty">{% trans "Connecting…" %}</div>
+    <div class="nice-padding">
+        <div id="activity-feed">
+            <div class="iaf-empty" id="feed-empty">{% trans "Connecting…" %}</div>
+        </div>
     </div>
-</div>
 {% endblock %}
 
 {% block extra_js %}
-{{ block.super }}
-<script>
-document.addEventListener('DOMContentLoaded', function () {
+    {{ block.super }}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
 
-    const SSE_URL        = '/admin/api/ingestion/events/';
-    const CANCEL_URL_TPL = '/api/jobs/__ID__/cancel/';
-    const CSRF_TOKEN     = '{{ csrf_token }}';
-    const feedEl         = document.getElementById('activity-feed');
-    const emptyEl        = document.getElementById('feed-empty');
+            const SSE_URL = '/admin/api/ingestion/events/';
+            const CANCEL_URL_TPL = '/api/jobs/__ID__/cancel/';
+            const CSRF_TOKEN = '{{ csrf_token }}';
+            const feedEl = document.getElementById('activity-feed');
+            const emptyEl = document.getElementById('feed-empty');
 
-    const TERMINAL_JOB_STATES = ['finished', 'failed', 'cancelled'];
+            const TERMINAL_JOB_STATES = ['finished', 'failed', 'cancelled'];
 
-    // ── Helpers ────────────────────────────────────────────────────────────
+            // ── Helpers ────────────────────────────────────────────────────────────
 
-    function fmtTime(iso) {
-        if (!iso) return '';
-        try { return new Date(iso).toLocaleString(); } catch (e) { return iso; }
-    }
-
-    function pillClass(status) {
-        const map = { processing: '--processing', completed: '--completed',
-                      failed: '--failed', partial: '--partial' };
-        return 'iaf-status-pill' + (map[status] || '');
-    }
-
-    function csrfHeaders() {
-        return { 'X-CSRFToken': CSRF_TOKEN, 'Content-Type': 'application/json' };
-    }
-
-    // ── Cancel button ──────────────────────────────────────────────────────
-
-    function addCancelButton(card, jobId) {
-        const btn = document.createElement('button');
-        btn.className = 'iaf-cancel-btn';
-        btn.textContent = '{% trans "Cancel" %}';
-        btn.dataset.cancelBtn = jobId;
-        btn.addEventListener('click', function () {
-            btn.disabled = true;
-            fetch(CANCEL_URL_TPL.replace('__ID__', jobId), {
-                method: 'POST',
-                headers: csrfHeaders(),
-            }).catch(function () {
-                btn.disabled = false;
-            });
-        });
-        const header = card.querySelector('.iaf-card-header');
-        if (header) header.appendChild(btn);
-    }
-
-    function removeCancelButton(card) {
-        const btn = card.querySelector('[data-cancel-btn]');
-        if (btn) btn.remove();
-    }
-
-    // ── Card builder ───────────────────────────────────────────────────────
-
-    function buildCard(arrival) {
-        const card = document.createElement('div');
-        card.className = 'iaf-card';
-        card.dataset.arrivalId = arrival.id;
-
-        const collection = arrival.collection_name
-            ? (arrival.catalog_name ? arrival.catalog_name + ' / ' : '') + arrival.collection_name
-            : (arrival.catalog_name || '');
-
-        card.innerHTML =
-            '<div class="iaf-card-header">' +
-                '<span class="iaf-trigger">' + (arrival.trigger || '') + '</span>' +
-                (collection ? '<span class="iaf-collection">' + collection + '</span>' : '') +
-                '<span class="' + pillClass(arrival.status) + '" data-status-pill>' +
-                    arrival.status +
-                '</span>' +
-                '<span class="iaf-time">' + fmtTime(arrival.started_at) + '</span>' +
-            '</div>' +
-            '<div class="iaf-card-body">' +
-                (arrival.file_path
-                    ? '<div class="iaf-filepath">' + arrival.file_path + '</div>'
-                    : '') +
-                '<ul class="iaf-log-steps" data-log-steps></ul>' +
-                '<div class="iaf-log-summary" data-log-summary></div>' +
-            '</div>';
-
-        arrival.file_ingestions.forEach(function (fi) {
-            if (fi.job_id && !TERMINAL_JOB_STATES.includes(fi.job_state)) {
-                attachJobLog(card, fi.job_id);
-                addCancelButton(card, fi.job_id);
-            } else if (fi.job_summary) {
-                const sumEl = card.querySelector('[data-log-summary]');
-                sumEl.textContent = fi.job_summary;
-                sumEl.className = 'iaf-log-summary iaf-log-summary--success';
+            function fmtTime(iso) {
+                if (!iso) return '';
+                try {
+                    return new Date(iso).toLocaleString();
+                } catch (e) {
+                    return iso;
+                }
             }
+
+            function pillClass(status) {
+                const map = {
+                    processing: '--processing', completed: '--completed',
+                    failed: '--failed', partial: '--partial'
+                };
+                return 'iaf-status-pill' + (map[status] || '');
+            }
+
+            function csrfHeaders() {
+                return {'X-CSRFToken': CSRF_TOKEN, 'Content-Type': 'application/json'};
+            }
+
+            // ── Cancel button ──────────────────────────────────────────────────────
+
+            function addCancelButton(card, jobId) {
+                const btn = document.createElement('button');
+                btn.className = 'iaf-cancel-btn';
+                btn.textContent = '{% trans "Cancel" %}';
+                btn.dataset.cancelBtn = jobId;
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    fetch(CANCEL_URL_TPL.replace('__ID__', jobId), {
+                        method: 'POST',
+                        headers: csrfHeaders(),
+                    }).catch(function () {
+                        btn.disabled = false;
+                    });
+                });
+                const header = card.querySelector('.iaf-card-header');
+                if (header) header.appendChild(btn);
+            }
+
+            function removeCancelButton(card) {
+                const btn = card.querySelector('[data-cancel-btn]');
+                if (btn) btn.remove();
+            }
+
+            // ── Card builder ───────────────────────────────────────────────────────
+
+            function buildCard(arrival) {
+                const card = document.createElement('div');
+                card.className = 'iaf-card';
+                card.dataset.arrivalId = arrival.id;
+
+                const collection = arrival.collection_name
+                    ? (arrival.catalog_name ? arrival.catalog_name + ' / ' : '') + arrival.collection_name
+                    : (arrival.catalog_name || '');
+
+                card.innerHTML =
+                    '<div class="iaf-card-header">' +
+                    '<span class="iaf-trigger">' + (arrival.trigger || '') + '</span>' +
+                    (collection ? '<span class="iaf-collection">' + collection + '</span>' : '') +
+                    '<span class="' + pillClass(arrival.status) + '" data-status-pill>' +
+                    arrival.status +
+                    '</span>' +
+                    '<span class="iaf-time">' + fmtTime(arrival.started_at) + '</span>' +
+                    '</div>' +
+                    '<div class="iaf-card-body">' +
+                    (arrival.file_path
+                        ? '<div class="iaf-filepath">' + arrival.file_path + '</div>'
+                        : '') +
+                    '<ul class="iaf-log-steps" data-log-steps></ul>' +
+                    '<div class="iaf-log-summary" data-log-summary></div>' +
+                    '</div>';
+
+                arrival.file_ingestions.forEach(function (fi) {
+                    if (fi.job_id && !TERMINAL_JOB_STATES.includes(fi.job_state)) {
+                        attachJobLog(card, fi.job_id);
+                        addCancelButton(card, fi.job_id);
+                    } else if (fi.job_summary) {
+                        const sumEl = card.querySelector('[data-log-summary]');
+                        sumEl.textContent = fi.job_summary;
+                        sumEl.className = 'iaf-log-summary iaf-log-summary--success';
+                    }
+                });
+
+                return card;
+            }
+
+            // ── Inline job progress log ────────────────────────────────────────────
+
+            function attachJobLog(card, jobId) {
+                card.dataset.jobId = jobId;
+            }
+
+            function appendStep(card, state, percentage) {
+                const list = card.querySelector('[data-log-steps]');
+                if (!list) return;
+                const li = document.createElement('li');
+                li.textContent = (percentage != null) ? '[' + Math.round(percentage) + '%] ' + state : state;
+                list.appendChild(li);
+            }
+
+            function finishJobOnCard(card, summaryText, isError) {
+                const sumEl = card.querySelector('[data-log-summary]');
+                if (!sumEl) return;
+                sumEl.textContent = summaryText;
+                sumEl.className = 'iaf-log-summary ' +
+                    (isError ? 'iaf-log-summary--error' : 'iaf-log-summary--success');
+                removeCancelButton(card);
+                delete card.dataset.jobId;
+            }
+
+            // ── Card registry ──────────────────────────────────────────────────────
+
+            function cardByArrival(id) {
+                return feedEl.querySelector('[data-arrival-id="' + id + '"]');
+            }
+
+            function cardByJob(id) {
+                return feedEl.querySelector('[data-job-id="' + id + '"]');
+            }
+
+            // ── Snapshot render ────────────────────────────────────────────────────
+
+            function renderSnapshot(arrivals) {
+                emptyEl.style.display = 'none';
+                if (!arrivals.length) {
+                    emptyEl.textContent = '{% trans "No arrivals yet." %}';
+                    emptyEl.style.display = '';
+                    return;
+                }
+                arrivals.forEach(function (arrival) {
+                    feedEl.appendChild(buildCard(arrival));
+                });
+            }
+
+            // ── SSE event handlers ─────────────────────────────────────────────────
+
+            function onArrivalStatusChanged(data) {
+                const card = cardByArrival(data.id);
+                if (!card) return;
+                const pill = card.querySelector('[data-status-pill]');
+                if (pill) {
+                    pill.textContent = data.status;
+                    pill.className = pillClass(data.status);
+                }
+            }
+
+            function onJobProgressUpdated(data) {
+                const card = cardByJob(data.job_id);
+                if (!card) return;
+                if (data.state) appendStep(card, data.state, data.percentage);
+            }
+
+            function onJobStateChanged(data) {
+                const card = cardByJob(data.id);
+                if (!card) return;
+                if (data.state === 'finished') {
+                    finishJobOnCard(card, '{% trans "Items and assets created successfully." %}', false);
+                } else if (data.state === 'failed' || data.state === 'cancelled') {
+                    finishJobOnCard(card, data.error || '{% trans "Cancelled by operator." %}', true);
+                }
+            }
+
+            // ── SSE connection ─────────────────────────────────────────────────────
+
+            const es = new EventSource(SSE_URL);
+
+            es.addEventListener('snapshot', function (ev) {
+                renderSnapshot(JSON.parse(ev.data));
+            });
+
+            es.addEventListener('data_arrival.created', function (ev) {
+                const arrival = JSON.parse(ev.data);
+                if (cardByArrival(arrival.id)) return;
+                emptyEl.style.display = 'none';
+                feedEl.insertBefore(buildCard(arrival), feedEl.firstChild);
+            });
+
+            es.addEventListener('data_arrival.job_created', function (ev) {
+                const data = JSON.parse(ev.data);
+                const card = cardByArrival(data.id);
+                if (!card) return;
+                attachJobLog(card, data.job_id);
+                addCancelButton(card, data.job_id);
+            });
+
+            es.addEventListener('data_arrival.status_changed', function (ev) {
+                onArrivalStatusChanged(JSON.parse(ev.data));
+            });
+
+            es.addEventListener('job.progress_updated', function (ev) {
+                onJobProgressUpdated(JSON.parse(ev.data));
+            });
+
+            es.addEventListener('job.state_changed', function (ev) {
+                onJobStateChanged(JSON.parse(ev.data));
+            });
+
+            es.onerror = function () {
+                emptyEl.textContent = '{% trans "Connection lost. Reconnecting…" %}';
+                emptyEl.style.display = '';
+            };
+
         });
-
-        return card;
-    }
-
-    // ── Inline job progress log ────────────────────────────────────────────
-
-    function attachJobLog(card, jobId) {
-        card.dataset.jobId = jobId;
-    }
-
-    function appendStep(card, state, percentage) {
-        const list = card.querySelector('[data-log-steps]');
-        if (!list) return;
-        const li = document.createElement('li');
-        li.textContent = (percentage != null) ? '[' + Math.round(percentage) + '%] ' + state : state;
-        list.appendChild(li);
-    }
-
-    function finishJobOnCard(card, summaryText, isError) {
-        const sumEl = card.querySelector('[data-log-summary]');
-        if (!sumEl) return;
-        sumEl.textContent = summaryText;
-        sumEl.className = 'iaf-log-summary ' +
-            (isError ? 'iaf-log-summary--error' : 'iaf-log-summary--success');
-        removeCancelButton(card);
-        delete card.dataset.jobId;
-    }
-
-    // ── Card registry ──────────────────────────────────────────────────────
-
-    function cardByArrival(id) {
-        return feedEl.querySelector('[data-arrival-id="' + id + '"]');
-    }
-
-    function cardByJob(id) {
-        return feedEl.querySelector('[data-job-id="' + id + '"]');
-    }
-
-    // ── Snapshot render ────────────────────────────────────────────────────
-
-    function renderSnapshot(arrivals) {
-        emptyEl.style.display = 'none';
-        if (!arrivals.length) {
-            emptyEl.textContent = '{% trans "No arrivals yet." %}';
-            emptyEl.style.display = '';
-            return;
-        }
-        arrivals.forEach(function (arrival) {
-            feedEl.appendChild(buildCard(arrival));
-        });
-    }
-
-    // ── SSE event handlers ─────────────────────────────────────────────────
-
-    function onArrivalStatusChanged(data) {
-        const card = cardByArrival(data.id);
-        if (!card) return;
-        const pill = card.querySelector('[data-status-pill]');
-        if (pill) {
-            pill.textContent = data.status;
-            pill.className = pillClass(data.status);
-        }
-    }
-
-    function onJobProgressUpdated(data) {
-        const card = cardByJob(data.job_id);
-        if (!card) return;
-        if (data.state) appendStep(card, data.state, data.percentage);
-    }
-
-    function onJobStateChanged(data) {
-        const card = cardByJob(data.id);
-        if (!card) return;
-        if (data.state === 'finished') {
-            finishJobOnCard(card, '{% trans "Items and assets created successfully." %}', false);
-        } else if (data.state === 'failed' || data.state === 'cancelled') {
-            finishJobOnCard(card, data.error || '{% trans "Cancelled by operator." %}', true);
-        }
-    }
-
-    // ── SSE connection ─────────────────────────────────────────────────────
-
-    const es = new EventSource(SSE_URL);
-
-    es.addEventListener('snapshot', function (ev) {
-        renderSnapshot(JSON.parse(ev.data));
-    });
-
-    es.addEventListener('data_arrival.created', function (ev) {
-        const arrival = JSON.parse(ev.data);
-        if (cardByArrival(arrival.id)) return;
-        emptyEl.style.display = 'none';
-        feedEl.insertBefore(buildCard(arrival), feedEl.firstChild);
-    });
-
-    es.addEventListener('data_arrival.status_changed', function (ev) {
-        onArrivalStatusChanged(JSON.parse(ev.data));
-    });
-
-    es.addEventListener('job.progress_updated', function (ev) {
-        onJobProgressUpdated(JSON.parse(ev.data));
-    });
-
-    es.addEventListener('job.state_changed', function (ev) {
-        onJobStateChanged(JSON.parse(ev.data));
-    });
-
-    es.onerror = function () {
-        emptyEl.textContent = '{% trans "Connection lost. Reconnecting…" %}';
-        emptyEl.style.display = '';
-    };
-
-});
-</script>
+    </script>
 {% endblock %}

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
@@ -175,11 +175,11 @@ document.addEventListener('DOMContentLoaded', function () {
         card.dataset.jobId = jobId;
     }
 
-    function appendStep(card, state) {
+    function appendStep(card, state, percentage) {
         const list = card.querySelector('[data-log-steps]');
         if (!list) return;
         const li = document.createElement('li');
-        li.textContent = state;
+        li.textContent = (percentage != null) ? '[' + Math.round(percentage) + '%] ' + state : state;
         list.appendChild(li);
     }
 
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function onJobProgressUpdated(data) {
         const card = cardByJob(data.job_id);
         if (!card) return;
-        if (data.state) appendStep(card, data.state);
+        if (data.state) appendStep(card, data.state, data.percentage);
     }
 
     function onJobStateChanged(data) {
@@ -251,6 +251,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     es.addEventListener('snapshot', function (ev) {
         renderSnapshot(JSON.parse(ev.data));
+    });
+
+    es.addEventListener('data_arrival.created', function (ev) {
+        const arrival = JSON.parse(ev.data);
+        if (cardByArrival(arrival.id)) return;
+        emptyEl.style.display = 'none';
+        feedEl.insertBefore(buildCard(arrival), feedEl.firstChild);
     });
 
     es.addEventListener('data_arrival.status_changed', function (ev) {

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/activity_feed.html
@@ -28,6 +28,24 @@
             background: var(--w-color-grey-50);
             border-bottom: 1px solid var(--w-color-border-furniture);
             font-size: 0.88em;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .iaf-card--collapsed .iaf-card-header {
+            border-bottom: none;
+        }
+
+        .iaf-chevron {
+            display: inline-block;
+            font-size: 0.75em;
+            color: var(--w-color-grey-400);
+            transition: transform 0.15s;
+            flex-shrink: 0;
+        }
+
+        .iaf-card--collapsed .iaf-chevron {
+            transform: rotate(-90deg);
         }
 
         .iaf-trigger {
@@ -77,6 +95,10 @@
 
         .iaf-card-body {
             padding: 0.6em 1em 0.8em;
+        }
+
+        .iaf-card--collapsed .iaf-card-body {
+            display: none;
         }
 
         .iaf-filepath {
@@ -155,6 +177,8 @@
             const emptyEl = document.getElementById('feed-empty');
 
             const TERMINAL_JOB_STATES = ['finished', 'failed', 'cancelled'];
+            const TERMINAL_ARRIVAL_STATUSES = ['completed', 'failed', 'partial', 'empty'];
+            const COLLAPSE_DELAY_MS = 3000;
 
             // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -186,7 +210,8 @@
                 btn.className = 'iaf-cancel-btn';
                 btn.textContent = '{% trans "Cancel" %}';
                 btn.dataset.cancelBtn = jobId;
-                btn.addEventListener('click', function () {
+                btn.addEventListener('click', function (e) {
+                    e.stopPropagation();
                     btn.disabled = true;
                     fetch(CANCEL_URL_TPL.replace('__ID__', jobId), {
                         method: 'POST',
@@ -204,6 +229,21 @@
                 if (btn) btn.remove();
             }
 
+            // ── Collapse / expand ──────────────────────────────────────────────────
+
+            function collapseCard(card) {
+                card.classList.add('iaf-card--collapsed');
+            }
+
+            function wireHeaderToggle(card) {
+                const header = card.querySelector('.iaf-card-header');
+                if (!header) return;
+                header.addEventListener('click', function (e) {
+                    if (e.target.closest('button')) return;
+                    card.classList.toggle('iaf-card--collapsed');
+                });
+            }
+
             // ── Card builder ───────────────────────────────────────────────────────
 
             function buildCard(arrival) {
@@ -211,12 +251,16 @@
                 card.className = 'iaf-card';
                 card.dataset.arrivalId = arrival.id;
 
+                const isTerminal = TERMINAL_ARRIVAL_STATUSES.includes(arrival.status);
+                if (isTerminal) card.classList.add('iaf-card--collapsed');
+
                 const collection = arrival.collection_name
                     ? (arrival.catalog_name ? arrival.catalog_name + ' / ' : '') + arrival.collection_name
                     : (arrival.catalog_name || '');
 
                 card.innerHTML =
                     '<div class="iaf-card-header">' +
+                    '<span class="iaf-chevron">▾</span>' +
                     '<span class="iaf-trigger">' + (arrival.trigger || '') + '</span>' +
                     (collection ? '<span class="iaf-collection">' + collection + '</span>' : '') +
                     '<span class="' + pillClass(arrival.status) + '" data-status-pill>' +
@@ -231,6 +275,8 @@
                     '<ul class="iaf-log-steps" data-log-steps></ul>' +
                     '<div class="iaf-log-summary" data-log-summary></div>' +
                     '</div>';
+
+                wireHeaderToggle(card);
 
                 arrival.file_ingestions.forEach(function (fi) {
                     if (fi.job_id && !TERMINAL_JOB_STATES.includes(fi.job_state)) {
@@ -303,6 +349,9 @@
                 if (pill) {
                     pill.textContent = data.status;
                     pill.className = pillClass(data.status);
+                }
+                if (TERMINAL_ARRIVAL_STATUSES.includes(data.status)) {
+                    setTimeout(function () { collapseCard(card); }, COLLAPSE_DELAY_MS);
                 }
             }
 

--- a/georiva/src/georiva/ingestion/tests/test_activity_feed.py
+++ b/georiva/src/georiva/ingestion/tests/test_activity_feed.py
@@ -42,6 +42,21 @@ class ActivityPageRenderTests(TestCase):
 # Cycle 1 (issue #55): Cancel wiring present in activity feed template
 # =============================================================================
 
+class ActivityFeedLiveArrivalTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_la", "la@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_page_handles_data_arrival_created_event(self):
+        response = self.client.get(ACTIVITY_URL)
+        self.assertContains(response, "data_arrival.created")
+
+    def test_page_shows_percentage_in_progress_step(self):
+        response = self.client.get(ACTIVITY_URL)
+        self.assertContains(response, "percentage")
+
+
 class ActivityFeedCancelWiringTests(TestCase):
 
     def setUp(self):

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from georiva.ingestion.events import CHANNEL
+from georiva.ingestion.models import DataArrival
 
 # =============================================================================
 # Shared test base — subscribes to ingestion:events before each test
@@ -80,11 +81,25 @@ class DataArrivalStatusEventTests(IngestionEventsTestCase):
         self.assertEqual(event["id"], arrival.pk)
         self.assertEqual(event["status"], "processing")
 
-    def test_creation_does_not_publish_status_event(self):
-        self._make_arrival()
+    def test_creation_publishes_created_event(self):
+        arrival = self._make_arrival()
 
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "data_arrival.created")
+        self.assertEqual(event["id"], arrival.pk)
+        self.assertEqual(event["trigger"], DataArrival.Trigger.MANUAL_UPLOAD)
+        self.assertIn("status", event)
+        self.assertIn("file_path", event)
+        self.assertIn("started_at", event)
+        self.assertIn("file_ingestions", event)
+
+    def test_creation_does_not_publish_status_changed_event(self):
+        self._make_arrival()
         event = self._next_event(timeout=0.5)
-        self.assertIsNone(event)
+        # creation should publish data_arrival.created, not data_arrival.status_changed
+        if event:
+            self.assertNotEqual(event["type"], "data_arrival.status_changed")
 
 
 # =============================================================================
@@ -118,8 +133,10 @@ class FileIngestionStatusEventTests(IngestionEventsTestCase):
         self.assertEqual(event["id"], fi.pk)
         self.assertEqual(event["status"], "processing")
 
-    def test_creation_does_not_publish_event(self):
+    def test_creation_does_not_publish_file_ingestion_event(self):
         self._make_file_ingestion()
+        # drain the data_arrival.created event (DataArrival is created inside _make_file_ingestion)
+        self._drain()
 
         event = self._next_event(timeout=0.5)
         self.assertIsNone(event)

--- a/georiva/src/georiva/ingestion/tests/test_sse_views.py
+++ b/georiva/src/georiva/ingestion/tests/test_sse_views.py
@@ -159,6 +159,7 @@ class SSELiveEventForwardingTests(TestCase):
         response = await self.async_client.get("/admin/api/ingestion/events/")
 
         # Consume the snapshot first, then publish a synthetic event and read it.
+        # Skip SSE comment lines (keepalives start with ':').
         async def _collect_next_event_after_snapshot():
             skipped_snapshot = False
             async for chunk in response.streaming_content:
@@ -167,7 +168,8 @@ class SSELiveEventForwardingTests(TestCase):
                     if "event: snapshot" in decoded:
                         skipped_snapshot = True
                     continue
-                if decoded.strip():
+                stripped = decoded.strip()
+                if stripped and not stripped.startswith(":"):
                     return decoded
             return ""
 

--- a/georiva/src/georiva/ingestion/tests/test_sse_views.py
+++ b/georiva/src/georiva/ingestion/tests/test_sse_views.py
@@ -81,11 +81,14 @@ class SnapshotShapeTests(TestCase):
         for field in ("id", "status", "job_id", "job_state"):
             self.assertIn(field, fi)
 
-    def test_snapshot_respects_limit(self):
+    def test_snapshot_caps_terminal_arrivals(self):
         from georiva.ingestion.snapshot import build_arrival_snapshot
 
-        result = async_to_sync(build_arrival_snapshot)(limit=1)
-        self.assertEqual(len(result), 1)
+        result = async_to_sync(build_arrival_snapshot)(terminal_limit=0)
+        # terminal_limit=0 → no completed/failed arrivals; active ones still returned
+        statuses = {r["status"] for r in result}
+        self.assertNotIn("completed", statuses)
+        self.assertIn("processing", statuses)
 
 
 # =============================================================================

--- a/georiva/src/georiva/ingestion/upload_views.py
+++ b/georiva/src/georiva/ingestion/upload_views.py
@@ -271,4 +271,7 @@ def manual_upload_submit(request, pk):
         job_id=job.pk,
     )
 
+    from georiva.ingestion.events import publish_event
+    publish_event({"type": "data_arrival.job_created", "id": arrival.pk, "job_id": job.pk})
+
     return JsonResponse({"data_arrival_id": arrival.pk, "job_id": job.pk})


### PR DESCRIPTION
## Summary

Implements the Ingestion Activity Feed — a live admin page that streams `DataArrival` updates via Server-Sent Events so operators can monitor every step of the ingestion pipeline in real time without polling.

- **SSE endpoint** (`/admin/api/ingestion/events/`) — async Django view using `redis.asyncio` pub/sub; subscribes before snapshot fetch to close the race window; replaces `pubsub.listen()` (blocked ASGI event loop) with `get_message` poll + 25-second keepalive heartbeats
- **Event publishing** — `data_arrival.created` and `data_arrival.status_changed` from a `post_save` signal; explicit publish calls after bulk `.update()` calls in `job_types.py` (bulk SQL bypasses signals); `data_arrival.job_created` from the upload submit view; `job.progress_updated` and `job.state_changed` via `PublishingProgress`
- **Activity feed page** — Wagtail admin view with SSE-driven cards per `DataArrival`; inline step log with percentage; Cancel button for in-flight jobs; new arrivals prepended live
- **List optimisation** — snapshot returns all active arrivals (no cap) + last 10 terminal arrivals; terminal cards render collapsed by default; cards auto-collapse 3 s after reaching a terminal status; header chevron toggles expand/collapse
- **Nginx SSE config** — dedicated location block with `proxy_http_version 1.1`, `proxy_buffering off`, `proxy_read_timeout 3600s`
- **ADR** — `docs/adr/0001-sse-for-ingestion-activity-feed.md` records the SSE vs polling vs WebSocket decision

## Test plan

- [ ] All 204 ingestion tests pass (`make dev-test TEST_ARGS="ingestion"`)
- [ ] Open activity feed in one tab, upload form in another — new arrival card appears in feed on submit
- [ ] Status pill on card progresses: `pending → processing → completed/failed` without page reload
- [ ] Step log accumulates per-step lines with percentage during processing
- [ ] Terminal card collapses after 3 s; clicking chevron toggles it back open
- [ ] Cancel button disables itself and stops the job
- [ ] After idle 25 s, keepalive comment keeps connection open (no reconnect)
- [ ] Closing/reopening the feed tab delivers a fresh snapshot with history capped at 10 terminal arrivals

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)