### PR TITLE
feat(ingestion): pipeline tracking model foundations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,12 +19,16 @@ _Avoid_: processing, import, fetch (for this phase)
 
 **DataArrival**:
 A batch of one or more files entering MinIO from any trigger. The top-level observable unit of work in the pipeline —
-exists for both scheduled and manual upload paths.
+exists for both scheduled and manual upload paths. Catalog-scoped: always carries a `catalog` FK. Does not link
+directly to a Collection — collection resolution is the job of `FileIngestion`.
 _Avoid_: LoaderRun, DataFeedRun, IngestionRun
 
 **FileIngestion**:
 The per-file record of processing a single file from MinIO into STAC items and assets. Owns the distributed lock, state
-machine, and retry logic for that file.
+machine, and retry logic for that file. Carries a `collections` M2M populated immediately after collection resolution
+(before per-collection processing begins), so failed runs are still collection-trackable even when no Items are
+created. Items produced by a FileIngestion are found via `Item.source_file` (indexed, value:
+`"{bucket}:{file_path}"`) — correct for all formats, including GRIB/NetCDF multi-item files.
 _Avoid_: IngestionLog
 
 ### Triggers
@@ -115,7 +119,7 @@ _Avoid_: time parsing, date detection
 ### Operator-facing monitoring surfaces
 
 **Collection Health Panel**:
-The Wagtail admin home panel showing a per-collection health summary — sparklines, OK/Warning/Failed counts, and last-run time. A fleet-level view across all active Collections. Entry point to the Ingestion Activity Feed via a "View all" link.
+The Wagtail admin home panel showing a per-collection health summary — sparklines, OK/Warning/Failed counts, and last-run time. A fleet-level view across all active Collections. Entry point to the Ingestion Activity Feed via a "View all" link. Sparkline data (30-day binary per-day status: success / failed / empty) is derived entirely from `FileIngestion.collections` M2M — completed runs for success days, failed runs for failure days. Both signals come from the same model with the same query shape.
 _Avoid_: ingestion dashboard, activity panel
 
 **Ingestion Activity Feed**:

--- a/docs/adr/0002-pipeline-tracking-model.md
+++ b/docs/adr/0002-pipeline-tracking-model.md
@@ -1,0 +1,72 @@
+# Pipeline Tracking Model — DataArrival, FileIngestion, Item
+
+## Context
+
+The Collection Health Panel needs per-collection health data (sparklines, last-run time, failure counts) for
+both automated (DataFeed) and manual upload paths. The original model could not support this for GRIB/NetCDF
+manual collections because:
+
+- `DataArrival.collection` FK was null for GRIB/NetCDF uploads (one file → N collections, no single FK target)
+- `FileIngestion.collection_slug` was an empty char field for GRIB/NetCDF (collection unknown at file-arrival time)
+- `FileIngestion.item` FK pointed *to* the TimescaleDB hypertable (`Item`), requiring `db_constraint=False`
+  and giving the wrong directionality
+
+## Decision
+
+**DataArrival is catalog-scoped.** It carries a `catalog` FK and no `collection` FK. A DataArrival represents
+"data arrived for this catalog" — which catalog is always known; which collection(s) are resolved during ingestion.
+
+**FileIngestion carries a `collections` M2M.** After `_resolve_collections()` succeeds but before the
+per-collection processing loop begins, the service writes the resolved collections into
+`FileIngestion.collections`. This means even a run that fails before creating any Items is still
+collection-trackable. The M2M is the authoritative record of which collections a file touched or attempted
+to touch.
+
+**`FileIngestion.item` FK is dropped.** It was semantically wrong for GRIB/NetCDF files — the FK was
+overwritten on every item processed, ending up pointing to the last item written. For a GRIB file producing
+80 items, 79 items had no link at all. `Item.source_file` (indexed, value: `"{bucket}:{file_path}"`) provides
+the correct audit join for all formats. The collection items list view switches from
+`prefetch_related('file_ingestions')` to a bulk lookup keyed on `source_file`.
+
+**Collection Health Panel uses `FileIngestion.collections` M2M for both success and failure signals.**
+The sparkline is binary per-day pipeline health (success / failed / empty) — not volume counts. Both signals
+come from the same query shape against `FileIngestion.collections`, just filtered on `status`. Items are not
+used for dashboard queries; `Item.source_file` (indexed) is the audit trail for tracing which Items a
+FileIngestion produced.
+
+**Wizard validates no duplicate source_name across collections within a catalog.** For GRIB/NetCDF, collection
+resolution is unambiguous only if each `source_name` (raw variable name in the file) maps to exactly one
+collection per catalog. This invariant is enforced at wizard save time, not at the DB level (source names live
+in a StreamField, not a constrainable column).
+
+## Alternatives considered
+
+**DataArrival with a `collections` M2M** — rejected. The natural scope of an arrival event is the catalog
+(one physical file, one catalog), not the collections it affects. Collections are an output of processing.
+
+**One FileIngestion per (file × collection)** — rejected. Would change the lock granularity from file to
+(file, collection), reshaping sweep, retry, and FileIngestionJob linkage. The `collections` M2M achieves
+per-collection failure tracking without restructuring the lock model.
+
+**Keep `FileIngestion.collection_slug` char field, backfill after processing** — rejected. The char field
+is not a FK, cannot be queried with joins, and is only populated for the last collection processed (the
+service loop overwrites it per iteration). No help for failures that abort before any collection completes.
+
+**Use `FileIngestion.collection_slug` for dashboard sparklines** — rejected. The char field is empty for
+all GRIB/NetCDF files; no amount of backfilling fixes the fundamental mismatch. The `collections` M2M
+supersedes it and handles both formats uniformly.
+
+**`FileIngestion.item` FK (kept)** — rejected. Semantically wrong for multi-item files (last-write-wins);
+79 of 80 items from a GRIB file would have no link. `Item.source_file` supersedes it cleanly.
+
+## Consequences
+
+- `DataArrival` migration: drop `collection` FK, add `catalog` FK. Existing rows: derive catalog from
+  `collection.catalog` or `data_feed` where available.
+- `FileIngestion` migration: add `collections` M2M, drop `catalog_slug` / `collection_slug` char fields.
+- `FileIngestion.item` FK removed.
+- `Item.source_file`: add `db_index=True`. Convention: value is `"{bucket}:{file_path}"`, matching
+  `FileIngestion.bucket + FileIngestion.file_path` — the audit join for "all Items from this FileIngestion".
+- `IngestionService.process_file()`: write `FileIngestion.collections` immediately after `_resolve_collections()`.
+- Dashboard queries: replace `FileIngestion.collection_slug` lookups with Item and FileIngestion.collections queries.
+- Wizard step 4 save: validate no duplicate `source_name` across all collections in the catalog being configured.

--- a/georiva/src/georiva/core/migrations/0004_item_source_file_index.py
+++ b/georiva/src/georiva/core/migrations/0004_item_source_file_index.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("georivacore", "0003_add_default_units"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="item",
+            name="source_file",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="Original source file path",
+                max_length=500,
+            ),
+        ),
+    ]

--- a/georiva/src/georiva/core/models/item.py
+++ b/georiva/src/georiva/core/models/item.py
@@ -39,10 +39,12 @@ class Item(TimescaleModel, TimeStampedModel, ClusterableModel):
         help_text=_("When data was produced (model run time for forecasts)"),
     )
     
-    # Source tracking
+    # Source tracking — convention: "{bucket}:{file_path}" (matches
+    # FileIngestion.bucket + FileIngestion.file_path for the audit join).
     source_file = models.CharField(
         max_length=500,
         blank=True,
+        db_index=True,
         help_text=_("Original source file path"),
     )
     

--- a/georiva/src/georiva/ingestion/consumer.py
+++ b/georiva/src/georiva/ingestion/consumer.py
@@ -33,8 +33,8 @@ def _resolve_origin(bucket_name: str):
     return _get_ingest_buckets().get(bucket_name)
 
 
-def _catalog_exists(catalog_slug: str) -> bool:
-    return Catalog.objects.filter(slug=catalog_slug, is_active=True).exists()
+def _get_catalog(catalog_slug: str):
+    return Catalog.objects.filter(slug=catalog_slug, is_active=True).first()
 
 
 def _required_time_error(catalog_slug: str, key: str) -> str | None:
@@ -106,14 +106,16 @@ def _handle_event(ev: dict):
     
     catalog_slug = meta["catalog"]
     collection_slug = meta.get("collection")
-    
-    if not _catalog_exists(catalog_slug):
+
+    catalog = _get_catalog(catalog_slug)
+    if catalog is None:
         logger.warning("Unknown catalog '%s': %s", catalog_slug, key)
         return
-    
+
     arrival, arrival_created = DataArrival.find_or_create(
         file_path=key,
         trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+        catalog=catalog,
     )
     if not arrival_created and arrival.status == DataArrival.Status.UPLOADING:
         arrival.status = DataArrival.Status.PENDING
@@ -122,8 +124,6 @@ def _handle_event(ev: dict):
     log, created = FileIngestion.register(
         bucket=origin_bucket,
         file_path=key,
-        catalog_slug=catalog_slug,
-        collection_slug=collection_slug or "",
         reference_time=meta.get("reference_time"),
         data_arrival=arrival,
     )
@@ -132,7 +132,7 @@ def _handle_event(ev: dict):
     # have already validated times server-side (the date may have been entered
     # in the form rather than encoded in the filename).
     if arrival_created:
-        time_error = _required_time_error(catalog_slug, key)
+        time_error = _required_time_error(catalog.slug, key)
         if time_error:
             logger.warning("Time extraction failed for %s: %s", key, time_error)
             FileIngestion.mark_failed(origin_bucket, key, time_error)

--- a/georiva/src/georiva/ingestion/dashboard_views.py
+++ b/georiva/src/georiva/ingestion/dashboard_views.py
@@ -20,7 +20,7 @@ def ingestion_dashboard_api(request):
     from georiva.ingestion.models import DataArrival, FileIngestion
     from georiva.sources.models import DataFeedCollectionLink
 
-    collections = (
+    collections = list(
         Collection.objects
         .select_related("catalog")
         .filter(is_active=True)
@@ -34,40 +34,42 @@ def ingestion_dashboard_api(request):
     today = timezone.now().date()
     thirty_days_ago = today - timedelta(days=29)
 
+    # Sparkline data: one row per (FileIngestion × Collection) pair via M2M join.
     recent_logs = (
         FileIngestion.objects
         .filter(created_at__date__gte=thirty_days_ago)
-        .values("collection_slug", "catalog_slug", "status", "created_at")
+        .filter(collections__isnull=False)
+        .values("collections", "status", "created_at")
         .order_by("created_at")
     )
 
     logs_by_collection = defaultdict(list)
     for log in recent_logs:
-        key = (log["catalog_slug"], log["collection_slug"])
-        logs_by_collection[key].append(log)
+        logs_by_collection[log["collections"]].append(log)
 
-    latest_arrivals = {}
+    # Latest DataArrival per catalog (catalog-scoped, not collection-scoped).
+    catalog_ids = {c.catalog_id for c in collections}
+    latest_arrivals_by_catalog = {}
     for arrival in (
         DataArrival.objects
-        .filter(collection__in=collections)
-        .order_by("collection_id", "-started_at")
-        .distinct("collection_id")
+        .filter(catalog_id__in=catalog_ids)
+        .order_by("catalog_id", "-started_at")
+        .distinct("catalog_id")
     ):
-        latest_arrivals[arrival.collection_id] = arrival
+        latest_arrivals_by_catalog[arrival.catalog_id] = arrival
 
     result = []
 
     for collection in collections:
         is_automated = collection.pk in automated_collection_ids
-        key = (collection.catalog.slug, collection.slug)
-        logs = logs_by_collection.get(key, [])
+        logs = logs_by_collection.get(collection.pk, [])
 
         sparkline = _build_sparkline(logs, today)
 
         last_run_at = None
         last_run_status = None
 
-        arrival = latest_arrivals.get(collection.pk)
+        arrival = latest_arrivals_by_catalog.get(collection.catalog_id)
         if arrival:
             last_run_at = arrival.started_at.isoformat()
             last_run_status = arrival.status
@@ -110,7 +112,7 @@ def collection_data_arrivals_api(request, collection_id):
 
     arrivals = (
         DataArrival.objects
-        .filter(collection=collection)
+        .filter(catalog=collection.catalog)
         .order_by("-started_at")[:100]
     )
 
@@ -159,10 +161,7 @@ def collection_ingestion_jobs_api(request, collection_id):
     
     jobs = (
         FileIngestionJob.objects
-        .filter(
-            file_ingestion__catalog_slug=collection.catalog.slug,
-            file_ingestion__collection_slug=collection.slug,
-        )
+        .filter(file_ingestion__collections=collection)
         .annotate(
             _active=Case(
                 When(state__in=active_states, then=0),
@@ -180,6 +179,7 @@ def collection_ingestion_jobs_api(request, collection_id):
         state = job.get_cached_state()
         if state in active_states:
             has_active = True
+        fi = job.file_ingestion
         result.append({
             "id": job.pk,
             "state": state,
@@ -187,8 +187,8 @@ def collection_ingestion_jobs_api(request, collection_id):
             "progress_state": job.get_cached_progress_state(),
             "file_path": job.file_path,
             "bucket": job.bucket,
-            "items_created": job.items_created,
-            "assets_created": job.assets_created,
+            "items_created": fi.items_created if fi else job.items_created,
+            "assets_created": fi.assets_created if fi else job.assets_created,
             "error": job.error or "",
             "created_at": job.created_at.isoformat(),
             "updated_at": job.updated_at.isoformat(),
@@ -212,10 +212,7 @@ def collection_ingestion_logs_api(request, collection_id):
     
     logs = (
         FileIngestion.objects
-        .filter(
-            catalog_slug=collection.catalog.slug,
-            collection_slug=collection.slug,
-        )
+        .filter(collections=collection)
         .order_by("-created_at")[:200]
     )
     
@@ -292,15 +289,11 @@ def _build_sparkline(logs, today):
 def _derive_status(sparkline, last_run_status):
     if not any(s["status"] != "empty" for s in sparkline):
         return "empty"
-    
-    if last_run_status in ("completed", "success"):
-        return "ok"
-    
-    if last_run_status == "failed":
-        return "failed"
-    
-    recent = [s["status"] for s in sparkline[-3:]]
-    if all(s == "empty" for s in recent):
-        return "warning"
-    
-    return "ok"
+
+    for entry in reversed(sparkline):
+        if entry["status"] == "failed":
+            return "failed"
+        if entry["status"] == "success":
+            return "ok"
+
+    return "empty"

--- a/georiva/src/georiva/ingestion/dashboard_views.py
+++ b/georiva/src/georiva/ingestion/dashboard_views.py
@@ -74,7 +74,7 @@ def ingestion_dashboard_api(request):
             last_run_at = arrival.started_at.isoformat()
             last_run_status = arrival.status
 
-        status = _derive_status(sparkline, last_run_status)
+        status = _derive_status(sparkline)
 
         result.append({
             "id": collection.pk,
@@ -100,13 +100,16 @@ def ingestion_dashboard_api(request):
 
 def collection_data_arrivals_api(request, collection_id):
     """
-    Returns DataArrival history for one collection.
+    Returns DataArrival history for the catalog that owns this collection.
+
+    DataArrival is catalog-scoped (one arrival per catalog per fetch/upload),
+    so all collections in the same catalog share the same arrivals list.
     """
     from georiva.core.models import Collection
     from georiva.ingestion.models import DataArrival
 
     try:
-        collection = Collection.objects.get(pk=collection_id)
+        collection = Collection.objects.select_related("catalog").get(pk=collection_id)
     except Collection.DoesNotExist:
         raise Http404
 
@@ -286,14 +289,10 @@ def _build_sparkline(logs, today):
     return sparkline
 
 
-def _derive_status(sparkline, last_run_status):
-    if not any(s["status"] != "empty" for s in sparkline):
-        return "empty"
-
+def _derive_status(sparkline):
     for entry in reversed(sparkline):
         if entry["status"] == "failed":
             return "failed"
         if entry["status"] == "success":
             return "ok"
-
     return "empty"

--- a/georiva/src/georiva/ingestion/handlers/item_handler.py
+++ b/georiva/src/georiva/ingestion/handlers/item_handler.py
@@ -87,11 +87,6 @@ class ItemHandler:
             if update_fields:
                 item.save(update_fields=update_fields)
 
-        # Link the FileIngestion to the Item it produced.
-        if ingestion_log and ingestion_log.item_id != item.pk:
-            ingestion_log.item = item
-            ingestion_log.save(update_fields=["item_id"])
-
         return item, created
     
     def increment_collection_item_count(self, collection: Collection) -> None:

--- a/georiva/src/georiva/ingestion/migrations/0009_pipeline_tracking_model.py
+++ b/georiva/src/georiva/ingestion/migrations/0009_pipeline_tracking_model.py
@@ -2,6 +2,20 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
+def _backfill_catalog(apps, schema_editor):
+    """
+    Populate DataArrival.catalog from the old collection FK before it is dropped.
+    Rows without a collection (or whose collection has no catalog) are left NULL.
+    """
+    DataArrival = apps.get_model("georivaingestion", "DataArrival")
+    for arrival in DataArrival.objects.filter(collection__isnull=False).select_related(
+        "collection__catalog"
+    ):
+        if arrival.collection and arrival.collection.catalog_id:
+            arrival.catalog_id = arrival.collection.catalog_id
+            arrival.save(update_fields=["catalog_id"])
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -22,6 +36,8 @@ class Migration(migrations.Migration):
                 to="georivacore.catalog",
             ),
         ),
+        # Backfill catalog from the existing collection FK before it is dropped.
+        migrations.RunPython(_backfill_catalog, migrations.RunPython.noop),
         migrations.RemoveField(
             model_name="dataarrival",
             name="collection",

--- a/georiva/src/georiva/ingestion/migrations/0009_pipeline_tracking_model.py
+++ b/georiva/src/georiva/ingestion/migrations/0009_pipeline_tracking_model.py
@@ -1,0 +1,56 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("georivaingestion", "0008_fileingestionjob_file_ingestion_fk"),
+        ("georivacore", "0001_initial"),
+    ]
+
+    operations = [
+        # DataArrival: swap collection FK for catalog FK
+        migrations.AddField(
+            model_name="dataarrival",
+            name="catalog",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="data_arrivals",
+                to="georivacore.catalog",
+            ),
+        ),
+        migrations.RemoveField(
+            model_name="dataarrival",
+            name="collection",
+        ),
+
+        # FileIngestion: add collections M2M
+        migrations.AddField(
+            model_name="fileingestion",
+            name="collections",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="file_ingestions",
+                to="georivacore.collection",
+            ),
+        ),
+
+        # FileIngestion: remove item FK
+        migrations.RemoveField(
+            model_name="fileingestion",
+            name="item",
+        ),
+
+        # FileIngestion: remove catalog_slug and collection_slug char fields
+        migrations.RemoveField(
+            model_name="fileingestion",
+            name="catalog_slug",
+        ),
+        migrations.RemoveField(
+            model_name="fileingestion",
+            name="collection_slug",
+        ),
+    ]

--- a/georiva/src/georiva/ingestion/models.py
+++ b/georiva/src/georiva/ingestion/models.py
@@ -52,8 +52,8 @@ class DataArrival(models.Model):
         on_delete=models.SET_NULL,
         related_name='arrivals',
     )
-    collection = models.ForeignKey(
-        'georivacore.Collection',
+    catalog = models.ForeignKey(
+        'georivacore.Catalog',
         null=True, blank=True,
         on_delete=models.SET_NULL,
         related_name='data_arrivals',
@@ -161,11 +161,21 @@ class FileIngestion(models.Model):
     error = models.TextField(blank=True, default='')
     
     # =========================================================================
+    # Collections M2M — populated after _resolve_collections() succeeds,
+    # before per-collection processing begins. Authoritative record of which
+    # collections a file touched or attempted to touch.
+    # =========================================================================
+
+    collections = models.ManyToManyField(
+        'georivacore.Collection',
+        blank=True,
+        related_name='file_ingestions',
+    )
+
+    # =========================================================================
     # Metadata
     # =========================================================================
-    
-    catalog_slug = models.CharField(max_length=100, blank=True, default='')
-    collection_slug = models.CharField(max_length=100, blank=True, null=True, default='')
+
     reference_time = models.DateTimeField(null=True, blank=True)
     file_size = models.BigIntegerField(null=True, blank=True)
     
@@ -180,21 +190,6 @@ class FileIngestion(models.Model):
         default=False
     )
     
-    # db_constraint=False: TimescaleDB does not support FK constraints pointing
-    # to hypertables. Django still handles on_delete at the ORM level.
-    # SET_NULL, not CASCADE: this is the lock/audit record for the file — it
-    # must survive Item deletion (e.g. ItemHandler.delete_orphan() removing an
-    # empty Item mid-run would otherwise cascade-delete it and break every
-    # subsequent ingestion_log.save() in the same run).
-    item = models.ForeignKey(
-        'georivacore.Item',
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
-        related_name='file_ingestions',
-        db_constraint=False,
-    )
-
     data_arrival = models.ForeignKey(
         DataArrival,
         on_delete=models.CASCADE,
@@ -264,7 +259,7 @@ class FileIngestion(models.Model):
         Register a file in the log. Returns (log, created).
 
         If the file is already registered, returns the existing record.
-        Extra kwargs are passed to defaults (catalog_slug, reference_time, etc).
+        Extra kwargs are passed to defaults (reference_time, data_arrival, etc).
         """
         defaults = {
             'status': cls.Status.PENDING,
@@ -446,18 +441,9 @@ class FileIngestion(models.Model):
         A completed log with no live items means data was lost — re-ingest.
         """
         from georiva.core.models import Item
-        
+
         source_file = f"{self.bucket}:{self.file_path}"
-        
-        qs = Item.objects.filter(
-            collection__catalog__slug=self.catalog_slug,
-            source_file__contains=source_file,
-        )
-        
-        if self.collection_slug:
-            qs = qs.filter(collection__slug=self.collection_slug)
-        
-        return qs.exists()
+        return Item.objects.filter(source_file=source_file).exists()
     
     @classmethod
     def reset_for_reingest(cls, bucket: str, file_path: str) -> bool:

--- a/georiva/src/georiva/ingestion/service.py
+++ b/georiva/src/georiva/ingestion/service.py
@@ -181,7 +181,12 @@ class IngestionService:
             ingestion_log = FileIngestion.objects.filter(
                 bucket=origin_bucket, file_path=file_path
             ).first()
-            
+
+            # Write resolved collections immediately — even a run that fails
+            # before creating any Items remains collection-trackable.
+            if ingestion_log:
+                ingestion_log.collections.set(collections)
+
             # ── Build shared context + handler ────────────────────────────────
             ctx = IngestionContext(
                 plugin=plugin,

--- a/georiva/src/georiva/ingestion/signals.py
+++ b/georiva/src/georiva/ingestion/signals.py
@@ -6,13 +6,11 @@ from django.dispatch import receiver
 def _data_arrival_post_save(sender, instance, created, update_fields, **kwargs):
     from georiva.ingestion.events import publish_event
     if created:
-        collection_name = None
         catalog_name = None
         try:
-            if instance.collection_id:
-                col = instance.collection
-                collection_name = col.name if col else None
-                catalog_name = col.catalog.name if col and col.catalog_id else None
+            if instance.catalog_id:
+                catalog = instance.catalog
+                catalog_name = catalog.name if catalog else None
         except Exception:
             pass
         publish_event({
@@ -22,7 +20,7 @@ def _data_arrival_post_save(sender, instance, created, update_fields, **kwargs):
             "status": instance.status,
             "file_path": instance.file_path,
             "started_at": instance.started_at.isoformat() if instance.started_at else None,
-            "collection_name": collection_name,
+            "collection_name": None,
             "catalog_name": catalog_name,
             "file_ingestions": [],
         })

--- a/georiva/src/georiva/ingestion/snapshot.py
+++ b/georiva/src/georiva/ingestion/snapshot.py
@@ -1,4 +1,5 @@
 from asgiref.sync import sync_to_async
+from django.db.models import Prefetch
 
 TERMINAL_STATUSES = frozenset(["completed", "failed", "partial", "empty"])
 
@@ -6,7 +7,9 @@ TERMINAL_STATUSES = frozenset(["completed", "failed", "partial", "empty"])
 def _build_arrival_dict(arrival) -> dict:
     file_ingestions = []
     for fi in arrival.file_ingestions.all():
-        latest_job = fi.jobs.order_by("-created_at").first()
+        # jobs are pre-sorted by the Prefetch in _fetch_arrivals; no extra query.
+        all_jobs = fi.jobs.all()
+        latest_job = all_jobs[0] if all_jobs else None
         file_ingestions.append({
             "id": fi.pk,
             "status": fi.status,
@@ -31,10 +34,17 @@ def _build_arrival_dict(arrival) -> dict:
 def _fetch_arrivals(terminal_limit: int) -> list[dict]:
     from georiva.ingestion.models import DataArrival
 
+    from georiva.ingestion.models import FileIngestionJob
+
     base = (
         DataArrival.objects
         .select_related("catalog")
-        .prefetch_related("file_ingestions__jobs")
+        .prefetch_related(
+            Prefetch(
+                "file_ingestions__jobs",
+                queryset=FileIngestionJob.objects.order_by("-created_at"),
+            )
+        )
     )
     # All active arrivals (no cap — operator needs to see everything in flight).
     active = list(base.exclude(status__in=TERMINAL_STATUSES).order_by("-created_at"))

--- a/georiva/src/georiva/ingestion/snapshot.py
+++ b/georiva/src/georiva/ingestion/snapshot.py
@@ -13,14 +13,14 @@ def _build_arrival_dict(arrival) -> dict:
             "job_id": latest_job.pk if latest_job else None,
             "job_state": latest_job.state if latest_job else None,
         })
-    collection = arrival.collection
+    catalog = arrival.catalog
     return {
         "id": arrival.pk,
         "status": arrival.status,
         "trigger": arrival.trigger,
         "file_path": arrival.file_path,
-        "collection_name": collection.name if collection else None,
-        "catalog_name": collection.catalog.name if collection else None,
+        "collection_name": None,
+        "catalog_name": catalog.name if catalog else None,
         "started_at": arrival.started_at.isoformat(),
         "finished_at": arrival.finished_at.isoformat() if arrival.finished_at else None,
         "file_ingestions": file_ingestions,
@@ -33,7 +33,7 @@ def _fetch_arrivals(terminal_limit: int) -> list[dict]:
 
     base = (
         DataArrival.objects
-        .select_related("collection__catalog")
+        .select_related("catalog")
         .prefetch_related("file_ingestions__jobs")
     )
     # All active arrivals (no cap — operator needs to see everything in flight).

--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -153,8 +153,6 @@ def sweep_unprocessed(sync: bool = False):
             FileIngestion.register(
                 bucket=bucket_type,
                 file_path=path,
-                catalog_slug=meta.get('catalog', ''),
-                collection_slug=meta.get('collection', ''),
                 reference_time=meta.get('reference_time'),
             )
             

--- a/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
+++ b/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
@@ -1,4 +1,3 @@
-import json
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
@@ -24,6 +23,25 @@ def _setup_collection(catalog_slug="cat", collection_slug="col"):
     return Collection.objects.create(name=collection_slug, slug=collection_slug, catalog=catalog)
 
 
+def _make_arrival(catalog, trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+                  status=DataArrival.Status.COMPLETED, **kwargs):
+    return DataArrival.objects.create(trigger=trigger, status=status, catalog=catalog, **kwargs)
+
+
+def _make_file_ingestion(collection, file_path=None, status=FileIngestion.Status.COMPLETED,
+                         **kwargs):
+    arrival = _make_arrival(collection.catalog)
+    fi = FileIngestion.objects.create(
+        bucket=BucketType.SOURCES,
+        file_path=file_path or f"{collection.catalog.slug}/{collection.slug}/file.grib2",
+        status=status,
+        data_arrival=arrival,
+        **kwargs,
+    )
+    fi.collections.add(collection)
+    return fi
+
+
 class DashboardLastRunFromDataArrivalTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_superuser("admin", "admin@test.com", "pw")
@@ -31,10 +49,9 @@ class DashboardLastRunFromDataArrivalTests(TestCase):
         self.collection = _setup_collection()
 
     def test_dashboard_returns_last_run_at_from_data_arrival(self):
-        arrival = DataArrival.objects.create(
-            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+        arrival = _make_arrival(
+            self.collection.catalog,
             status=DataArrival.Status.COMPLETED,
-            collection=self.collection,
         )
 
         response = self.client.get(DASHBOARD_URL)
@@ -50,16 +67,10 @@ class DashboardLastRunFromDataArrivalTests(TestCase):
         manual_col = _setup_collection("cat-m", "col-m")
         scheduled_col = _setup_collection("cat-s", "col-s")
 
-        DataArrival.objects.create(
-            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
-            status=DataArrival.Status.COMPLETED,
-            collection=manual_col,
-        )
-        DataArrival.objects.create(
-            trigger=DataArrival.Trigger.SCHEDULED,
-            status=DataArrival.Status.COMPLETED,
-            collection=scheduled_col,
-        )
+        _make_arrival(manual_col.catalog, trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+                      status=DataArrival.Status.COMPLETED)
+        _make_arrival(scheduled_col.catalog, trigger=DataArrival.Trigger.SCHEDULED,
+                      status=DataArrival.Status.COMPLETED)
 
         response = self.client.get(DASHBOARD_URL)
         data = response.json()
@@ -68,9 +79,7 @@ class DashboardLastRunFromDataArrivalTests(TestCase):
         manual_entry = by_id[manual_col.pk]
         scheduled_entry = by_id[scheduled_col.pk]
 
-        # Both have the same keys
         self.assertEqual(set(manual_entry.keys()), set(scheduled_entry.keys()))
-        # Both have last_run_at populated
         self.assertIsNotNone(manual_entry["last_run_at"])
         self.assertIsNotNone(scheduled_entry["last_run_at"])
 
@@ -107,43 +116,83 @@ class DashboardLastRunFromDataArrivalTests(TestCase):
         col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
         self.assertEqual(col["status"], "empty")
 
-    def test_derived_status_is_ok_when_last_arrival_completed(self):
-        arrival = DataArrival.objects.create(
-            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
-            status=DataArrival.Status.COMPLETED,
-            collection=self.collection,
-        )
-        FileIngestion.objects.create(
-            bucket=BucketType.SOURCES,
-            file_path="cat/col/f.grib2",
-            catalog_slug="cat",
-            collection_slug="col",
-            status=FileIngestion.Status.COMPLETED,
-            data_arrival=arrival,
-        )
+    def test_derived_status_is_ok_when_completed_file_ingestion_linked_via_m2m(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
 
         response = self.client.get(DASHBOARD_URL)
         col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
         self.assertEqual(col["status"], "ok")
 
-    def test_derived_status_is_failed_when_last_arrival_failed(self):
-        arrival = DataArrival.objects.create(
-            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
-            status=DataArrival.Status.FAILED,
-            collection=self.collection,
-        )
-        FileIngestion.objects.create(
-            bucket=BucketType.SOURCES,
-            file_path="cat/col/f2.grib2",
-            catalog_slug="cat",
-            collection_slug="col",
-            status=FileIngestion.Status.FAILED,
-            data_arrival=arrival,
-        )
+    def test_derived_status_is_failed_when_failed_file_ingestion_linked_via_m2m(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.FAILED)
 
         response = self.client.get(DASHBOARD_URL)
         col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
         self.assertEqual(col["status"], "failed")
+
+    def test_grib_collection_shows_success_sparkline_via_m2m(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
+
+        response = self.client.get(DASHBOARD_URL)
+        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        today_entry = col["sparkline"][-1]
+        self.assertEqual(today_entry["status"], "success")
+
+    def test_grib_collection_shows_failed_sparkline_when_no_items_created(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.FAILED)
+
+        response = self.client.get(DASHBOARD_URL)
+        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        today_entry = col["sparkline"][-1]
+        self.assertEqual(today_entry["status"], "failed")
+
+    def test_multi_collection_grib_independent_sparkline_statuses(self):
+        """A single GRIB file serving two collections shows each collection's own status."""
+        catalog = Catalog.objects.create(name="shared-cat", slug="shared-cat", file_format="grib2")
+        col_a = Collection.objects.create(name="col-a", slug="col-a", catalog=catalog)
+        col_b = Collection.objects.create(name="col-b", slug="col-b", catalog=catalog)
+
+        arrival = _make_arrival(catalog)
+
+        fi_a = FileIngestion.objects.create(
+            bucket=BucketType.SOURCES,
+            file_path="shared-cat/col-a/file.grib2",
+            status=FileIngestion.Status.COMPLETED,
+            data_arrival=arrival,
+        )
+        fi_a.collections.add(col_a)
+
+        fi_b = FileIngestion.objects.create(
+            bucket=BucketType.SOURCES,
+            file_path="shared-cat/col-b/file.grib2",
+            status=FileIngestion.Status.FAILED,
+            data_arrival=arrival,
+        )
+        fi_b.collections.add(col_b)
+
+        response = self.client.get(DASHBOARD_URL)
+        by_id = {c["id"]: c for c in response.json()["collections"]}
+
+        self.assertEqual(by_id[col_a.pk]["sparkline"][-1]["status"], "success")
+        self.assertEqual(by_id[col_b.pk]["sparkline"][-1]["status"], "failed")
+
+    def test_last_run_at_comes_from_most_recent_catalog_arrival(self):
+        """last_run_at is the most recent DataArrival for the collection's catalog."""
+        older = _make_arrival(
+            self.collection.catalog,
+            status=DataArrival.Status.COMPLETED,
+            started_at=timezone.now() - timedelta(days=2),
+        )
+        newer = _make_arrival(
+            self.collection.catalog,
+            status=DataArrival.Status.FAILED,
+        )
+
+        response = self.client.get(DASHBOARD_URL)
+        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+
+        self.assertEqual(col["last_run_at"], newer.started_at.isoformat())
+        self.assertEqual(col["last_run_status"], DataArrival.Status.FAILED)
 
 
 class CollectionArrivalsAPITests(TestCase):
@@ -153,10 +202,10 @@ class CollectionArrivalsAPITests(TestCase):
         self.collection = _setup_collection("cat2", "col2")
 
     def test_arrivals_endpoint_returns_data_arrival_history(self):
-        DataArrival.objects.create(
+        _make_arrival(
+            self.collection.catalog,
             trigger=DataArrival.Trigger.SCHEDULED,
             status=DataArrival.Status.COMPLETED,
-            collection=self.collection,
             files_fetched=3,
             bytes_transferred=1024,
         )
@@ -187,10 +236,10 @@ class CollectionArrivalsAPITests(TestCase):
     def test_arrivals_duration_seconds_computed_from_started_and_finished_at(self):
         started = timezone.now()
         finished = started + timedelta(seconds=90)
-        DataArrival.objects.create(
+        _make_arrival(
+            self.collection.catalog,
             trigger=DataArrival.Trigger.SCHEDULED,
             status=DataArrival.Status.COMPLETED,
-            collection=self.collection,
             started_at=started,
             finished_at=finished,
         )
@@ -200,15 +249,23 @@ class CollectionArrivalsAPITests(TestCase):
         self.assertEqual(entry["duration_seconds"], 90.0)
 
     def test_arrivals_duration_seconds_is_null_when_not_finished(self):
-        DataArrival.objects.create(
+        _make_arrival(
+            self.collection.catalog,
             trigger=DataArrival.Trigger.MANUAL_UPLOAD,
             status=DataArrival.Status.PROCESSING,
-            collection=self.collection,
         )
 
         response = self.client.get(ARRIVALS_URL.format(self.collection.pk))
         entry = response.json()["arrivals"][0]
         self.assertIsNone(entry["duration_seconds"])
+
+    def test_arrivals_from_different_catalog_not_included(self):
+        other_collection = _setup_collection("other-cat", "other-col")
+        _make_arrival(other_collection.catalog)
+
+        response = self.client.get(ARRIVALS_URL.format(self.collection.pk))
+        data = response.json()
+        self.assertEqual(data["arrivals"], [])
 
 
 class CollectionIngestionLogsAPITests(TestCase):
@@ -218,16 +275,11 @@ class CollectionIngestionLogsAPITests(TestCase):
         self.collection = _setup_collection("cat3", "col3")
 
     def test_ingestion_logs_returns_file_ingestion_history(self):
-        arrival = DataArrival.objects.create(trigger=DataArrival.Trigger.MANUAL_UPLOAD)
-        FileIngestion.objects.create(
-            bucket=BucketType.SOURCES,
-            file_path="cat3/col3/file.grib2",
-            catalog_slug="cat3",
-            collection_slug="col3",
+        _make_file_ingestion(
+            self.collection,
             status=FileIngestion.Status.COMPLETED,
             items_created=2,
             assets_created=4,
-            data_arrival=arrival,
         )
 
         response = self.client.get(LOGS_URL.format(self.collection.pk))
@@ -239,11 +291,18 @@ class CollectionIngestionLogsAPITests(TestCase):
 
         entry = data["logs"][0]
         self.assertEqual(entry["status"], FileIngestion.Status.COMPLETED)
-        self.assertEqual(entry["file_path"], "cat3/col3/file.grib2")
         self.assertEqual(entry["items_created"], 2)
         self.assertEqual(entry["assets_created"], 4)
 
-    def test_ingestion_logs_returns_empty_list_when_no_logs(self):
+    def test_ingestion_logs_returns_empty_list_when_no_m2m_link(self):
+        # FileIngestion exists but is not linked to this collection
+        arrival = _make_arrival(self.collection.catalog)
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES,
+            file_path="cat3/col3/unlinked.grib2",
+            data_arrival=arrival,
+        )
+
         response = self.client.get(LOGS_URL.format(self.collection.pk))
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -253,16 +312,26 @@ class CollectionIngestionLogsAPITests(TestCase):
         response = self.client.get(LOGS_URL.format(99999))
         self.assertEqual(response.status_code, 404)
 
+    def test_ingestion_logs_for_grib_collection_linked_via_m2m(self):
+        """GRIB produces items for multiple collections; each collection only sees its own logs."""
+        catalog = Catalog.objects.create(name="grib-cat", slug="grib-cat", file_format="grib2")
+        col_x = Collection.objects.create(name="col-x", slug="col-x", catalog=catalog)
+        col_y = Collection.objects.create(name="col-y", slug="col-y", catalog=catalog)
 
-def _make_file_ingestion(catalog_slug, collection_slug, file_path=None):
-    arrival = DataArrival.objects.create(trigger=DataArrival.Trigger.MANUAL_UPLOAD)
-    return FileIngestion.objects.create(
-        bucket=BucketType.SOURCES,
-        file_path=file_path or f"{catalog_slug}/{collection_slug}/file.grib2",
-        catalog_slug=catalog_slug,
-        collection_slug=collection_slug,
-        data_arrival=arrival,
-    )
+        arrival = _make_arrival(catalog)
+        fi = FileIngestion.objects.create(
+            bucket=BucketType.SOURCES,
+            file_path="grib-cat/multi.grib2",
+            status=FileIngestion.Status.COMPLETED,
+            data_arrival=arrival,
+        )
+        fi.collections.set([col_x, col_y])
+
+        resp_x = self.client.get(LOGS_URL.format(col_x.pk))
+        resp_y = self.client.get(LOGS_URL.format(col_y.pk))
+
+        self.assertEqual(len(resp_x.json()["logs"]), 1)
+        self.assertEqual(len(resp_y.json()["logs"]), 1)
 
 
 def _make_job(fi, **kwargs):
@@ -283,8 +352,8 @@ class CollectionIngestionJobsAPITests(TestCase):
         self.collection = _setup_collection("cat4", "col4")
 
     def test_ingestion_jobs_returns_job_history(self):
-        fi = _make_file_ingestion("cat4", "col4")
-        _make_job(fi, items_created=1, assets_created=2)
+        fi = _make_file_ingestion(self.collection, items_created=1, assets_created=2)
+        _make_job(fi)
 
         response = self.client.get(JOBS_URL.format(self.collection.pk))
         self.assertEqual(response.status_code, 200)
@@ -300,15 +369,16 @@ class CollectionIngestionJobsAPITests(TestCase):
         self.assertEqual(entry["assets_created"], 2)
 
     def test_has_active_true_when_job_is_pending(self):
-        fi = _make_file_ingestion("cat4", "col4", "cat4/col4/pending.grib2")
-        _make_job(fi)  # default state is "pending"
+        fi = _make_file_ingestion(self.collection,
+                                   file_path="cat4/col4/pending.grib2")
+        _make_job(fi)
 
         response = self.client.get(JOBS_URL.format(self.collection.pk))
         data = response.json()
         self.assertTrue(data["has_active"])
 
     def test_has_active_false_when_all_jobs_finished(self):
-        fi = _make_file_ingestion("cat4", "col4", "cat4/col4/done.grib2")
+        fi = _make_file_ingestion(self.collection, file_path="cat4/col4/done.grib2")
         _make_job(fi, state="finished")
 
         response = self.client.get(JOBS_URL.format(self.collection.pk))

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
@@ -114,8 +114,6 @@ class FileIngestionStatusEventTests(IngestionEventsTestCase):
         fi, _ = FileIngestion.register(
             bucket="incoming",
             file_path="catalog/somefile.grib2",
-            catalog_slug="catalog",
-            collection_slug="",
             data_arrival=arrival,
         )
         return fi

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_models.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_models.py
@@ -4,7 +4,7 @@ import pytz
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from georiva.core.models import Catalog, Collection, Item
+from georiva.core.models import Catalog, Collection
 from georiva.ingestion.handlers.item_handler import ItemHandler
 from georiva.ingestion.models import DataArrival, FileIngestion, FileIngestionJob
 
@@ -22,7 +22,6 @@ def _setup():
     log, _ = FileIngestion.register(
         bucket="incoming",
         file_path="wrf/file.nc",
-        catalog_slug="wrf",
         data_arrival=arrival,
     )
     return collection, log
@@ -30,27 +29,14 @@ def _setup():
 
 class FileIngestionItemLinkTests(TestCase):
     """
-    Deleting an Item must never delete the FileIngestion lock/audit record.
+    ItemHandler.delete_orphan() must not break subsequent timestamps.
 
-    Regression: FileIngestion.item was on_delete=CASCADE, so
-    ItemHandler.delete_orphan() (run when a timestamp produced no assets)
-    cascade-deleted the FileIngestion mid-run, and every subsequent
-    timestamp failed with 'Save with update_fields did not affect any rows.'
+    Regression: FileIngestion.item was on_delete=CASCADE; deleting an orphan
+    Item mid-run cascade-deleted the FileIngestion record, causing every
+    subsequent save() to fail. The item FK has since been removed — Items are
+    now linked via Item.source_file. This test verifies that delete_orphan()
+    is safe and that the next timestamp can still create an Item.
     """
-
-    def test_item_delete_nulls_link_instead_of_cascading(self):
-        collection, log = _setup()
-        item = Item.objects.create(
-            collection=collection,
-            time=pytz.utc.localize(datetime(2023, 7, 1, 6)),
-        )
-        log.item = item
-        log.save(update_fields=["item"])
-
-        item.delete()
-
-        log.refresh_from_db()
-        self.assertIsNone(log.item)
 
     def test_orphan_deletion_does_not_break_next_timestamp(self):
         collection, log = _setup()
@@ -66,20 +52,19 @@ class FileIngestionItemLinkTests(TestCase):
             crs="EPSG:4326",
         )
 
-        # Timestamp 1: item created and linked, then all variables fail
-        # and the orphan item is deleted.
+        # Timestamp 1: item created, then all variables fail and orphan is deleted.
         item1, _ = handler.get_or_create(
             timestamp=pytz.utc.localize(datetime(2023, 7, 1, 6)), **kwargs
         )
         handler.delete_orphan(item1)
 
-        # Timestamp 2 must still be able to link the same FileIngestion.
+        # Timestamp 2 must still succeed — FileIngestion must still exist.
         item2, created = handler.get_or_create(
             timestamp=pytz.utc.localize(datetime(2023, 7, 2, 6)), **kwargs
         )
         self.assertTrue(created)
         log.refresh_from_db()
-        self.assertEqual(log.item_id, item2.pk)
+        self.assertEqual(log.status, FileIngestion.Status.PENDING)
 
 
 class FileIngestionJobLinkTests(TestCase):

--- a/georiva/src/georiva/ingestion/tests/test_upload_page.py
+++ b/georiva/src/georiva/ingestion/tests/test_upload_page.py
@@ -146,7 +146,7 @@ class UploadSubmitTests(TestCase):
     def test_geotiff_submit_success_full_transition(self, mock_incoming, mock_task):
         bucket = _mock_incoming_bucket()
         mock_incoming.return_value = bucket
-        _, collection, config, variable = _geotiff_setup()
+        catalog, collection, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
             "variable_id": variable.pk,
@@ -162,7 +162,7 @@ class UploadSubmitTests(TestCase):
         self.assertEqual(arrival.trigger, DataArrival.Trigger.MANUAL_UPLOAD)
         self.assertEqual(arrival.status, DataArrival.Status.PENDING)
         self.assertEqual(arrival.file_path, expected_path)
-        self.assertEqual(arrival.collection, collection)
+        self.assertEqual(arrival.catalog, catalog)
         self.assertEqual(arrival.files_fetched, 1)
 
         bucket.save.assert_called_once()
@@ -170,8 +170,6 @@ class UploadSubmitTests(TestCase):
 
         fi = FileIngestion.objects.get(file_path=expected_path)
         self.assertEqual(fi.bucket, "incoming")
-        self.assertEqual(fi.catalog_slug, "imagery")
-        self.assertEqual(fi.collection_slug, "ndvi")
         self.assertEqual(fi.data_arrival, arrival)
 
         call_kwargs = mock_task.delay.call_args.kwargs
@@ -207,7 +205,7 @@ class UploadSubmitTests(TestCase):
         self.assertEqual(response.status_code, 200)
         arrival = DataArrival.objects.get(pk=response.json()["data_arrival_id"])
         self.assertEqual(arrival.file_path, "models/GR--20250115T0600--gfs.grib2")
-        self.assertIsNone(arrival.collection)
+        self.assertIsNotNone(arrival.catalog)
 
         mock_task.delay.assert_called_once()
         self.assertEqual(
@@ -274,7 +272,6 @@ class UploadSubmitTests(TestCase):
         spent, _ = FileIngestion.register(
             bucket="incoming",
             file_path="imagery/ndvi/band_1/2025/01/15/20250115.tif",
-            catalog_slug="imagery",
             data_arrival=old_arrival,
         )
         FileIngestion.objects.filter(pk=spent.pk).update(

--- a/georiva/src/georiva/ingestion/upload_views.py
+++ b/georiva/src/georiva/ingestion/upload_views.py
@@ -211,7 +211,7 @@ def manual_upload_submit(request, pk):
         trigger=DataArrival.Trigger.MANUAL_UPLOAD,
         status=DataArrival.Status.UPLOADING,
         file_path=file_path,
-        collection=variable.collection if is_geotiff else None,
+        catalog=config.catalog,
         files_requested=1,
     )
 
@@ -245,8 +245,6 @@ def manual_upload_submit(request, pk):
     log, created = FileIngestion.register(
         bucket=BucketType.INCOMING,
         file_path=saved_path,
-        catalog_slug=config.catalog.slug,
-        collection_slug=variable.collection.slug if is_geotiff else "",
         reference_time=reference_time,
         data_arrival=arrival,
     )

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -207,7 +207,7 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
             trigger=DataArrival.Trigger.SCHEDULED,
             status=_status_map.get(result.status, DataArrival.Status.PENDING),
             data_feed=self,
-            collection=collection,
+            catalog=collection.catalog,
             files_requested=result.files_requested,
             files_fetched=result.files_fetched,
             files_skipped=result.files_skipped,

--- a/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
+++ b/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
@@ -43,7 +43,7 @@ class RecordRunCreatesDataArrivalTests(TestCase):
         self.assertEqual(arrival.files_skipped, 1)
         self.assertEqual(arrival.files_failed, 0)
         self.assertEqual(arrival.bytes_transferred, 2048)
-        self.assertEqual(arrival.collection, self.collection)
+        self.assertEqual(arrival.catalog, self.collection.catalog)
 
     def test_record_run_links_file_ingestions_to_arrival(self):
         paths = [
@@ -55,8 +55,6 @@ class RecordRunCreatesDataArrivalTests(TestCase):
             FileIngestion.objects.create(
                 bucket=BucketType.SOURCES,
                 file_path=path,
-                catalog_slug="test-cat",
-                collection_slug="test-col",
                 data_arrival=preliminary,
             )
 


### PR DESCRIPTION
## Summary

- **`DataArrival` is now catalog-scoped**: replaces the `collection` FK with a `catalog` FK. One physical file always belongs to one catalog; which collections it touches is an output of processing, not an arrival property.
- **`FileIngestion.collections` M2M**: written immediately after `_resolve_collections()` succeeds (before the per-collection loop), so failed runs are still collection-trackable even when no Items are created. Supersedes the dropped `catalog_slug`/`collection_slug` char fields.
- **`FileIngestion.item` FK removed**: was semantically wrong for GRIB/NetCDF multi-item files (last-write-wins; 79 of 80 items had no link). `Item.source_file` (now indexed) is the correct audit join for all formats.
- **Dashboard queries rewritten**: all four dashboard APIs now use the `FileIngestion.collections` M2M and `DataArrival.catalog` FK — making GRIB/NetCDF multi-collection health tracking correct for the first time.
- **ADR added**: `docs/adr/0002-pipeline-tracking-model.md` documents the decision and alternatives considered.

## Migrations

- `georivaingestion/0009_pipeline_tracking_model` — adds `catalog` FK and `collections` M2M to the arrival/ingestion models; drops the old FK and char fields
- `georivacore/0004_item_source_file_index` — adds `db_index=True` to `Item.source_file`

## Test plan

- [ ] `make dev-test TEST_ARGS="georiva.ingestion"` — 209 tests pass
- [ ] `make dev-test TEST_ARGS="georiva.sources"` — 2 tests pass
- [ ] `make dev-test TEST_ARGS="georiva.core"` — passes
- [ ] Collection Health Panel sparklines show correct per-collection status for GRIB catalogs (manual verification)
- [ ] Manual upload for a GeoTIFF creates a `DataArrival` with `catalog` set (not `collection`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)