### PR TITLE
feat(ingestion): reject duplicate source_name across collections at wizard step 4

### DIFF
--- a/georiva/src/georiva/ingestion/tests/test_upload_wizard.py
+++ b/georiva/src/georiva/ingestion/tests/test_upload_wizard.py
@@ -454,6 +454,113 @@ class Step4CollectionsTests(TestCase):
 
 
 # =============================================================================
+# Step 4 — duplicate source_name validation
+# =============================================================================
+
+class Step4DuplicateSourceNameTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin4dup", "dup@test.com", "pw")
+        self.client.force_login(self.user)
+        _seed_session(self.client, {
+            "catalog_mode": "create",
+            "new_catalog_name": "WM",
+            "new_catalog_slug": "wm",
+            "new_catalog_format": "grib2",
+            "config_name": "Surface variables",
+            "variables": [{"name": "2t", "long_name": "2m temp", "units": "K"}],
+            "selected_variable_names": ["2t"],
+            "sample_filename": "20250115.grib2",
+            "valid_time_format": "CONTENT",
+            "is_forecast": False,
+        })
+
+    def _post(self, collections, assignments):
+        return self.client.post(STEP4_URL, {
+            "collections_json": json.dumps(collections),
+            "assignments_json": json.dumps(assignments),
+        })
+
+    def test_same_source_name_in_two_collections_rerenders_with_error(self):
+        collections = [
+            {"name": "Col A", "slug": "col-a"},
+            {"name": "Col B", "slug": "col-b"},
+        ]
+        assignments = [
+            _assignment(variable_name="2t", collection_idx=0),
+            _assignment(variable_name="2t", collection_idx=1),
+        ]
+        response = self._post(collections, assignments)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2t")
+        self.assertContains(response, "Col A")
+        self.assertContains(response, "Col B")
+
+    def test_same_source_name_same_collection_is_allowed(self):
+        # Two assignments pointing to the same collection slug — not a conflict.
+        collections = [{"name": "Col A", "slug": "col-a"}]
+        assignments = [
+            _assignment(variable_name="2t", collection_idx=0),
+            _assignment(variable_name="2t", collection_idx=0),
+        ]
+        response = self._post(collections, assignments)
+        self.assertRedirects(response, STEP5_URL, fetch_redirect_response=False)
+
+    def test_conflict_with_existing_config_in_different_collection_rerenders(self):
+        catalog = _make_catalog(slug="existing-cat")
+        existing_col = _make_collection(catalog, slug="existing-col")
+        existing_config = ManualUploadConfig.objects.create(
+            catalog=catalog, name="Existing config",
+            is_forecast=False, valid_time_format="CONTENT",
+        )
+        ManualUploadConfigVariable.objects.create(
+            config=existing_config, collection=existing_col,
+            variable_name="2t", long_name="2m temperature", units="K",
+        )
+        _seed_session(self.client, {
+            "catalog_mode": "existing",
+            "catalog_id": catalog.pk,
+            "config_name": "New config",
+            "variables": [{"name": "2t", "long_name": "2m temp", "units": "K"}],
+            "selected_variable_names": ["2t"],
+            "sample_filename": "20250115.grib2",
+            "valid_time_format": "CONTENT",
+            "is_forecast": False,
+        })
+        collections = [{"name": "New Col", "slug": "new-col"}]
+        assignments = [_assignment(variable_name="2t", collection_idx=0)]
+        response = self._post(collections, assignments)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2t")
+
+    def test_same_source_name_same_existing_collection_is_allowed(self):
+        catalog = _make_catalog(slug="reuse-cat")
+        existing_col = _make_collection(catalog, slug="reuse-col")
+        existing_config = ManualUploadConfig.objects.create(
+            catalog=catalog, name="Existing config",
+            is_forecast=False, valid_time_format="CONTENT",
+        )
+        ManualUploadConfigVariable.objects.create(
+            config=existing_config, collection=existing_col,
+            variable_name="2t", long_name="2m temperature", units="K",
+        )
+        _seed_session(self.client, {
+            "catalog_mode": "existing",
+            "catalog_id": catalog.pk,
+            "config_name": "New config 2",
+            "variables": [{"name": "2t", "long_name": "2m temp", "units": "K"}],
+            "selected_variable_names": ["2t"],
+            "sample_filename": "20250115.grib2",
+            "valid_time_format": "CONTENT",
+            "is_forecast": False,
+        })
+        # Assigning the same variable to the same collection slug — should pass.
+        collections = [{"name": "Reuse Col", "slug": "reuse-col"}]
+        assignments = [_assignment(variable_name="2t", collection_idx=0)]
+        response = self._post(collections, assignments)
+        self.assertRedirects(response, STEP5_URL, fetch_redirect_response=False)
+
+
+# =============================================================================
 # Step 5 — Review
 # =============================================================================
 

--- a/georiva/src/georiva/ingestion/upload_wizard_views.py
+++ b/georiva/src/georiva/ingestion/upload_wizard_views.py
@@ -509,6 +509,45 @@ def upload_wizard_step4(request):
                         _("Variable '%s': unit '%s' is not a valid unit symbol.") % (var_label, unit_create)
                     )
 
+        # Duplicate source_name check: each variable_name must map to exactly
+        # one collection per catalog (unambiguous collection resolution for
+        # GRIB/NetCDF ingestion).
+        source_name_to_collection = {}
+        for a in assignments:
+            source_name = a.get("variable_name", "").strip()
+            coll_idx = a.get("collection_idx")
+            if not source_name or coll_idx is None or coll_idx >= len(collections):
+                continue
+            coll = collections[coll_idx]
+            coll_slug = coll.get("slug", "").strip() or slugify(coll.get("name", ""))
+            coll_name = coll.get("name", f"Collection {coll_idx + 1}")
+            if source_name in source_name_to_collection:
+                existing_slug, existing_name = source_name_to_collection[source_name]
+                if existing_slug != coll_slug:
+                    errors.append(
+                        _("Variable '%(var)s' is assigned to both '%(c1)s' and '%(c2)s' — "
+                          "each source_name must map to exactly one collection per catalog.")
+                        % {"var": source_name, "c1": existing_name, "c2": coll_name}
+                    )
+            else:
+                source_name_to_collection[source_name] = (coll_slug, coll_name)
+
+        # Also check against existing ManualUploadConfigs for the same catalog.
+        catalog_id = session.get("catalog_id")
+        if catalog_id:
+            from georiva.ingestion.models import ManualUploadConfigVariable
+            for ev in ManualUploadConfigVariable.objects.filter(
+                config__catalog_id=catalog_id
+            ).select_related("collection"):
+                if ev.variable_name in source_name_to_collection:
+                    new_slug, new_name = source_name_to_collection[ev.variable_name]
+                    if ev.collection.slug != new_slug:
+                        errors.append(
+                            _("Variable '%(var)s' is already assigned to collection '%(existing)s' "
+                              "in this catalog — cannot also assign it to '%(new)s'.")
+                            % {"var": ev.variable_name, "existing": ev.collection.name, "new": new_name}
+                        )
+
         if errors:
             for e in errors:
                 messages.error(request, e)


### PR DESCRIPTION
## Summary

- Adds save-time validation to wizard step 4 that rejects a config where the same `variable_name` (the `source_name` written to `Variable.sources`) appears in more than one collection under the same catalog
- Check covers **within the new config** (two collections in the same wizard session) and **against existing `ManualUploadConfigVariable` records** for the catalog when adding to an existing catalog
- Same `variable_name` assigned to the same collection slug is allowed (re-provisioning into an existing collection)
- Error re-renders step 4 naming the conflicting variable and both collection names — no unhandled exception

This enforces the invariant that each `source_name` maps to exactly one collection per catalog, which is required for unambiguous collection resolution during GRIB/NetCDF ingestion.

## Test plan

- [x] Same `variable_name` in two different collections → step 4 re-renders with error naming both collections
- [x] Same `variable_name` in the same collection twice → proceeds to step 5
- [x] New config for existing catalog: `variable_name` conflicts with existing `ManualUploadConfigVariable` in a different collection → re-renders
- [x] New config for existing catalog: `variable_name` matches existing config in the same collection slug → proceeds to step 5
- [x] `make dev-test TEST_ARGS="georiva.ingestion georiva.core georiva.sources"` — 219 tests pass

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)