### PR TITLE
docs: pipeline acquisition model glossary and ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,34 +17,59 @@ _Avoid_: processing, import, fetch (for this phase)
 
 ### Pipeline records
 
-**DataArrival**:
-A batch of one or more files entering MinIO from any trigger. The top-level observable unit of work in the pipeline —
-exists for both scheduled and manual upload paths. Catalog-scoped: always carries a `catalog` FK. Does not link
-directly to a Collection — collection resolution is the job of `FileIngestion`.
-_Avoid_: LoaderRun, DataFeedRun, IngestionRun
+**FetchRun**:
+The record of a single automated DataFeed execution. Created at the start of the run — before any files are fetched —
+to enable real-time monitoring. One `FetchRun` per DataFeed execution, covering all collections in that feed.
+Status: `running → completed / failed / cancelled`. Success vs partial outcome is derived from `FetchedFile` children,
+not stored on the run itself.
+_Avoid_: DataArrival, LoaderRun, DataFeedRun
+
+**FetchedFile**:
+Per-file acquisition record within a `FetchRun`. Created and updated incrementally as the Loader processes each file.
+Status: `pending → fetching → stored / skipped / failed`. Skipped files (already exist in storage) appear as
+`FetchedFile` records with `status=skipped`. Linked to `FileIngestion` via `file_path` — there is no FK.
+_Avoid_: FetchResult (that is a transient in-memory dataclass, not a model)
+
+**UploadSession**:
+The record of a manual multi-file upload by an operator. Owned by `catalog` + `user`. Status:
+`active → completed / failed / cancelled`. Transitions to `completed` automatically once all `UploadedFile` children
+reach a terminal state (`stored` or `failed`). Not linked to a `DataFeed` — manual uploads are independent of
+configured automated sources.
+_Avoid_: DataArrival, upload batch, upload job
+
+**UploadedFile**:
+Per-file upload record within an `UploadSession`. Status: `pending → uploading → stored / failed`. No `skipped`
+state — user-chosen files are always attempted. Linked to `FileIngestion` via `file_path` — there is no FK.
+_Avoid_: UploadArrival
 
 **FileIngestion**:
-The per-file record of processing a single file from MinIO into STAC items and assets. Owns the distributed lock, state
-machine, and retry logic for that file. Carries a `collections` M2M populated immediately after collection resolution
-(before per-collection processing begins), so failed runs are still collection-trackable even when no Items are
-created. Items produced by a FileIngestion are found via `Item.source_file` (indexed, value:
-`"{bucket}:{file_path}"`) — correct for all formats, including GRIB/NetCDF multi-item files.
+The per-file record of processing a single file from MinIO into STAC items and assets. Owns the distributed lock,
+state machine, and retry logic for that file. Created directly by the MinIO consumer (bucket event) or by the
+sweep task — with no reference to any acquisition record. Carries a `collections` M2M populated immediately after
+collection resolution (before per-collection processing begins), so failed runs are still collection-trackable even
+when no Items are created. Summary fields populated on completion: `variables_discovered` (int),
+`valid_time_start` (datetime), `valid_time_end` (datetime), `timestep_count` (int), `reference_time` (datetime).
+Items produced by a FileIngestion are found via `Item.source_file` (indexed, value: `"{bucket}:{file_path}"`) —
+correct for all formats, including GRIB/NetCDF multi-item files.
 _Avoid_: IngestionLog
 
 ### Triggers
 
 **DataFeed**:
-A configured automated data source — what to fetch, how often, and from where. Creates `DataArrival` records on a
+A configured automated data source — what to fetch, how often, and from where. Creates `FetchRun` records on a
 schedule via the Loader.
 _Avoid_: data source, loader config, plugin (when referring to the configured instance)
 
 **Manual Upload**:
-A `DataArrival` triggered by a human, either via the admin upload interface (DataArrival created before the file lands)
-or by dropping a file directly into MinIO (DataArrival created at the bucket event).
+A file upload triggered by a human via the admin upload interface. Creates an `UploadSession` and one
+`UploadedFile` per submitted file. Files never go client → MinIO directly (no presigned URLs).
 _Avoid_: manual drop, manual ingest, manual ingestion
 
-**Trigger**:
-The cause of a `DataArrival`. One of: `scheduled` (created by a DataFeed) or `manual_upload` (created by a human).
+**Sweep**:
+A periodic safety-net task that finds files in MinIO that have no corresponding `FileIngestion` record and
+registers them for processing. Sweep is not an acquisition event — it creates `FileIngestion` records directly,
+without a `FetchRun` or `UploadSession`.
+_Avoid_: sweep arrival, sweep ingestion
 
 ### Manual upload setup
 
@@ -84,27 +109,20 @@ Through model linking a `ManualUploadConfig` to a `Collection` for one variable.
 The collection FK is what routes each variable to the right Collection at upload time.
 _Avoid_: variable mapping, variable link
 
-**Arrival Status Endpoint**:
-A lightweight polling endpoint `GET /api/arrivals/{id}/status/` returning `{id, status, error_message}`. Used by
-the admin upload interface to poll until the `DataArrival` reaches a terminal status. Separate from the heavier
-collection arrivals list endpoint.
-
 **Upload Page**:
-The admin page where an operator submits a single file for ingestion, one page per `ManualUploadConfig` (reached via
-the list page's "Upload" button at `/admin/manual-uploads/<pk>/upload/`). Shows: a variable dropdown (from
-`ManualUploadConfigVariable`), a single time field (labelled "Model run time" when `is_forecast`, "Observation date"
-otherwise) pre-filled from the filename on file pick, and a file picker. One file per submission; each submission
-creates one `DataArrival`. After submit, the page polls the Arrival Status Endpoint every 2.5s and shows progress
-inline until a terminal status. Incoming paths: GeoTIFF
-`{catalog}/{collection}/{variable}/{YYYY}/{MM}/{DD}/{filename}`; GRIB/NetCDF `{catalog}/[GR--{reftime}--]{filename}`.
+The admin page where an operator submits files for ingestion, one page per `ManualUploadConfig` (reached via
+the list page's "Upload" button at `/admin/manual-uploads/<pk>/upload/`). Supports multi-file upload (like
+Wagtail's images/multiple/add interface). Each submission creates one `UploadSession` with one `UploadedFile`
+per file. After submit, the page shows per-file progress in real time.
+_Avoid_: upload form, upload interface
 
 **Upload Flow**:
-The sequence for a manual upload via the admin interface: (1) operator submits the upload form; (2) server creates
-`DataArrival(trigger=MANUAL_UPLOAD, status=UPLOADING)`; (3) server writes the file to MinIO `incoming` bucket — on
-failure, sets `DataArrival.status=FAILED, error_message=<reason>` and returns 500; (4) on success, sets
-`DataArrival.status=PENDING` and enqueues the ingestion task; (5) server returns `DataArrival.id`; (6) client polls
-the Arrival Status Endpoint until terminal. The file never goes client → MinIO directly (no presigned URLs).
-`DataArrival` gains an `error_message = TextField(blank=True)` field to carry upload-time failure reasons.
+The sequence for a manual upload via the admin interface: (1) operator selects one or more files and submits;
+(2) server creates `UploadSession(status=active)` and one `UploadedFile(status=pending)` per file; (3) for each
+file: transition to `uploading`, stream to MinIO `incoming` bucket — on failure set `status=failed`; on success
+set `status=stored`; (4) when all `UploadedFile` children reach a terminal state, `UploadSession` transitions to
+`completed`. The MinIO bucket event then triggers `FileIngestion` independently. Files never go client → MinIO
+directly (no presigned URLs).
 _Avoid_: upload pipeline, ingest flow
 
 **Time Extraction**:
@@ -119,18 +137,26 @@ _Avoid_: time parsing, date detection
 ### Operator-facing monitoring surfaces
 
 **Collection Health Panel**:
-The Wagtail admin home panel showing a per-collection health summary — sparklines, OK/Warning/Failed counts, and last-run time. A fleet-level view across all active Collections. Entry point to the Ingestion Activity Feed via a "View all" link. Sparkline data (30-day binary per-day status: success / failed / empty) is derived entirely from `FileIngestion.collections` M2M — completed runs for success days, failed runs for failure days. Both signals come from the same model with the same query shape.
+The Wagtail admin home panel showing a per-collection health summary — sparklines, OK/Warning/Failed counts, and
+last-run time. A fleet-level view across all active Collections. Entry point to the Ingestion Feed via a "View all"
+link. Sparkline data (30-day binary per-day status: success / failed / empty) is derived entirely from
+`FileIngestion.collections` M2M — completed runs for success days, failed runs for failure days.
 _Avoid_: ingestion dashboard, activity panel
 
-**Ingestion Activity Feed**:
-A dedicated admin page (`/admin/ingestion/activity/`) showing a live, chronologically-ordered feed of `DataArrival` records with inline `FileIngestion` status and per-job step-by-step progress. Updated in real time via SSE. Covers both manual and scheduled arrivals. Accessible from the sidebar and from the Collection Health Panel.
-_Avoid_: live feed, ingestion log, activity dashboard
+**Acquisition Feed**:
+A dedicated admin page showing a live, chronologically-ordered feed of acquisition activity — both `FetchRun`
+records (automated DataFeed executions) and `UploadSession` records (manual uploads). Each card shows the run/session
+status with per-file detail expandable. Updated in real time via SSE.
+_Avoid_: fetch feed, arrival feed, data arrival feed
+
+**Ingestion Feed**:
+A dedicated admin page showing a live, chronologically-ordered feed of `FileIngestion` records with inline
+per-job step-by-step progress and summary fields (variables discovered, valid time range, timestep count). Updated
+in real time via SSE. Covers files from any trigger — automated fetch, manual upload, or sweep. Accessible from
+the sidebar and from the Collection Health Panel.
+_Avoid_: live feed, ingestion log, activity dashboard, Ingestion Activity Feed
 
 ### Jobs
-
-**DataArrivalJob**:
-A task-ferry job providing real-time status of a single `DataArrival` run — covers the full batch from start to finish.
-_Avoid_: DataFeedJob
 
 **FileIngestionJob**:
 A task-ferry job providing real-time status of a single `FileIngestion` run. One job is created per

--- a/docs/adr/0003-acquisition-model-fetchrun-uploadsession.md
+++ b/docs/adr/0003-acquisition-model-fetchrun-uploadsession.md
@@ -1,0 +1,91 @@
+# Acquisition Model — FetchRun, FetchedFile, UploadSession, UploadedFile
+
+## Context
+
+`DataArrival` was introduced to anchor pipeline visibility — it represented "data arrived for this catalog" and
+served as the bridge between the acquisition phase (Loader / manual upload) and the processing phase
+(`FileIngestion`). It worked for basic history, but had several structural problems:
+
+- **No per-file fetch visibility.** `DataArrival` was a batch record; individual files fetched during a `Loader`
+  run had no model-level representation. The only way to know "which files did this run fetch?" was to infer it
+  from `FileIngestion` records after they were processed — too late for real-time monitoring.
+- **Conflated acquisition and processing.** `DataArrival` carried both "how did data arrive?" (trigger, fetch
+  metadata) and "what happened to it?" (status that mirrored `FileIngestion` state). These are separate concerns
+  with different lifecycles and different owners.
+- **Created after the run.** `Loader.record_run()` was called in the `finally` block — the record existed only
+  after completion, making real-time feed updates impossible without a separate mechanism.
+- **Sweep was not acquisition.** `sweep_unprocessed` was forced to create a `DataArrival(trigger=SWEEP)` to
+  satisfy the non-null FK on `FileIngestion`. But sweep is a recovery mechanism, not an acquisition event — it
+  finds files already in MinIO and registers them for processing.
+- **Manual upload had no session concept.** One `DataArrival` was created per file submission, making multi-file
+  upload tracking awkward and preventing a natural "upload session" UX.
+
+## Decision
+
+**`DataArrival` is removed.** Its responsibilities are split into two separate concerns.
+
+**Acquisition side** — two new models track how files got into MinIO:
+
+- `FetchRun`: one record per `DataFeed` execution, created at the start of the run (before any files are
+  fetched). Status: `running → completed / failed / cancelled`. Covers all collections in the feed.
+- `FetchedFile`: one record per file within a `FetchRun`, created and updated incrementally as the Loader
+  processes each file. Status: `pending → fetching → stored / skipped / failed`. Skipped files (already
+  exist in storage) appear as records with `status=skipped` for full audit coverage.
+- `UploadSession`: one record per manual multi-file upload, owned by `catalog + user`. Status:
+  `active → completed / failed / cancelled`. Transitions to `completed` automatically once all `UploadedFile`
+  children reach a terminal state.
+- `UploadedFile`: one record per file within an `UploadSession`. Status:
+  `pending → uploading → stored / failed`. No `skipped` state — user-chosen files are always attempted.
+
+**Processing side** — `FileIngestion` becomes self-contained:
+
+- The `data_arrival` FK is dropped. `FileIngestion` is created directly by the MinIO consumer (bucket event)
+  or by the sweep task.
+- New summary fields populated on completion: `variables_discovered`, `valid_time_start`, `valid_time_end`,
+  `timestep_count`.
+- The join from `FileIngestion` to acquisition records is via `file_path` only — no FK. This keeps the two
+  concerns independent and handles the sweep path naturally.
+
+**Two monitoring feeds** replace the single Ingestion Activity Feed:
+
+- `Acquisition Feed`: shows `FetchRun` and `UploadSession` records with per-file `FetchedFile` /
+  `UploadedFile` drill-down. Real-time via SSE. Answers "what did we fetch / upload?"
+- `Ingestion Feed`: shows `FileIngestion` records with step-by-step job progress and summary metadata.
+  Real-time via SSE. Answers "what did we process?"
+
+**`Loader` creates `FetchRun` / `FetchedFile` incrementally.** The `on_file_fetched` (and a new
+`on_file_started`) callback hooks on `Loader` are used to write `FetchedFile` status transitions as they happen.
+
+**`sweep_unprocessed` creates `FileIngestion` directly.** No acquisition record. Sweep is recovery, not fetch.
+
+## Alternatives considered
+
+**Keep `DataArrival` and add per-file child records to it** — rejected. `DataArrival` conflates acquisition
+context with processing state; adding children would deepen that coupling rather than resolving it. Removing
+it gives each concern a clean model with its own lifecycle.
+
+**One `FetchRun` per collection per execution** — rejected. Operators think in terms of "the CHIRPS run at
+06:00", not "the CHIRPS precip-daily run". One `FetchRun` per DataFeed execution (Option A) maps to the
+mental model; per-file collection context is already encoded in `file_path`.
+
+**Keep `DataArrival` as a Sweep anchor** — rejected. Sweep is a recovery mechanism for files already in
+MinIO. Creating a `DataArrival(trigger=SWEEP)` just to satisfy a FK constraint misrepresents what happened.
+`FileIngestion` standalone is the correct representation for sweep-registered files.
+
+**FK from `FileIngestion` to `FetchedFile` / `UploadedFile`** — rejected. The MinIO consumer fires on
+bucket events and has no knowledge of which acquisition path produced the file. A `file_path` join is the
+right coupling — it decouples the two pipelines and handles sweep naturally.
+
+## Consequences
+
+- `DataArrival` model, migrations, and all references removed. `DataArrival.Trigger` enum removed.
+- New models added: `FetchRun`, `FetchedFile`, `UploadSession`, `UploadedFile` (with clean migrations).
+- `FileIngestion`: drop `data_arrival` FK; add `variables_discovered`, `valid_time_start`,
+  `valid_time_end`, `timestep_count` fields.
+- `DataFeed.record_run()` replaced by `FetchRun` creation + `FetchedFile` incremental updates in `Loader`.
+- MinIO consumer: call `FileIngestion.register()` directly (no `DataArrival.find_or_create()`).
+- `sweep_unprocessed`: remove `DataArrival` creation; call `FileIngestion.register()` directly.
+- SSE events: `data_arrival.*` events replaced by `fetch_run.*`, `fetched_file.*`, `upload_session.*`,
+  `uploaded_file.*`, and `file_ingestion.*` event types.
+- `DataArrivalJob` removed. `FileIngestionJob` unchanged.
+- Upload Page: rewritten to support multi-file upload sessions.


### PR DESCRIPTION
## Summary

- Rewrites `CONTEXT.md` to replace `DataArrival` terminology with the new acquisition model vocabulary (`FetchRun`, `FetchedFile`, `UploadSession`, `UploadedFile`, `Acquisition Feed`, `Ingestion Feed`, `Sweep`)
- Adds `docs/adr/0003-acquisition-model-fetchrun-uploadsession.md` documenting the architectural decision to replace `DataArrival` with purpose-built acquisition models

## Why now

Issues #73–#77 implement this architecture. Agents picking up those issues load `CONTEXT.md` at session start — this branch ensures the glossary matches the work they're about to do.

## Test plan

- [ ] `CONTEXT.md` contains no references to `DataArrival`
- [ ] All new terms (`FetchRun`, `FetchedFile`, `UploadSession`, `UploadedFile`, `Acquisition Feed`, `Ingestion Feed`) are defined
- [ ] ADR 0003 exists and references the correct trade-offs

🤖 Generated with [Claude Code](https://claude.com/claude-code)