### PR TITLE
feat(ingestion): Loader FetchRun tracking + consumer/sweep direct FileIngestion registration

### DIFF
--- a/georiva/src/georiva/ingestion/consumer.py
+++ b/georiva/src/georiva/ingestion/consumer.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from georiva.core.filename import validate_path
 from georiva.core.models import Catalog
 from georiva.core.storage import BucketType, get_bucket_config
-from georiva.ingestion.models import DataArrival, FileIngestion
+from georiva.ingestion.models import FileIngestion
 from georiva.ingestion.tasks import process_incoming_file
 
 logger = logging.getLogger(__name__)
@@ -112,34 +112,17 @@ def _handle_event(ev: dict):
         logger.warning("Unknown catalog '%s': %s", catalog_slug, key)
         return
 
-    arrival, arrival_created = DataArrival.find_or_create(
-        file_path=key,
-        trigger=DataArrival.Trigger.MANUAL_UPLOAD,
-        catalog=catalog,
-    )
-    if not arrival_created and arrival.status == DataArrival.Status.UPLOADING:
-        arrival.status = DataArrival.Status.PENDING
-        arrival.save(update_fields=['status', 'updated_at'])
-
     log, created = FileIngestion.register(
         bucket=origin_bucket,
         file_path=key,
         reference_time=meta.get("reference_time"),
-        data_arrival=arrival,
     )
 
-    # Only genuine direct drops: admin uploads pre-create the DataArrival and
-    # have already validated times server-side (the date may have been entered
-    # in the form rather than encoded in the filename).
-    if arrival_created:
-        time_error = _required_time_error(catalog.slug, key)
-        if time_error:
-            logger.warning("Time extraction failed for %s: %s", key, time_error)
-            FileIngestion.mark_failed(origin_bucket, key, time_error)
-            arrival.status = DataArrival.Status.FAILED
-            arrival.error_message = time_error
-            arrival.save(update_fields=['status', 'error_message', 'updated_at'])
-            return
+    time_error = _required_time_error(catalog.slug, key)
+    if time_error:
+        logger.warning("Time extraction failed for %s: %s", key, time_error)
+        FileIngestion.mark_failed(origin_bucket, key, time_error)
+        return
 
     if not created:
         if log.status == FileIngestion.Status.PROCESSING:

--- a/georiva/src/georiva/ingestion/job_types.py
+++ b/georiva/src/georiva/ingestion/job_types.py
@@ -98,6 +98,10 @@ class FileIngestionJobType(JobType):
                 archive_path=result.archive_path,
                 items_created=len(result.items_created),
                 assets_created=len(result.assets_created),
+                variables_discovered=result.variables_discovered,
+                valid_time_start=result.valid_time_start,
+                valid_time_end=result.valid_time_end,
+                timestep_count=result.timestep_count,
             )
             job.items_created = len(result.items_created)
             job.assets_created = len(result.assets_created)

--- a/georiva/src/georiva/ingestion/models.py
+++ b/georiva/src/georiva/ingestion/models.py
@@ -342,6 +342,10 @@ class FileIngestion(models.Model):
             archive_path: str = '',
             items_created: int = 0,
             assets_created: int = 0,
+            variables_discovered: int = None,
+            valid_time_start=None,
+            valid_time_end=None,
+            timestep_count: int = None,
     ):
         """Mark a file as successfully processed."""
         cls.objects.filter(
@@ -354,6 +358,10 @@ class FileIngestion(models.Model):
             items_created=items_created,
             assets_created=assets_created,
             error='',
+            variables_discovered=variables_discovered,
+            valid_time_start=valid_time_start,
+            valid_time_end=valid_time_end,
+            timestep_count=timestep_count,
         )
     
     @classmethod

--- a/georiva/src/georiva/ingestion/result.py
+++ b/georiva/src/georiva/ingestion/result.py
@@ -38,6 +38,12 @@ class IngestionResult:
     
     # Archive path — populated if catalog.archive_source_files is True
     archive_path: str = ""
+
+    # Processing summary — populated after the ingestion loop completes
+    variables_discovered: Optional[int] = None
+    valid_time_start: Optional[datetime] = None
+    valid_time_end: Optional[datetime] = None
+    timestep_count: Optional[int] = None
     
     def add_error(self, msg: str):
         self.errors.append(msg)

--- a/georiva/src/georiva/ingestion/service.py
+++ b/georiva/src/georiva/ingestion/service.py
@@ -280,6 +280,14 @@ class IngestionService:
                                 )
                 
                 result.success = len(result.items_created) > 0
+
+                # Populate summary fields from the last collection processed
+                if timestamps:
+                    result.variables_discovered = n_vars
+                    result.timestep_count = len(timestamps)
+                    sorted_ts = sorted(timestamps)
+                    result.valid_time_start = sorted_ts[0]
+                    result.valid_time_end = sorted_ts[-1]
             
             finally:
                 if hasattr(plugin, "clear_cache"):

--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -149,23 +149,10 @@ def sweep_unprocessed(sync: bool = False):
             
             logger.info("Found untracked file: %s/%s", bucket_type, path)
 
-            # Ensure a DataArrival exists before registering the FileIngestion.
-            from georiva.core.models import Catalog
-            from georiva.ingestion.models import DataArrival
-            catalog_slug = meta.get('catalog')
-            catalog = Catalog.objects.filter(slug=catalog_slug).first() if catalog_slug else None
-            arrival, _ = DataArrival.find_or_create(
-                file_path=path,
-                trigger=DataArrival.Trigger.SWEEP,
-                catalog=catalog,
-            )
-
-            # Register
             FileIngestion.register(
                 bucket=bucket_type,
                 file_path=path,
                 reference_time=meta.get('reference_time'),
-                data_arrival=arrival,
             )
             
             # Queue for processing

--- a/georiva/src/georiva/ingestion/tests/test_consumer.py
+++ b/georiva/src/georiva/ingestion/tests/test_consumer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 from django.test import TestCase
 
@@ -27,34 +27,72 @@ def _run(ev, catalog_slug="test-catalog", collection_slug="test-collection"):
         _handle_event(ev)
 
 
-class ConsumerCreatesDataArrivalTests(TestCase):
+class ConsumerDirectFileIngestionTests(TestCase):
     def setUp(self):
         Catalog.objects.create(name="Test", slug="test-catalog", file_format="grib2")
         self.file_path = "test-catalog/test-collection/somefile.grib2"
         self.ev = _make_event("georiva-sources", self.file_path)
 
-    def test_direct_drop_creates_data_arrival_and_linked_file_ingestion(self):
+    def test_direct_drop_creates_file_ingestion_without_data_arrival(self):
         _run(self.ev)
 
-        arrival = DataArrival.objects.get(file_path=self.file_path)
-        self.assertEqual(arrival.trigger, DataArrival.Trigger.MANUAL_UPLOAD)
-        self.assertEqual(arrival.status, DataArrival.Status.PENDING)
-
         log = FileIngestion.objects.get(file_path=self.file_path)
-        self.assertEqual(log.data_arrival_id, arrival.pk)
+        self.assertIsNone(log.data_arrival)
 
-    def test_pre_registered_uploading_arrival_transitions_to_pending(self):
-        existing = DataArrival.objects.create(
-            file_path=self.file_path,
-            trigger=DataArrival.Trigger.MANUAL_UPLOAD,
-            status=DataArrival.Status.UPLOADING,
-        )
-
+    def test_direct_drop_does_not_create_data_arrival(self):
         _run(self.ev)
+        self.assertEqual(DataArrival.objects.count(), 0)
 
-        existing.refresh_from_db()
-        self.assertEqual(existing.status, DataArrival.Status.PENDING)
-        self.assertEqual(DataArrival.objects.filter(file_path=self.file_path).count(), 1)
+    def test_time_extraction_failure_marks_file_ingestion_failed(self):
+        with (
+            patch("georiva.ingestion.consumer.validate_path") as mock_vp,
+            patch("georiva.ingestion.consumer._resolve_origin", return_value=BucketType.SOURCES),
+            patch("georiva.ingestion.consumer.process_incoming_file") as mock_task,
+            patch("georiva.ingestion.consumer._required_time_error",
+                  return_value="Could not extract valid time"),
+        ):
+            mock_vp.return_value = {
+                "catalog": "test-catalog",
+                "collection": "test-collection",
+                "reference_time": None,
+            }
+            mock_task.delay = MagicMock()
+            _handle_event(self.ev)
 
         log = FileIngestion.objects.get(file_path=self.file_path)
-        self.assertEqual(log.data_arrival_id, existing.pk)
+        self.assertEqual(log.status, FileIngestion.Status.FAILED)
+        self.assertIn("valid time", log.error)
+        self.assertEqual(DataArrival.objects.count(), 0)
+
+
+class SweepDirectFileIngestionTests(TestCase):
+    def setUp(self):
+        Catalog.objects.create(name="Sweep", slug="sweep-cat", file_format="grib2")
+
+    def test_sweep_registers_file_without_data_arrival(self):
+        from georiva.core.storage import BucketType as BT
+        from georiva.ingestion.tasks import sweep_unprocessed
+
+        file_path = "sweep-cat/col/rain.grib"
+        incoming_bucket = MagicMock()
+        incoming_bucket.list_files.return_value = []
+        sources_bucket = MagicMock()
+        sources_bucket.list_files.return_value = [{"path": file_path}]
+
+        def _bucket_side_effect(bucket_type):
+            return sources_bucket if bucket_type == BT.SOURCES else incoming_bucket
+
+        with (
+            patch("georiva.ingestion.tasks.storage") as mock_storage,
+            patch("georiva.ingestion.tasks.validate_path") as mock_vp,
+            patch("georiva.ingestion.tasks.process_incoming_file") as mock_task,
+        ):
+            mock_storage.bucket.side_effect = _bucket_side_effect
+            mock_vp.return_value = {"catalog": "sweep-cat", "reference_time": None}
+            mock_task.run = MagicMock()
+
+            sweep_unprocessed(sync=True)
+
+        log = FileIngestion.objects.get(file_path=file_path, bucket=BT.SOURCES)
+        self.assertIsNone(log.data_arrival)
+        self.assertEqual(DataArrival.objects.count(), 0)

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_models.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_models.py
@@ -193,3 +193,28 @@ class FileIngestionSummaryFieldTests(TestCase):
         self.assertEqual(log.valid_time_start, t_start)
         self.assertEqual(log.valid_time_end, t_end)
         self.assertEqual(log.timestep_count, 30)
+
+    def test_mark_completed_writes_summary_fields(self):
+        from datetime import datetime, timezone
+
+        FileIngestion.register(bucket="incoming", file_path="mark/file.nc")
+        t_start = datetime(2024, 7, 1, tzinfo=timezone.utc)
+        t_end = datetime(2024, 7, 31, tzinfo=timezone.utc)
+
+        FileIngestion.mark_completed(
+            bucket="incoming",
+            file_path="mark/file.nc",
+            items_created=4,
+            assets_created=8,
+            variables_discovered=3,
+            valid_time_start=t_start,
+            valid_time_end=t_end,
+            timestep_count=31,
+        )
+
+        log = FileIngestion.objects.get(file_path="mark/file.nc")
+        self.assertEqual(log.status, FileIngestion.Status.COMPLETED)
+        self.assertEqual(log.variables_discovered, 3)
+        self.assertEqual(log.valid_time_start, t_start)
+        self.assertEqual(log.valid_time_end, t_end)
+        self.assertEqual(log.timestep_count, 31)

--- a/georiva/src/georiva/ingestion/tests/test_upload_page.py
+++ b/georiva/src/georiva/ingestion/tests/test_upload_page.py
@@ -365,10 +365,6 @@ class DirectDropTimeValidationTests(TestCase):
         self.assertIn("Could not extract a valid time", fi.error)
         self.assertIn("YYYYMMDD", fi.error)
 
-        arrival = DataArrival.objects.get(file_path="imagery/random_name.tif")
-        self.assertEqual(arrival.status, DataArrival.Status.FAILED)
-        self.assertIn("Could not extract a valid time", arrival.error_message)
-
         mock_task.delay.assert_not_called()
 
     def test_parseable_geotiff_drop_is_enqueued(self, mock_task):
@@ -391,11 +387,12 @@ class DirectDropTimeValidationTests(TestCase):
         self.assertEqual(fi.status, FileIngestion.Status.PENDING)
         mock_task.delay.assert_called_once()
 
-    def test_admin_upload_event_skips_filename_check(self, mock_task):
+    def test_consumer_applies_time_check_uniformly(self, mock_task):
+        """Consumer checks time extractability for all drops; no DataArrival bypass."""
         from georiva.ingestion.consumer import _handle_event
         _geotiff_setup()
 
-        # Admin upload pre-creates the arrival before the bucket event fires
+        # A pre-existing DataArrival no longer bypasses the time check.
         DataArrival.objects.create(
             trigger=DataArrival.Trigger.MANUAL_UPLOAD,
             status=DataArrival.Status.UPLOADING,
@@ -404,11 +401,13 @@ class DirectDropTimeValidationTests(TestCase):
 
         _handle_event(self._event("imagery/operator_named.tif"))
 
-        arrival = DataArrival.objects.get(file_path="imagery/operator_named.tif")
-        self.assertEqual(arrival.status, DataArrival.Status.PENDING)
+        # FileIngestion is created but fails time extraction
         fi = FileIngestion.objects.get(file_path="imagery/operator_named.tif")
-        self.assertNotEqual(fi.status, FileIngestion.Status.FAILED)
-        mock_task.delay.assert_called_once()
+        self.assertEqual(fi.status, FileIngestion.Status.FAILED)
+        # DataArrival is left untouched — consumer no longer manages it
+        arrival = DataArrival.objects.get(file_path="imagery/operator_named.tif")
+        self.assertEqual(arrival.status, DataArrival.Status.UPLOADING)
+        mock_task.delay.assert_not_called()
 
 
 # =============================================================================

--- a/georiva/src/georiva/sources/job_types.py
+++ b/georiva/src/georiva/sources/job_types.py
@@ -119,11 +119,6 @@ class DataArrivalJobType(JobType):
             job.files_failed += result.files_failed
             job.save(update_fields=["files_skipped", "files_failed"])
 
-            arrival = data_feed.record_run(result, collection)
-            if arrival and not job.data_arrival_id:
-                job.data_arrival = arrival
-                job.save(update_fields=["data_arrival"])
-
             logger.info(
                 "DataArrivalJob %d (%s): %s",
                 job.id, col_label, result.summary(),

--- a/georiva/src/georiva/sources/loader.py
+++ b/georiva/src/georiva/sources/loader.py
@@ -158,52 +158,64 @@ class Loader:
         Returns:
             LoaderRunResult with statistics and details
         """
+        from georiva.sources.models import FetchRun, FetchedFile
+
         result = LoaderRunResult()
-        
+        fetch_run = None
+
+        if self.data_feed:
+            fetch_run = FetchRun.objects.create(data_feed=self.data_feed, status='running')
+
         try:
             self.logger.info(f"Starting loader run for {self.collection.name}")
-            
+
             # Connect fetch strategy
             self.fetch_strategy.connect()
             self.logger.debug("Fetch strategy connected")
-            
+
             # Generate requests from data source
             requests = list(self.data_source.generate_requests_for_collection(self.collection))
             result.files_requested = len(requests)
-            
+
             if not requests:
                 self.logger.warning("No file requests generated")
                 result.finish()
                 return result
-            
+
             # Extract run time from first request (for forecasts)
             if requests[0].reference_time:
                 result.run_time = requests[0].reference_time
                 self.logger.info(
                     f"Processing forecast run: {result.run_time.isoformat()}"
                 )
-            
+
             self.logger.info(f"Generated {len(requests)} file requests")
-            
+
             if dry_run:
                 self.logger.info("Dry run - skipping fetch")
                 for req in requests:
                     self.logger.debug(f"  Would fetch: {req.filename}")
                 result.finish()
                 return result
-            
+
             # Filter already-fetched files; copy from another collection if available
             requests_to_fetch = []
             for request in requests:
+                storage_path = self._get_storage_path(request)
+
                 if skip_existing and self._already_exists(request):
                     result.files_skipped += 1
                     self.logger.debug(f"Skipping (exists): {request.filename}")
+                    if fetch_run:
+                        ff = FetchedFile.objects.create(
+                            fetch_run=fetch_run, file_path=storage_path)
+                        ff.mark_skipped(reason="already exists")
                     continue
-                
+
                 if skip_existing:
                     existing_path = self._find_existing_catalog_path(request)
                     if existing_path:
-                        dest_path = self._get_storage_path(request)
+                        dest_path = storage_path
                         try:
                             storage.sources.copy(existing_path, dest_path)
                             result.files_fetched += 1
@@ -211,71 +223,95 @@ class Loader:
                             self.logger.info(
                                 f"Copied (no re-download): {existing_path} → {dest_path}"
                             )
+                            if fetch_run:
+                                ff = FetchedFile.objects.create(
+                                    fetch_run=fetch_run, file_path=dest_path)
+                                ff.mark_fetching()
+                                ff.mark_stored(bytes_transferred=0)
                         except Exception as e:
                             self.logger.warning(
                                 f"Copy failed, will re-download: {e}"
                             )
                             requests_to_fetch.append(request)
                         continue
-                
+
                 requests_to_fetch.append(request)
-                
+
                 if max_files and len(requests_to_fetch) >= max_files:
                     self.logger.info(f"Reached max_files limit ({max_files})")
                     break
-            
+
             self.logger.info(
                 f"{len(requests_to_fetch)} to fetch, {result.files_skipped} skipped"
             )
-            
+
             # Fetch files
             for i, request in enumerate(requests_to_fetch, 1):
                 self.logger.info(
                     f"[{i}/{len(requests_to_fetch)}] Fetching {request.filename}"
                 )
-                
+
+                ff = None
+                if fetch_run:
+                    ff = FetchedFile.objects.create(
+                        fetch_run=fetch_run,
+                        file_path=self._get_storage_path(request),
+                    )
+                    ff.mark_fetching()
+
                 fetch_result = self._fetch_and_store(request)
                 result.fetch_results.append(fetch_result)
-                
+
                 if fetch_result.success:
                     result.files_fetched += 1
                     result.bytes_transferred += fetch_result.bytes_transferred
                     result.stored_paths.append(self._get_storage_path(request))
-                    
+                    if ff:
+                        ff.mark_stored(bytes_transferred=fetch_result.bytes_transferred or 0)
+
                     # Callback
                     if self.on_file_fetched:
                         try:
                             self.on_file_fetched(request, fetch_result)
                         except Exception as e:
                             self.logger.warning(f"on_file_fetched callback error: {e}")
-                
+
                 elif fetch_result.status == 'queued':
                     result.files_queued += 1
                 else:
                     result.files_failed += 1
                     if fetch_result.error:
                         result.add_error(f"{request.filename}: {fetch_result.error}")
-        
+                    if ff:
+                        ff.mark_failed(error=fetch_result.error or "")
+
         except Exception as e:
             self.logger.exception(f"Loader run failed: {e}")
             result.add_error(str(e))
-        
+
         finally:
             # Cleanup
             try:
                 self.fetch_strategy.disconnect()
             except Exception as e:
                 self.logger.warning(f"Error disconnecting: {e}")
-            
+
             self._cleanup_temp()
             result.finish()
-            
-            # Record if we have a profile reference
+
+            if fetch_run:
+                fetch_run.mark_completed(
+                    files_fetched=result.files_fetched,
+                    files_skipped=result.files_skipped,
+                    files_failed=result.files_failed,
+                    bytes_transferred=result.bytes_transferred,
+                )
+
             if self.data_feed:
-                self.data_feed.record_run(result, self.collection)
-            
+                self.data_feed._update_run_stats(result, self.collection)
+
             self.logger.info(result.summary())
-        
+
         return result
     
     # =========================================================================
@@ -316,7 +352,7 @@ class Loader:
             FileIngestion.objects
             .filter(
                 bucket=BucketType.SOURCES,
-                data_arrival__catalog__slug=catalog_slug,
+                file_path__startswith=f"{catalog_slug}/",
                 file_path__endswith=f"/{filename}",
                 status__in=[
                     FileIngestion.Status.PENDING,

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -189,53 +189,20 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
     # Run Management
     # =========================================================================
     
-    def record_run(self, result, collection):
-        """Record data feed run result. Returns the created DataArrival."""
+    def _update_run_stats(self, result, collection):
+        """Update feed-level and collection-link scheduling stats after a run."""
         from django.utils import timezone
-        from georiva.core.storage import BucketType
-        from georiva.ingestion.models import DataArrival, FileIngestion
-
-        _status_map = {
-            'success': DataArrival.Status.COMPLETED,
-            'partial': DataArrival.Status.PARTIAL,
-            'failed': DataArrival.Status.FAILED,
-            'empty': DataArrival.Status.EMPTY,
-            'queued': DataArrival.Status.PENDING,
-        }
-
-        arrival = DataArrival.objects.create(
-            trigger=DataArrival.Trigger.SCHEDULED,
-            status=_status_map.get(result.status, DataArrival.Status.PENDING),
-            data_feed=self,
-            catalog=collection.catalog,
-            files_requested=result.files_requested,
-            files_fetched=result.files_fetched,
-            files_skipped=result.files_skipped,
-            files_failed=result.files_failed,
-            files_queued=result.files_queued,
-            bytes_transferred=result.bytes_transferred,
-            started_at=result.started_at,
-            finished_at=result.finished_at,
-        )
-
-        if result.stored_paths:
-            FileIngestion.objects.filter(
-                file_path__in=result.stored_paths,
-                bucket=BucketType.SOURCES,
-            ).update(data_arrival=arrival)
 
         now = timezone.now()
-        
-        # Update per-collection link's last_run_at for independent scheduling
         self.collection_links.filter(collection=collection).update(last_run_at=now)
-        
+
         self.last_run_at = now
         self.last_run_status = result.status
         self.last_run_message = '; '.join(result.errors[:3]) if result.errors else ''
         self.total_runs += 1
         self.total_files_fetched += result.files_fetched
         self.total_bytes_transferred += result.bytes_transferred
-        
+
         if result.success:
             self.last_success_at = self.last_run_at
 
@@ -244,8 +211,6 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
             'last_success_at', 'total_runs', 'total_files_fetched',
             'total_bytes_transferred',
         ])
-
-        return arrival
     
     def is_due(self) -> bool:
         """Check if data feed is due to run."""
@@ -292,7 +257,6 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
         for coll in collections:
             loader = self.get_loader(coll)
             result = loader.run()
-            self.record_run(result, coll)
             results.append(result)
         return results
     

--- a/georiva/src/georiva/sources/tasks.py
+++ b/georiva/src/georiva/sources/tasks.py
@@ -48,7 +48,6 @@ def run_data_feed_loader(self, data_feed_id):
         collection = real_link.collection
         loader = data_feed.get_loader(collection)
         result = loader.run()
-        data_feed.record_run(result, collection)
         results.append(result.to_dict())
     
     return results

--- a/georiva/src/georiva/sources/tests/test_loader_fetchrun.py
+++ b/georiva/src/georiva/sources/tests/test_loader_fetchrun.py
@@ -1,0 +1,192 @@
+"""
+Tests for Loader incremental FetchRun/FetchedFile tracking.
+
+We mock fetch_strategy and storage to keep these fast and deterministic —
+the point is to verify FetchRun/FetchedFile records are written correctly,
+not to test network or storage I/O.
+"""
+from unittest.mock import MagicMock, patch, call
+
+from django.test import TestCase
+
+from georiva.core.models import Catalog, Collection
+from georiva.sources.loader import Loader
+from georiva.sources.models import DataFeed, FetchRun, FetchedFile
+from georiva.sources.fetch.base import FetchResult
+
+
+def _make_feed_and_collection():
+    catalog = Catalog.objects.create(name="Test", slug="test", file_format="grib2")
+    collection = Collection.objects.create(name="Col", slug="col", catalog=catalog)
+    feed = DataFeed.objects.create(name="Feed", catalog=catalog)
+    return feed, collection
+
+
+def _mock_request(filename="file.grib", reference_time=None):
+    req = MagicMock()
+    req.filename = filename
+    req.reference_time = reference_time
+    req.expected_size = None
+    return req
+
+
+def _success_fetch_result(req, bytes_transferred=1024):
+    return FetchResult(request=req, success=True, status="success",
+                       bytes_transferred=bytes_transferred)
+
+
+def _failed_fetch_result(req, error="timeout"):
+    return FetchResult(request=req, success=False, status="failed", error=error)
+
+
+class LoaderFetchRunCreationTests(TestCase):
+    def setUp(self):
+        self.feed, self.collection = _make_feed_and_collection()
+
+    def _run_loader(self, requests, fetch_results, skip_existing=False):
+        """Helper: run Loader with mocked strategy + storage, returning the run result."""
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=self.feed,
+        )
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = requests
+        loader.data_source.post_process_fetched_file.side_effect = (
+            lambda req, path: (path, None)
+        )
+
+        fetch_iter = iter(fetch_results)
+
+        with (
+            patch.object(loader, '_already_exists', return_value=False),
+            patch.object(loader, '_find_existing_catalog_path', return_value=None),
+            patch.object(loader, '_fetch_and_store',
+                         side_effect=lambda req: next(fetch_iter)),
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            result = loader.run(skip_existing=skip_existing)
+        return result
+
+    def test_completed_run_creates_fetch_run(self):
+        req = _mock_request("a.grib")
+        self._run_loader([req], [_success_fetch_result(req)])
+
+        self.assertEqual(FetchRun.objects.count(), 1)
+        run = FetchRun.objects.get()
+        self.assertEqual(run.data_feed, self.feed)
+        self.assertEqual(run.status, "completed")
+        self.assertEqual(run.files_fetched, 1)
+        self.assertEqual(run.files_skipped, 0)
+        self.assertEqual(run.files_failed, 0)
+        self.assertIsNotNone(run.finished_at)
+
+    def test_failed_files_reflected_in_fetch_run(self):
+        req = _mock_request("bad.grib")
+        self._run_loader([req], [_failed_fetch_result(req)])
+
+        run = FetchRun.objects.get()
+        self.assertEqual(run.status, "completed")
+        self.assertEqual(run.files_fetched, 0)
+        self.assertEqual(run.files_failed, 1)
+
+    def test_no_data_feed_no_fetch_run(self):
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=None,
+        )
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = []
+        loader.data_source.post_process_fetched_file.side_effect = lambda r, p: (p, None)
+        with (
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            loader.run()
+        self.assertEqual(FetchRun.objects.count(), 0)
+
+
+class LoaderFetchedFileTrackingTests(TestCase):
+    def setUp(self):
+        self.feed, self.collection = _make_feed_and_collection()
+
+    def test_successful_fetch_creates_stored_fetched_file(self):
+        req = _mock_request("rain.grib")
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=self.feed,
+        )
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = [req]
+        loader.data_source.post_process_fetched_file.side_effect = lambda r, p: (p, None)
+
+        with (
+            patch.object(loader, '_already_exists', return_value=False),
+            patch.object(loader, '_find_existing_catalog_path', return_value=None),
+            patch.object(loader, '_fetch_and_store',
+                         return_value=_success_fetch_result(req, bytes_transferred=2048)),
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            loader.run()
+
+        ff = FetchedFile.objects.get()
+        self.assertEqual(ff.status, "stored")
+        self.assertEqual(ff.bytes_transferred, 2048)
+        self.assertIsNotNone(ff.completed_at)
+
+    def test_skipped_file_creates_skipped_fetched_file(self):
+        req = _mock_request("existing.grib")
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=self.feed,
+        )
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = [req]
+        loader.data_source.post_process_fetched_file.side_effect = lambda r, p: (p, None)
+
+        with (
+            patch.object(loader, '_already_exists', return_value=True),
+            patch.object(loader, '_find_existing_catalog_path', return_value=None),
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            loader.run()
+
+        ff = FetchedFile.objects.get()
+        self.assertEqual(ff.status, "skipped")
+        self.assertEqual(ff.skip_reason, "already exists")
+
+    def test_failed_fetch_creates_failed_fetched_file(self):
+        req = _mock_request("broken.grib")
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=self.feed,
+        )
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = [req]
+        loader.data_source.post_process_fetched_file.side_effect = lambda r, p: (p, None)
+
+        with (
+            patch.object(loader, '_already_exists', return_value=False),
+            patch.object(loader, '_find_existing_catalog_path', return_value=None),
+            patch.object(loader, '_fetch_and_store',
+                         return_value=_failed_fetch_result(req, error="FTP timeout")),
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            loader.run()
+
+        ff = FetchedFile.objects.get()
+        self.assertEqual(ff.status, "failed")
+        self.assertEqual(ff.error, "FTP timeout")

--- a/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
+++ b/georiva/src/georiva/sources/tests/test_scheduled_arrival.py
@@ -1,69 +1,94 @@
+"""
+Tests for Loader-driven FetchRun creation after a scheduled data-feed run.
+
+Replaces the old DataArrival-based tests that verified DataFeed.record_run().
+"""
+from unittest.mock import MagicMock, patch
+
 from django.test import TestCase
 
 from georiva.core.models import Catalog, Collection
-from georiva.core.storage import BucketType
-from georiva.ingestion.models import DataArrival, FileIngestion
-from georiva.sources.loader import LoaderRunResult
-from georiva.sources.models import DataFeed
+from georiva.sources.loader import Loader
+from georiva.sources.models import DataFeed, FetchRun
+from georiva.sources.fetch.base import FetchResult
 
 
-def _make_feed():
-    return DataFeed.objects.create(name="Test Feed")
+def _make_feed_and_collection():
+    catalog = Catalog.objects.create(name="Sched", slug="sched", file_format="grib2")
+    collection = Collection.objects.create(name="Col", slug="col", catalog=catalog)
+    feed = DataFeed.objects.create(name="Sched Feed", catalog=catalog)
+    return feed, collection
 
 
-def _make_collection():
-    catalog = Catalog.objects.create(name="Test", slug="test-cat", file_format="grib2")
-    return Collection.objects.create(name="Test Col", slug="test-col", catalog=catalog)
+def _mock_request(filename):
+    req = MagicMock()
+    req.filename = filename
+    req.reference_time = None
+    req.expected_size = None
+    return req
 
 
-class RecordRunCreatesDataArrivalTests(TestCase):
+class ScheduledRunCreatesFetchRunTests(TestCase):
     def setUp(self):
-        self.feed = _make_feed()
-        self.collection = _make_collection()
+        self.feed, self.collection = _make_feed_and_collection()
 
-    def test_successful_run_creates_scheduled_data_arrival(self):
-        result = LoaderRunResult(
-            files_requested=4,
-            files_fetched=3,
-            files_skipped=1,
-            files_failed=0,
-            bytes_transferred=2048,
-        )
-        result.finish()
-
-        self.feed.record_run(result, self.collection)
-
-        arrival = DataArrival.objects.get(
-            trigger=DataArrival.Trigger.SCHEDULED,
+    def _run(self, requests, fetch_results):
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
             data_feed=self.feed,
         )
-        self.assertEqual(arrival.status, DataArrival.Status.COMPLETED)
-        self.assertEqual(arrival.files_requested, 4)
-        self.assertEqual(arrival.files_fetched, 3)
-        self.assertEqual(arrival.files_skipped, 1)
-        self.assertEqual(arrival.files_failed, 0)
-        self.assertEqual(arrival.bytes_transferred, 2048)
-        self.assertEqual(arrival.catalog, self.collection.catalog)
+        loader.data_source.name = "test"
+        loader.data_source.generate_requests_for_collection.return_value = requests
+        loader.data_source.post_process_fetched_file.side_effect = lambda r, p: (p, None)
+        fetch_iter = iter(fetch_results)
+        with (
+            patch.object(loader, '_already_exists', return_value=False),
+            patch.object(loader, '_find_existing_catalog_path', return_value=None),
+            patch.object(loader, '_fetch_and_store', side_effect=lambda r: next(fetch_iter)),
+            patch.object(loader, '_cleanup_temp'),
+            patch.object(loader.fetch_strategy, 'connect'),
+            patch.object(loader.fetch_strategy, 'disconnect'),
+        ):
+            return loader.run()
 
-    def test_record_run_links_file_ingestions_to_arrival(self):
-        paths = [
-            "test-cat/test-col/file_a.grib2",
-            "test-cat/test-col/file_b.grib2",
-        ]
-        preliminary = DataArrival.objects.create(trigger=DataArrival.Trigger.MANUAL_UPLOAD)
-        for path in paths:
-            FileIngestion.objects.create(
-                bucket=BucketType.SOURCES,
-                file_path=path,
-                data_arrival=preliminary,
-            )
+    def test_successful_run_creates_completed_fetch_run(self):
+        req = _mock_request("rain.grib")
+        result = self._run(
+            [req],
+            [FetchResult(request=req, success=True, status="success",
+                         bytes_transferred=4096)],
+        )
 
-        result = LoaderRunResult(files_fetched=2, stored_paths=paths)
-        result.finish()
+        run = FetchRun.objects.get(data_feed=self.feed)
+        self.assertEqual(run.status, "completed")
+        self.assertEqual(run.files_fetched, 1)
+        self.assertEqual(run.bytes_transferred, 4096)
+        self.assertEqual(run.files_failed, 0)
 
-        self.feed.record_run(result, self.collection)
+    def test_feed_stats_updated_after_run(self):
+        req = _mock_request("temp.grib")
+        self._run(
+            [req],
+            [FetchResult(request=req, success=True, status="success",
+                         bytes_transferred=512)],
+        )
 
-        arrival = DataArrival.objects.get(trigger=DataArrival.Trigger.SCHEDULED)
-        linked = FileIngestion.objects.filter(data_arrival=arrival)
-        self.assertEqual(linked.count(), 2)
-        self.assertSetEqual(set(linked.values_list("file_path", flat=True)), set(paths))
+        self.feed.refresh_from_db()
+        self.assertEqual(self.feed.total_runs, 1)
+        self.assertEqual(self.feed.total_files_fetched, 1)
+        self.assertIsNotNone(self.feed.last_run_at)
+
+    def test_collection_link_last_run_at_updated(self):
+        from georiva.sources.models import DataFeedCollectionLink
+        DataFeedCollectionLink.objects.create(
+            data_feed=self.feed, collection=self.collection
+        )
+        req = _mock_request("wind.grib")
+        self._run(
+            [req],
+            [FetchResult(request=req, success=True, status="success",
+                         bytes_transferred=256)],
+        )
+        link = self.feed.collection_links.get(collection=self.collection)
+        self.assertIsNotNone(link.last_run_at)


### PR DESCRIPTION
## Summary

- **Loader** creates a `FetchRun` at the start of every run and a `FetchedFile` per request, updated incrementally (`pending → fetching → stored/skipped/failed`); `FetchRun` is finalized in the `finally` block with summary counts
- **`DataFeed.record_run()`** removed; replaced by `DataFeed._update_run_stats()` (scheduling fields only, no `DataArrival`); called automatically from `Loader.run()`; all three external callers (`tasks.py`, `job_types.py`, `run_now()`) updated
- **`Loader._find_existing_catalog_path`** filter fixed: `data_arrival__catalog__slug` → `file_path__startswith` (data_arrival is now nullable)
- **`consumer._handle_event`** registers `FileIngestion` directly — no `DataArrival` created or transitioned for MinIO bucket events
- **`sweep_unprocessed`** registers `FileIngestion` directly — `DataArrival.find_or_create()` block removed
- **`FileIngestion.mark_completed()`** extended with summary fields; `IngestionResult` carries them from the service loop; `FileIngestionJobType` passes them through on completion

Closes #74
Parent epic: #72

## Test plan

- [x] `Loader.run()` with a data_feed → `FetchRun` exists with `status=completed` and correct counts
- [x] Each fetched file → `FetchedFile(status=stored, bytes_transferred=N)`
- [x] Skipped file (already exists) → `FetchedFile(status=skipped, skip_reason="already exists")`
- [x] Failed fetch → `FetchedFile(status=failed, error=...)`
- [x] No data_feed → no `FetchRun` created
- [x] Scheduled run → `DataFeed` stats updated (`total_runs`, `last_run_at`, etc.)
- [x] Collection link `last_run_at` updated after run
- [x] Consumer `_handle_event` → `FileIngestion` created, `DataArrival.objects.count() == 0`
- [x] Consumer time extraction failure → `FileIngestion.status == FAILED`, no `DataArrival`
- [x] Consumer applies time check uniformly (pre-existing DataArrivals no longer bypass it)
- [x] Sweep → `FileIngestion` registered directly, `DataArrival.objects.count() == 0`
- [x] `FileIngestion.mark_completed()` writes all four summary fields
- [x] Full suite: 247 tests, 0 regressions (only pre-existing `pages.home` import error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)