### PR TITLE
fix(core): collection items list ingestion badge via source_file bulk lookup

### DIFF
--- a/georiva/src/georiva/core/templates/core/collection_items.html
+++ b/georiva/src/georiva/core/templates/core/collection_items.html
@@ -454,7 +454,7 @@
                     </td>
 
                     <td class="w-text-14">
-                        {% with log=item.prefetched_logs|first %}
+                        {% with log=item.ingestion_log %}
                             {% if log %}
                                 {% if log.status == 'completed' %}
                                     <span class="w-status-tag w-status-tag--primary ci-log-tag">

--- a/georiva/src/georiva/core/tests.py
+++ b/georiva/src/georiva/core/tests.py
@@ -1,3 +1,91 @@
-from django.test import TestCase
+from datetime import datetime, timezone
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from georiva.core.models import Catalog, Collection, Item
+from georiva.ingestion.models import DataArrival, FileIngestion
+
+User = get_user_model()
+
+
+def _setup():
+    catalog = Catalog.objects.create(name="Models", slug="models", file_format="grib2")
+    collection = Collection.objects.create(catalog=catalog, name="Surface", slug="surface")
+    return catalog, collection
+
+
+def _make_arrival(catalog):
+    return DataArrival.objects.create(
+        trigger=DataArrival.Trigger.MANUAL_UPLOAD,
+        catalog=catalog,
+    )
+
+
+def _make_item(collection, source_file, t=None):
+    if t is None:
+        t = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return Item.objects.create(collection=collection, time=t, source_file=source_file)
+
+
+def _make_fi(bucket, file_path, status, arrival, error=""):
+    fi = FileIngestion.objects.create(
+        bucket=bucket,
+        file_path=file_path,
+        status=status,
+        data_arrival=arrival,
+        error=error,
+    )
+    return fi
+
+
+class CollectionItemsIngestionBadgeTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_ci", "ci@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog, self.collection = _setup()
+        self.url = reverse("collection_items_list", args=[self.collection.pk])
+
+    def test_completed_ingestion_shows_completed_badge(self):
+        arrival = _make_arrival(self.catalog)
+        _make_item(self.collection, "mybucket:models/surface/file.grib")
+        _make_fi("mybucket", "models/surface/file.grib", FileIngestion.Status.COMPLETED, arrival)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "w-status-tag--primary")
+
+    def test_failed_ingestion_shows_failed_badge_with_error(self):
+        arrival = _make_arrival(self.catalog)
+        _make_item(self.collection, "mybucket:models/surface/failed.grib")
+        _make_fi(
+            "mybucket", "models/surface/failed.grib",
+            FileIngestion.Status.FAILED, arrival, error="Decoding error",
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "w-status-tag--critical")
+        self.assertContains(response, "Decoding error")
+
+    def test_item_with_no_ingestion_shows_dash(self):
+        _make_item(self.collection, "")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "w-text-grey-400")
+
+    def test_multiple_items_from_same_source_file_all_show_status(self):
+        arrival = _make_arrival(self.catalog)
+        _make_item(self.collection, "mybucket:models/surface/multi.grib", t=datetime(2024, 1, 1, tzinfo=timezone.utc))
+        _make_item(self.collection, "mybucket:models/surface/multi.grib", t=datetime(2024, 1, 2, tzinfo=timezone.utc))
+        _make_fi("mybucket", "models/surface/multi.grib", FileIngestion.Status.COMPLETED, arrival)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode().count("w-status-tag--primary ci-log-tag"), 2)

--- a/georiva/src/georiva/core/views.py
+++ b/georiva/src/georiva/core/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.core.paginator import InvalidPage
-from django.db.models import Count, OuterRef, Prefetch, Q, Subquery, Sum
+from django.db.models import Count, OuterRef, Subquery
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.urls import reverse_lazy
@@ -13,7 +13,6 @@ from wagtail.admin.widgets import ListingButton, HeaderButton, ButtonWithDropdow
 
 from georiva.core.models import Catalog
 from georiva.core.models import Collection, Item
-from georiva.ingestion.models import FileIngestion
 from .table import LinkColumnWithIcon
 from .viewsets import CatalogViewSet, CollectionViewSet
 
@@ -188,13 +187,6 @@ def collection_items_list(request, collection_pk):
     items = (
         Item.objects.filter(collection=collection)
         .annotate(asset_count=Subquery(asset_count_sq))
-        .prefetch_related(
-            Prefetch(
-                'file_ingestions',
-                queryset=FileIngestion.objects.order_by('-created_at'),
-                to_attr='prefetched_logs',
-            )
-        )
         .order_by("-time")
     )
     
@@ -218,29 +210,33 @@ def collection_items_list(request, collection_pk):
         page_obj = paginator.page(1)
     
     elided_page_range = paginator.get_elided_page_range(page_obj.number)
-    
-    # ------------------------------------------------------------------
-    # Automation section (only rendered if data_feed is set)
-    # ------------------------------------------------------------------
-    data_feed = None
-    recent_runs = []
-    ingestion_summary = {}
 
-    if data_feed:
-        logs_qs = FileIngestion.objects.filter(
-            collection_slug=collection.slug,
-            catalog_slug=collection.catalog.slug,
-        )
-        ingestion_summary = logs_qs.aggregate(
-            total=Count("id"),
-            completed=Count("id", filter=Q(status=FileIngestion.Status.COMPLETED)),
-            failed=Count("id", filter=Q(status=FileIngestion.Status.FAILED)),
-            pending=Count("id", filter=Q(status=FileIngestion.Status.PENDING)),
-            processing=Count("id", filter=Q(status=FileIngestion.Status.PROCESSING)),
-            total_items_created=Sum("items_created"),
-            total_assets_created=Sum("assets_created"),
-        )
-    
+    # ------------------------------------------------------------------
+    # Attach ingestion_log to each item on this page.
+    # Bulk lookup by source_file (convention: "{bucket}:{file_path}") so
+    # every item — including GRIB/NetCDF items that are not the last one
+    # written — gets the correct status badge.
+    # ------------------------------------------------------------------
+    from django.db.models import F, Value
+    from django.db.models.functions import Concat
+    from georiva.ingestion.models import FileIngestion
+
+    source_files = {item.source_file for item in page_obj.object_list if item.source_file}
+    fi_by_source_file = {}
+    if source_files:
+        for fi in (
+            FileIngestion.objects
+            .annotate(_sf=Concat(F("bucket"), Value(":"), F("file_path")))
+            .filter(_sf__in=source_files)
+            .order_by("-created_at")
+        ):
+            key = f"{fi.bucket}:{fi.file_path}"
+            if key not in fi_by_source_file:
+                fi_by_source_file[key] = fi
+
+    for item in page_obj.object_list:
+        item.ingestion_log = fi_by_source_file.get(item.source_file)
+
     # ------------------------------------------------------------------
     # Context
     # ------------------------------------------------------------------
@@ -259,9 +255,6 @@ def collection_items_list(request, collection_pk):
         "page_obj": page_obj,
         "paginator": paginator,
         "elided_page_range": elided_page_range,
-        "data_feed": data_feed,
-        "recent_runs": recent_runs,
-        "ingestion_summary": ingestion_summary,
     }
     
     return render(request, "core/collection_items.html", context)


### PR DESCRIPTION
## Summary

- Replaces the broken `prefetch_related('file_ingestions')` that used the removed `FileIngestion.item` FK — the view was raising `AttributeError` on every page load
- Adds a post-pagination bulk lookup keyed on `Item.source_file` (`"{bucket}:{file_path}"`), so every item on the page — including GRIB/NetCDF items that aren't the last one written — gets the correct ingestion status badge
- Removes the dead `if data_feed:` block that still referenced the removed `catalog_slug`/`collection_slug` fields
- Moves `FileIngestion` import to local scope inside the view (no ingestion models imported at core module level)

## Test plan

- [x] `make dev-test TEST_ARGS="georiva.core"` — 4 new tests pass
- [x] `make dev-test TEST_ARGS="georiva.core georiva.ingestion georiva.sources"` — 215 tests pass
- [ ] Collection items list page renders without error
- [ ] Items from a GRIB file all show the correct ingestion status badge
- [ ] Items with no matching FileIngestion show "—"

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)