### PR TITLE
feat(ingestion): multi-file Upload Page — batch UploadSession submissions

### DIFF
--- a/georiva/src/georiva/ingestion/templates/georivaingestion/manual_upload_page.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/manual_upload_page.html
@@ -5,7 +5,7 @@
 
 {% block extra_css %}
 <style>
-    .mup-form { max-width: 42em; }
+    .mup-form { max-width: 48em; }
     .mup-field { margin-bottom: 1.25em; }
     .mup-help { color: var(--w-color-grey-400); font-size: 0.9em; margin-top: 0.3em; }
     .mup-meta {
@@ -16,9 +16,7 @@
     }
     .mup-meta-label { color: var(--w-color-grey-400); }
     .mup-actions { display: flex; gap: 1em; margin-top: 1.5em; align-items: center; }
-    .mup-collections {
-        margin: 0.4em 0 0 0; padding-left: 1.3em; line-height: 1.9;
-    }
+    .mup-collections { margin: 0.4em 0 0 0; padding-left: 1.3em; line-height: 1.9; }
     .mup-collections li { color: var(--w-color-text-label); }
     .mup-error {
         display: none; color: var(--w-color-critical-200);
@@ -26,9 +24,46 @@
     }
     .mup-error--visible { display: block; }
 
+    /* File queue */
+    .mup-queue {
+        margin-top: 0.75em;
+        border: 1px solid var(--w-color-border-furniture);
+        border-radius: 4px;
+        overflow: hidden;
+    }
+    .mup-queue-row {
+        display: grid;
+        align-items: center;
+        gap: 0.6em;
+        padding: 0.55em 0.8em;
+        border-bottom: 1px solid var(--w-color-border-furniture);
+        font-size: 0.88em;
+        background: var(--w-color-surface-page);
+    }
+    .mup-queue-row:last-child { border-bottom: none; }
+    .mup-queue-row--geotiff { grid-template-columns: 1fr 1fr 1fr auto; }
+    .mup-queue-row--plain   { grid-template-columns: 1fr auto; }
+
+    .mup-row-filename {
+        font-family: monospace;
+        font-size: 0.9em;
+        word-break: break-all;
+        color: var(--w-color-text-label);
+    }
+    .mup-row-select, .mup-row-time { font-size: 0.88em; width: 100%; }
+    .mup-row-status {
+        font-size: 0.8em; padding: 0.15em 0.5em;
+        border-radius: 3px; white-space: nowrap;
+        background: var(--w-color-grey-100);
+        color: var(--w-color-text-label);
+    }
+    .mup-row-status--uploading { background: var(--w-color-info-100); color: var(--w-color-white); }
+    .mup-row-status--stored    { background: var(--w-color-positive-100); color: var(--w-color-white); }
+    .mup-row-status--failed    { background: var(--w-color-critical-200); color: var(--w-color-white); }
+
     /* Progress log */
     .mup-log {
-        display: none; max-width: 42em; margin-top: 1.5em;
+        display: none; max-width: 48em; margin-top: 1.5em;
         border: 1px solid var(--w-color-border-furniture);
         border-radius: 4px; background: var(--w-color-grey-50);
     }
@@ -51,24 +86,17 @@
     @keyframes mup-spin { to { transform: rotate(360deg); } }
     .mup-log-steps {
         list-style: none; margin: 0; padding: 0.4em 1em 0.6em;
-        font-size: 0.88em; line-height: 1.9;
-        color: var(--w-color-text-label);
+        font-size: 0.88em; line-height: 1.9; color: var(--w-color-text-label);
     }
     .mup-log-steps li::before { content: "›  "; color: var(--w-color-grey-400); }
-    .mup-log-summary {
-        padding: 0.5em 1em 0.8em;
-        font-size: 0.88em;
-    }
+    .mup-log-summary { padding: 0.5em 1em 0.8em; font-size: 0.88em; }
     .mup-log-summary--success { color: var(--w-color-positive-100); font-weight: 600; }
     .mup-log-summary--error   { color: var(--w-color-critical-200); }
-    .mup-log-retry {
-        padding: 0 1em 0.8em; font-size: 0.88em;
-    }
 </style>
 {% endblock %}
 
 {% block content %}
-{% include "wagtailadmin/shared/header.html" with title=upload_config.name subtitle=_("Upload file") icon="upload" breadcrumbs=breadcrumbs_items %}
+{% include "wagtailadmin/shared/header.html" with title=upload_config.name subtitle=_("Upload files") icon="upload" breadcrumbs=breadcrumbs_items %}
 
 <div class="nice-padding">
     <div class="mup-meta">
@@ -87,18 +115,7 @@
     <form id="upload-form" class="mup-form">
         {% csrf_token %}
 
-        {% if is_geotiff %}
-        <div class="w-field__wrapper mup-field">
-            <label class="w-field__label" for="variable-select">{% trans "Variable" %} <sup>*</sup></label>
-            <select id="variable-select" class="w-field__input" required>
-                {% for var in variables %}
-                <option value="{{ var.pk }}">
-                    {{ var.long_name|default:var.variable_name }} ({{ var.collection.name }})
-                </option>
-                {% endfor %}
-            </select>
-        </div>
-        {% else %}
+        {% if not is_geotiff %}
         <div class="mup-field">
             <div class="w-field__label">{% trans "Collections to be processed" %}</div>
             <ul class="mup-collections">
@@ -106,17 +123,16 @@
                 <li>{{ collection.name }}</li>
                 {% endfor %}
             </ul>
-            <div class="mup-help">{% trans "All active variables in these collections will be extracted from the uploaded file." %}</div>
+            <div class="mup-help">{% trans "All active variables in these collections will be extracted from each uploaded file." %}</div>
         </div>
-        {% endif %}
 
-        <div class="w-field__wrapper mup-field">
-            <label class="w-field__label" for="time-input">
+        <div class="w-field__wrapper mup-field" id="shared-time-field">
+            <label class="w-field__label" for="shared-time-input">
                 {{ time_label }}{% if time_required %} <sup>*</sup>{% endif %}
             </label>
-            <input type="datetime-local" id="time-input" class="w-field__input"
+            <input type="datetime-local" id="shared-time-input" class="w-field__input"
                    {% if time_required %}required{% endif %}>
-            <div class="mup-help" id="time-help">
+            <div class="mup-help">
                 {% if upload_config.valid_time_format != "CONTENT" %}
                 {% trans "Pre-filled from the filename when it matches the" %} <code>{{ upload_config.valid_time_format }}</code> {% trans "format." %}
                 {% else %}
@@ -124,13 +140,16 @@
                 {% endif %}
             </div>
         </div>
+        {% endif %}
 
         <div class="w-field__wrapper mup-field">
-            <label class="w-field__label" for="file-input">{% trans "File" %} <sup>*</sup></label>
+            <label class="w-field__label" for="file-input">{% trans "Files" %} <sup>*</sup></label>
             <input type="file" id="file-input" class="w-field__input"
-                   accept="{{ accept_extensions }}" required>
+                   accept="{{ accept_extensions }}" multiple required>
             <div class="mup-help">{{ format_label }} {% trans "files only" %} ({{ accept_extensions }})</div>
         </div>
+
+        <div id="file-queue"></div>
 
         <div class="mup-error" id="form-error"></div>
 
@@ -150,7 +169,6 @@
         </div>
         <ul class="mup-log-steps" id="log-steps"></ul>
         <div class="mup-log-summary" id="log-summary"></div>
-        <div class="mup-log-retry" id="log-retry"></div>
     </div>
 </div>
 {% endblock %}
@@ -167,14 +185,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const CSRF_TOKEN   = document.querySelector('[name=csrfmiddlewaretoken]').value;
     const POLL_MS      = 2500;
     const TERMINAL     = ['completed', 'failed', 'cancelled'];
+    const IS_GEOTIFF   = {{ is_geotiff|yesno:"true,false" }};
+    const TIME_LABEL   = '{{ time_label|escapejs }}';
+    const VARIABLES    = [{% for var in variables %}{"id": {{ var.pk }}, "label": "{{ var.long_name|default:var.variable_name|escapejs }} ({{ var.collection.name|escapejs }})"}{% if not forloop.last %},{% endif %}{% endfor %}];
 
-    const form        = document.getElementById('upload-form');
-    const fileInput   = document.getElementById('file-input');
-    const timeInput   = document.getElementById('time-input');
-    const variableSel = document.getElementById('variable-select');
-    const submitBtn   = document.getElementById('submit-btn');
-    const formError   = document.getElementById('form-error');
+    const form         = document.getElementById('upload-form');
+    const fileInput    = document.getElementById('file-input');
+    const sharedTime   = document.getElementById('shared-time-input');
+    const submitBtn    = document.getElementById('submit-btn');
+    const formError    = document.getElementById('form-error');
+    const queueEl      = document.getElementById('file-queue');
 
+    let fileRows = [];
     let pollTimer = null;
 
     function showError(msg) {
@@ -186,33 +208,131 @@ document.addEventListener('DOMContentLoaded', function () {
         formError.classList.remove('mup-error--visible');
     }
 
-    // ── Time pre-fill on file pick ─────────────────────────────────────────
-    fileInput.addEventListener('change', function () {
-        if (!this.files.length) return;
-        clearError();
+    // ── Build per-file row (GeoTIFF) ───────────────────────────────────────
+    function buildVariableSelect() {
+        const sel = document.createElement('select');
+        sel.className = 'mup-row-select w-field__input';
+        VARIABLES.forEach(function (v) {
+            const opt = document.createElement('option');
+            opt.value = v.id;
+            opt.textContent = v.label;
+            sel.appendChild(opt);
+        });
+        return sel;
+    }
+
+    function buildTimeInput() {
+        const inp = document.createElement('input');
+        inp.type = 'datetime-local';
+        inp.className = 'mup-row-time w-field__input';
+        inp.placeholder = TIME_LABEL;
+        inp.title = TIME_LABEL;
+        return inp;
+    }
+
+    function buildRow(file, index) {
+        const row = document.createElement('div');
+        row.className = IS_GEOTIFF ? 'mup-queue-row mup-queue-row--geotiff' : 'mup-queue-row mup-queue-row--plain';
+        row.dataset.index = index;
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'mup-row-filename';
+        nameEl.textContent = file.name;
+
+        const statusEl = document.createElement('span');
+        statusEl.className = 'mup-row-status';
+        statusEl.textContent = '{% trans "pending" %}';
+        statusEl.dataset.statusEl = '';
+
+        row.appendChild(nameEl);
+
+        if (IS_GEOTIFF) {
+            const sel  = buildVariableSelect();
+            const time = buildTimeInput();
+            row._variableSel = sel;
+            row._timeInput   = time;
+            row.appendChild(sel);
+            row.appendChild(time);
+        }
+
+        row.appendChild(statusEl);
+        return row;
+    }
+
+    function setRowStatus(row, status) {
+        const el = row.querySelector('[data-status-el]');
+        if (!el) return;
+        el.textContent = status;
+        el.className = 'mup-row-status mup-row-status--' + status;
+    }
+
+    // ── Time pre-fill (GeoTIFF rows) ───────────────────────────────────────
+    function prefillRowTime(file, row) {
         const fd = new FormData();
         fd.append('csrfmiddlewaretoken', CSRF_TOKEN);
-        fd.append('filename', this.files[0].name);
+        fd.append('filename', file.name);
         fetch(EXTRACT_URL, { method: 'POST', body: fd })
             .then(function (r) { return r.json(); })
             .then(function (data) {
-                if (data.prefill) timeInput.value = data.prefill;
+                if (data.prefill && row._timeInput) row._timeInput.value = data.prefill;
             })
-            .catch(function () { /* pre-fill is best-effort */ });
+            .catch(function () {});
+    }
+
+    // ── GRIB shared-time pre-fill (first file only) ────────────────────────
+    function prefillSharedTime(file) {
+        if (!sharedTime) return;
+        const fd = new FormData();
+        fd.append('csrfmiddlewaretoken', CSRF_TOKEN);
+        fd.append('filename', file.name);
+        fetch(EXTRACT_URL, { method: 'POST', body: fd })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.prefill) sharedTime.value = data.prefill;
+            })
+            .catch(function () {});
+    }
+
+    // ── File selection ─────────────────────────────────────────────────────
+    fileInput.addEventListener('change', function () {
+        clearError();
+        queueEl.innerHTML = '';
+        fileRows = [];
+
+        const files = Array.from(this.files);
+        if (!files.length) return;
+
+        const wrap = document.createElement('div');
+        wrap.className = 'mup-queue';
+
+        files.forEach(function (file, i) {
+            const row = buildRow(file, i);
+            wrap.appendChild(row);
+            fileRows.push(row);
+            if (IS_GEOTIFF) {
+                prefillRowTime(file, row);
+            } else if (i === 0) {
+                prefillSharedTime(file);
+            }
+        });
+
+        queueEl.appendChild(wrap);
     });
 
-    // ── Progress log component ─────────────────────────────────────────────
-    function mountProgressLog(jobId, sseUrl) {
-        const logEl      = document.getElementById('progress-log');
-        const spinner    = document.getElementById('log-spinner');
-        const titleEl    = document.getElementById('log-title');
-        const stepsList  = document.getElementById('log-steps');
-        const summaryEl  = document.getElementById('log-summary');
+    // ── Progress log ───────────────────────────────────────────────────────
+    function mountIngestionProgress(jobIds) {
+        if (!jobIds.length) return;
+        const logEl    = document.getElementById('progress-log');
+        const spinner  = document.getElementById('log-spinner');
+        const titleEl  = document.getElementById('log-title');
+        const stepsList = document.getElementById('log-steps');
+        const summaryEl = document.getElementById('log-summary');
 
         logEl.classList.add('mup-log--visible');
 
+        const pending = new Set(jobIds);
         let es = null;
-        let finished = false;
+        let done = false;
 
         function appendStep(state) {
             const li = document.createElement('li');
@@ -220,55 +340,52 @@ document.addEventListener('DOMContentLoaded', function () {
             stepsList.appendChild(li);
         }
 
-        function finish(summaryText, isError) {
-            if (finished) return;
-            finished = true;
+        function finish(isError) {
+            if (done) return;
+            done = true;
             if (es) { es.close(); es = null; }
             spinner.classList.add('mup-spinner--hidden');
-            titleEl.textContent = isError
-                ? '{% trans "Ingestion failed" %}'
-                : '{% trans "Ingestion complete" %}';
-            summaryEl.textContent = summaryText;
-            summaryEl.className = 'mup-log-summary ' +
-                (isError ? 'mup-log-summary--error' : 'mup-log-summary--success');
+            const allOk = !isError;
+            titleEl.textContent = allOk
+                ? '{% trans "Ingestion complete" %}'
+                : '{% trans "Ingestion finished with errors" %}';
+            summaryEl.textContent = allOk
+                ? '{% trans "Items and assets created successfully." %}'
+                : '{% trans "Some files failed — check logs for details." %}';
+            summaryEl.className = 'mup-log-summary ' + (allOk ? 'mup-log-summary--success' : 'mup-log-summary--error');
             submitBtn.disabled = false;
         }
 
-        try {
-            es = new EventSource(sseUrl);
-        } catch (e) {
-            finish('{% trans "Could not open event stream." %}', true);
-            return;
-        }
+        try { es = new EventSource(SSE_URL); } catch (e) { finish(true); return; }
 
         es.addEventListener('job.progress_updated', function (ev) {
             const data = JSON.parse(ev.data);
-            if (data.job_id !== jobId) return;
-            if (data.state) appendStep(data.state);
+            if (pending.has(data.job_id) && data.state) appendStep(data.state);
         });
 
         es.addEventListener('job.state_changed', function (ev) {
             const data = JSON.parse(ev.data);
-            if (data.id !== jobId) return;
-            if (data.state === 'finished') {
-                finish('{% trans "Items and assets created successfully." %}', false);
-            } else if (data.state === 'failed' || data.state === 'cancelled') {
-                finish(data.error || '{% trans "Ingestion failed — check logs for details." %}', true);
+            if (!pending.has(data.id)) return;
+            if (data.state === 'finished') { pending.delete(data.id); }
+            else if (data.state === 'failed' || data.state === 'cancelled') { pending.delete(data.id); }
+            if (pending.size === 0) {
+                const hasError = data.state === 'failed' || data.state === 'cancelled';
+                finish(hasError);
             }
         });
 
-        es.onerror = function () {
-            if (!finished) {
-                es.close(); es = null;
-            }
-        };
+        es.onerror = function () { if (es) { es.close(); es = null; } };
     }
 
-    // ── Upload session status polling (fallback) ───────────────────────────
+    // ── Upload session polling (fallback / session completion) ─────────────
     function poll(sessionId) {
         fetch(STATUS_URL.replace('999999999', String(sessionId)))
             .then(function (r) { return r.json(); })
             .then(function (data) {
+                // Update per-file row statuses from polling response.
+                (data.files || []).forEach(function (f, i) {
+                    if (fileRows[i]) setRowStatus(fileRows[i], f.status);
+                });
                 if (!TERMINAL.includes(data.status)) {
                     pollTimer = setTimeout(function () { poll(sessionId); }, POLL_MS);
                 }
@@ -284,13 +401,32 @@ document.addEventListener('DOMContentLoaded', function () {
         clearError();
         if (pollTimer) clearTimeout(pollTimer);
 
+        const files = Array.from(fileInput.files);
+        if (!files.length) {
+            showError('{% trans "Please choose at least one file to upload." %}');
+            return;
+        }
+
         const fd = new FormData();
         fd.append('csrfmiddlewaretoken', CSRF_TOKEN);
-        if (variableSel) fd.append('variable_id', variableSel.value);
-        fd.append('time', timeInput.value);
-        fd.append('file', fileInput.files[0]);
+
+        files.forEach(function (file, i) {
+            fd.append('files', file);
+        });
+
+        if (IS_GEOTIFF) {
+            fileRows.forEach(function (row) {
+                fd.append('variable_ids', row._variableSel ? row._variableSel.value : '');
+                fd.append('times', row._timeInput ? row._timeInput.value : '');
+            });
+        } else {
+            files.forEach(function () {
+                fd.append('times', sharedTime ? sharedTime.value : '');
+            });
+        }
 
         submitBtn.disabled = true;
+        fileRows.forEach(function (row) { setRowStatus(row, 'uploading'); });
 
         fetch(SUBMIT_URL, { method: 'POST', body: fd })
             .then(function (r) { return r.json().then(function (data) { return { ok: r.ok, data: data }; }); })
@@ -298,15 +434,26 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (!res.ok || res.data.error) {
                     showError(res.data.error || '{% trans "Upload failed." %}');
                     submitBtn.disabled = false;
+                    fileRows.forEach(function (row) { setRowStatus(row, 'pending'); });
                     return;
                 }
+
+                const resultFiles = res.data.files || [];
+                const jobIds = [];
+
+                resultFiles.forEach(function (f, i) {
+                    if (fileRows[i]) setRowStatus(fileRows[i], f.status);
+                    if (f.job_id) jobIds.push(f.job_id);
+                });
+
                 form.style.display = 'none';
-                mountProgressLog(res.data.job_id, SSE_URL);
+                mountIngestionProgress(jobIds);
                 poll(res.data.upload_session_id);
             })
             .catch(function () {
                 showError('{% trans "Upload failed — network error." %}');
                 submitBtn.disabled = false;
+                fileRows.forEach(function (row) { setRowStatus(row, 'pending'); });
             });
     });
 

--- a/georiva/src/georiva/ingestion/tests/test_upload_page.py
+++ b/georiva/src/georiva/ingestion/tests/test_upload_page.py
@@ -64,17 +64,29 @@ class UploadPageRenderTests(TestCase):
         self.user = User.objects.create_superuser("admin_up", "u@p.com", "pw")
         self.client.force_login(self.user)
 
+    def test_file_input_accepts_multiple(self):
+        _, _, config, _ = _geotiff_setup()
+        response = self.client.get(PAGE_URL.format(config.pk))
+        self.assertContains(response, "multiple")
+
+    def test_geotiff_page_has_file_queue_container(self):
+        _, _, config, _ = _geotiff_setup()
+        response = self.client.get(PAGE_URL.format(config.pk))
+        self.assertContains(response, 'id="file-queue"')
+
     def test_page_renders_with_variable_dropdown_and_file_picker(self):
         _, _, config, variable = _geotiff_setup()
         response = self.client.get(PAGE_URL.format(config.pk))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "NDVI")
         self.assertContains(response, 'type="file"')
-        self.assertContains(response, 'type="datetime-local"')
+        # datetime-local inputs are JS-generated for GeoTIFF rows
+        self.assertContains(response, "datetime-local")
 
     def test_time_label_is_observation_date_for_non_forecast(self):
         _, _, config, _ = _geotiff_setup()
         response = self.client.get(PAGE_URL.format(config.pk))
+        # TIME_LABEL is injected as a JS constant and used as placeholder on row time inputs
         self.assertContains(response, "Observation date")
 
     def test_time_label_is_model_run_time_for_forecast(self):
@@ -157,22 +169,22 @@ class UploadSubmitTests(TestCase):
         catalog, collection, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("upload_session_id", data)
-        self.assertIn("uploaded_file_id", data)
+        self.assertIn("files", data)
         self.assertNotIn("data_arrival_id", data)
 
         session = UploadSession.objects.get(pk=data["upload_session_id"])
         self.assertEqual(session.catalog, catalog)
         self.assertEqual(session.status, "completed")
 
-        uf = UploadedFile.objects.get(pk=data["uploaded_file_id"])
+        uf = UploadedFile.objects.get(pk=data["files"][0]["id"])
         self.assertEqual(uf.status, "stored")
         self.assertEqual(uf.file_path, "imagery/ndvi/band_1/2025/01/15/20250115.tif")
 
@@ -181,9 +193,9 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _geotiff_setup()
 
         self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(UploadSession.objects.count(), 1)
@@ -193,9 +205,9 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _geotiff_setup()
 
         self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         fi = FileIngestion.objects.get(file_path="imagery/ndvi/band_1/2025/01/15/20250115.tif")
@@ -206,13 +218,13 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "2025-03-02T00:00",
-            "file": SimpleUploadedFile("scene.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": ["2025-03-02T00:00"],
+            "files": [SimpleUploadedFile("scene.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
-        uf = UploadedFile.objects.get(pk=response.json()["uploaded_file_id"])
+        uf = UploadedFile.objects.get(pk=response.json()["files"][0]["id"])
         self.assertEqual(uf.file_path, "imagery/ndvi/band_1/2025/03/02/scene.tif")
 
     def test_grib_forecast_path_gets_gr_prefix(self, mock_incoming, mock_task):
@@ -220,13 +232,12 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _grib_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "2025-01-15T06:00",
-            "file": SimpleUploadedFile("gfs.grib2", b"grib-bytes"),
+            "times": ["2025-01-15T06:00"],
+            "files": [SimpleUploadedFile("gfs.grib2", b"grib-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
-        uf = UploadedFile.objects.get(pk=response.json()["uploaded_file_id"])
+        uf = UploadedFile.objects.get(pk=response.json()["files"][0]["id"])
         self.assertEqual(uf.file_path, "models/GR--20250115T0600--gfs.grib2")
 
         mock_task.delay.assert_called_once()
@@ -239,12 +250,11 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _grib_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "2025-06-01T00:00",
-            "file": SimpleUploadedFile("GR--20250115T0600--gfs.grib2", b"grib-bytes"),
+            "times": ["2025-06-01T00:00"],
+            "files": [SimpleUploadedFile("GR--20250115T0600--gfs.grib2", b"grib-bytes")],
         })
 
-        uf = UploadedFile.objects.get(pk=response.json()["uploaded_file_id"])
+        uf = UploadedFile.objects.get(pk=response.json()["files"][0]["id"])
         self.assertEqual(uf.file_path, "models/GR--20250115T0600--gfs.grib2")
 
     def test_forecast_without_time_returns_400(self, mock_incoming, mock_task):
@@ -252,9 +262,8 @@ class UploadSubmitTests(TestCase):
         _, _, config, variable = _grib_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("gfs.grib2", b"grib-bytes"),
+            "times": [""],
+            "files": [SimpleUploadedFile("gfs.grib2", b"grib-bytes")],
         })
 
         self.assertEqual(response.status_code, 400)
@@ -266,7 +275,7 @@ class UploadSubmitTests(TestCase):
         mock_incoming.return_value = _mock_incoming_bucket()
         _, _, config, variable = _geotiff_setup()
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk, "time": "2025-01-15T00:00",
+            "variable_ids": [variable.pk], "times": ["2025-01-15T00:00"],
         })
         self.assertEqual(response.status_code, 400)
 
@@ -275,9 +284,9 @@ class UploadSubmitTests(TestCase):
         _, _, config, _ = _geotiff_setup()
         _, _, _, other_variable = _grib_setup()
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": other_variable.pk,
-            "time": "2025-01-15T00:00",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [other_variable.pk],
+            "times": ["2025-01-15T00:00"],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
         self.assertEqual(response.status_code, 400)
 
@@ -297,9 +306,9 @@ class UploadSubmitTests(TestCase):
         )
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
@@ -309,56 +318,186 @@ class UploadSubmitTests(TestCase):
         self.assertEqual(spent.error, "")
         mock_task.delay.assert_called_once()
 
-    def test_minio_failure_marks_uploaded_file_failed_and_returns_500(self, mock_incoming, mock_task):
+    def test_minio_failure_marks_uploaded_file_failed(self, mock_incoming, mock_task):
         bucket = MagicMock()
         bucket.save.side_effect = RuntimeError("minio down")
         mock_incoming.return_value = bucket
         _, _, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("upload_session_id", data)
+        self.assertEqual(data["files"][0]["status"], "failed")
         session = UploadSession.objects.get(pk=data["upload_session_id"])
-        self.assertEqual(session.status, "failed")
+        self.assertEqual(session.status, "completed")
         uf = UploadedFile.objects.get(session=session)
         self.assertEqual(uf.status, "failed")
         self.assertIn("minio down", uf.error)
         mock_task.delay.assert_not_called()
 
-    def test_submit_response_includes_job_id(self, mock_incoming, mock_task):
+    def test_submit_response_includes_job_id_in_files(self, mock_incoming, mock_task):
         mock_incoming.return_value = _mock_incoming_bucket()
         _, _, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn("job_id", data)
-        self.assertIsNotNone(data["job_id"])
+        self.assertIsNotNone(data["files"][0]["job_id"])
 
     def test_file_ingestion_job_exists_before_task_is_enqueued(self, mock_incoming, mock_task):
         mock_incoming.return_value = _mock_incoming_bucket()
         _, _, config, variable = _geotiff_setup()
 
         response = self.client.post(SUBMIT_URL.format(config.pk), {
-            "variable_id": variable.pk,
-            "time": "",
-            "file": SimpleUploadedFile("20250115.tif", b"tiff-bytes"),
+            "variable_ids": [variable.pk],
+            "times": [""],
+            "files": [SimpleUploadedFile("20250115.tif", b"tiff-bytes")],
         })
 
         self.assertEqual(response.status_code, 200)
-        job_id = response.json()["job_id"]
+        job_id = response.json()["files"][0]["job_id"]
         self.assertTrue(FileIngestionJob.objects.filter(pk=job_id).exists())
+
+
+# =============================================================================
+# Multi-file batch upload
+# =============================================================================
+
+@patch("georiva.ingestion.tasks.process_incoming_file")
+@patch("georiva.core.storage.StorageManager.incoming", new_callable=PropertyMock)
+class UploadSubmitMultiFileTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_mf", "mf@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_two_geotiff_files_create_one_session_two_uploaded_files(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_ids": [variable.pk, variable.pk],
+            "times": ["", ""],
+            "files": [
+                SimpleUploadedFile("20250115.tif", b"bytes-1"),
+                SimpleUploadedFile("20250116.tif", b"bytes-2"),
+            ],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UploadSession.objects.count(), 1)
+        self.assertEqual(UploadedFile.objects.count(), 2)
+        data = response.json()
+        self.assertEqual(len(data["files"]), 2)
+
+    def test_two_grib_files_create_one_session_two_uploaded_files(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, _ = _grib_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "times": ["2025-01-15T06:00", "2025-01-16T06:00"],
+            "files": [
+                SimpleUploadedFile("GR--20250115T0600--gfs.grib2", b"bytes-1"),
+                SimpleUploadedFile("GR--20250116T0600--gfs.grib2", b"bytes-2"),
+            ],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UploadSession.objects.count(), 1)
+        self.assertEqual(UploadedFile.objects.count(), 2)
+
+    def test_first_file_minio_failure_does_not_block_second(self, mock_incoming, mock_task):
+        bucket = MagicMock()
+        call_count = [0]
+
+        def side_effect(path, content):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("minio blip")
+            return path
+
+        bucket.save.side_effect = side_effect
+        mock_incoming.return_value = bucket
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_ids": [variable.pk, variable.pk],
+            "times": ["", ""],
+            "files": [
+                SimpleUploadedFile("20250115.tif", b"bytes-1"),
+                SimpleUploadedFile("20250116.tif", b"bytes-2"),
+            ],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["files"][0]["status"], "failed")
+        self.assertEqual(data["files"][1]["status"], "stored")
+        self.assertEqual(UploadedFile.objects.filter(status="stored").count(), 1)
+        self.assertEqual(UploadedFile.objects.filter(status="failed").count(), 1)
+
+    def test_session_completes_when_all_files_stored(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_ids": [variable.pk, variable.pk],
+            "times": ["", ""],
+            "files": [
+                SimpleUploadedFile("20250115.tif", b"bytes-1"),
+                SimpleUploadedFile("20250116.tif", b"bytes-2"),
+            ],
+        })
+
+        session = UploadSession.objects.get(pk=response.json()["upload_session_id"])
+        self.assertEqual(session.status, "completed")
+
+    def test_session_completes_even_when_one_file_fails(self, mock_incoming, mock_task):
+        bucket = MagicMock()
+        bucket.save.side_effect = [RuntimeError("fail"), "imagery/ndvi/band_1/2025/01/16/20250116.tif"]
+        mock_incoming.return_value = bucket
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_ids": [variable.pk, variable.pk],
+            "times": ["", ""],
+            "files": [
+                SimpleUploadedFile("20250115.tif", b"bytes-1"),
+                SimpleUploadedFile("20250116.tif", b"bytes-2"),
+            ],
+        })
+
+        session = UploadSession.objects.get(pk=response.json()["upload_session_id"])
+        self.assertEqual(session.status, "completed")
+
+    def test_each_stored_file_gets_its_own_ingestion_job(self, mock_incoming, mock_task):
+        mock_incoming.return_value = _mock_incoming_bucket()
+        _, _, config, variable = _geotiff_setup()
+
+        response = self.client.post(SUBMIT_URL.format(config.pk), {
+            "variable_ids": [variable.pk, variable.pk],
+            "times": ["", ""],
+            "files": [
+                SimpleUploadedFile("20250115.tif", b"bytes-1"),
+                SimpleUploadedFile("20250116.tif", b"bytes-2"),
+            ],
+        })
+
+        self.assertEqual(mock_task.delay.call_count, 2)
+        data = response.json()
+        self.assertIsNotNone(data["files"][0]["job_id"])
+        self.assertIsNotNone(data["files"][1]["job_id"])
+        self.assertNotEqual(data["files"][0]["job_id"], data["files"][1]["job_id"])
 
 
 @patch("georiva.ingestion.consumer.process_incoming_file")

--- a/georiva/src/georiva/ingestion/upload_views.py
+++ b/georiva/src/georiva/ingestion/upload_views.py
@@ -173,96 +173,98 @@ def manual_upload_submit(request, pk):
         ManualUploadConfig.objects.select_related("catalog"), pk=pk
     )
 
-    uploaded = request.FILES.get("file")
-    variable_id = request.POST.get("variable_id")
-    operator_time = _parse_datetime_local(request.POST.get("time", ""))
-
+    uploaded_files = request.FILES.getlist("files")
     is_geotiff = config.catalog.file_format == "geotiff"
+    variable_ids = request.POST.getlist("variable_ids")
+    times = request.POST.getlist("times")
 
-    errors = []
-    if not uploaded:
-        errors.append(str(_("Please choose a file to upload.")))
+    if not uploaded_files:
+        return JsonResponse({"error": str(_("Please choose a file to upload."))}, status=400)
 
-    variable = None
-    if variable_id:
-        variable = config.variables.select_related("collection").filter(pk=variable_id).first()
-    if is_geotiff and variable is None:
-        errors.append(str(_("Please choose a variable.")))
+    # For GeoTIFF, validate that each file has a corresponding variable.
+    if is_geotiff:
+        for i, uploaded in enumerate(uploaded_files):
+            vid = variable_ids[i] if i < len(variable_ids) else None
+            if not vid or not config.variables.filter(pk=vid).exists():
+                return JsonResponse(
+                    {"error": str(_("Please choose a variable for each file."))}, status=400
+                )
 
-    if errors:
-        return JsonResponse({"error": " ".join(errors)}, status=400)
-
-    reference_time, valid_time = _resolve_times(config, uploaded.name, operator_time)
-
-    if config.is_forecast and reference_time is None:
-        return JsonResponse(
-            {"error": str(_("Model run time is required for forecast uploads."))},
-            status=400,
-        )
-    if config.catalog.file_format == "geotiff" and valid_time is None:
-        return JsonResponse(
-            {"error": str(_(
-                "Could not determine the observation date. Use a filename matching "
-                "the '%s' format, or fill in the date field."
-            ) % config.valid_time_format)},
-            status=400,
-        )
-
-    file_path = _build_incoming_path(config, variable, uploaded.name, reference_time, valid_time)
+    # Pre-validate time requirements before creating the session.
+    for i, uploaded in enumerate(uploaded_files):
+        operator_time = _parse_datetime_local(times[i] if i < len(times) else "")
+        reference_time, valid_time = _resolve_times(config, uploaded.name, operator_time)
+        if config.is_forecast and reference_time is None:
+            return JsonResponse(
+                {"error": str(_("Model run time is required for forecast uploads."))},
+                status=400,
+            )
+        if is_geotiff and valid_time is None:
+            return JsonResponse(
+                {"error": str(_(
+                    "Could not determine the observation date. Use a filename matching "
+                    "the '%s' format, or fill in the date field."
+                ) % config.valid_time_format)},
+                status=400,
+            )
 
     session = UploadSession.objects.create(
         catalog=config.catalog,
         user=request.user if request.user.is_authenticated else None,
     )
-    uf = UploadedFile.objects.create(
-        session=session,
-        original_filename=uploaded.name,
-    )
-    uf.mark_uploading()
-
-    try:
-        saved_path = storage.incoming.save(file_path, uploaded)
-    except Exception as exc:
-        logger.error("Manual upload MinIO write failed for %s: %s", file_path, exc)
-        uf.mark_failed(error=str(exc)[:2000])
-        session.mark_failed()
-        return JsonResponse(
-            {"error": str(_("Upload to storage failed: %s") % exc),
-             "upload_session_id": session.pk},
-            status=500,
-        )
-
-    uf.mark_stored(file_path=saved_path, bytes=uploaded.size or 0)
-
-    # Register before enqueueing — idempotent with the bucket event that will also fire.
-    log, created = FileIngestion.register(
-        bucket=BucketType.INCOMING,
-        file_path=saved_path,
-        reference_time=reference_time,
-    )
-    if not created:
-        FileIngestion.reset_for_reingest(BucketType.INCOMING, saved_path)
 
     ct = ContentType.objects.get_for_model(FileIngestionJob, for_concrete_model=False)
-    job = FileIngestionJob.objects.create(
-        user=None,
-        content_type=ct,
-        file_path=saved_path,
-        bucket=BucketType.INCOMING,
-    )
+    result_files = []
 
-    process_incoming_file.delay(
-        file_path=saved_path,
-        origin_bucket=BucketType.INCOMING,
-        reference_time=reference_time.isoformat() if reference_time else None,
-        job_id=job.pk,
-    )
+    for i, uploaded in enumerate(uploaded_files):
+        vid = variable_ids[i] if i < len(variable_ids) else None
+        variable = (
+            config.variables.select_related("collection").filter(pk=vid).first()
+            if vid else None
+        )
+        operator_time = _parse_datetime_local(times[i] if i < len(times) else "")
+        reference_time, valid_time = _resolve_times(config, uploaded.name, operator_time)
 
-    from georiva.ingestion.events import publish_event
-    publish_event({"type": "upload_session.job_created", "id": session.pk, "job_id": job.pk})
+        file_path = _build_incoming_path(
+            config, variable, uploaded.name, reference_time, valid_time
+        )
 
-    return JsonResponse({
-        "upload_session_id": session.pk,
-        "uploaded_file_id": uf.pk,
-        "job_id": job.pk,
-    })
+        uf = UploadedFile.objects.create(session=session, original_filename=uploaded.name)
+        uf.mark_uploading()
+
+        try:
+            saved_path = storage.incoming.save(file_path, uploaded)
+        except Exception as exc:
+            logger.error("Manual upload MinIO write failed for %s: %s", file_path, exc)
+            uf.mark_failed(error=str(exc)[:2000])
+            result_files.append({"id": uf.pk, "status": "failed", "error": str(exc), "job_id": None})
+            continue
+
+        uf.mark_stored(file_path=saved_path, bytes=uploaded.size or 0)
+
+        # Register before enqueueing — idempotent with the bucket event that will also fire.
+        _fi, created = FileIngestion.register(
+            bucket=BucketType.INCOMING,
+            file_path=saved_path,
+            reference_time=reference_time,
+        )
+        if not created:
+            FileIngestion.reset_for_reingest(BucketType.INCOMING, saved_path)
+
+        job = FileIngestionJob.objects.create(
+            user=None,
+            content_type=ct,
+            file_path=saved_path,
+            bucket=BucketType.INCOMING,
+        )
+
+        process_incoming_file.delay(
+            file_path=saved_path,
+            origin_bucket=BucketType.INCOMING,
+            reference_time=reference_time.isoformat() if reference_time else None,
+            job_id=job.pk,
+        )
+
+        result_files.append({"id": uf.pk, "status": "stored", "job_id": job.pk})
+
+    return JsonResponse({"upload_session_id": session.pk, "files": result_files})


### PR DESCRIPTION
Closes #77

## Summary

- **Server**: `manual_upload_submit` accepts `files[]` / `variable_ids[]` / `times[]` arrays; creates one `UploadSession` + one `UploadedFile` per file; processes sequentially so a MinIO failure on one file does not block the rest; session auto-completes once all files reach a terminal state
- **Response**: `{upload_session_id, files: [{id, status, job_id}]}` (replaces single `{uploaded_file_id, job_id}`)
- **Template**: `<input type="file" multiple>`; `#file-queue` div shows per-file status rows — GeoTIFF rows include a JS-built variable select + datetime input (pre-filled via extract-times), GRIB/NetCDF rows show filename only with a shared time field; progress log tracks all job IDs via SSE; poll updates per-row statuses via `/api/upload-sessions/{id}/status/`

## Test plan

- [x] 223 ingestion tests pass (`make dev-test TEST_ARGS="georiva.ingestion.tests"`)
- [x] New `UploadSubmitMultiFileTests`: two-file GeoTIFF/GRIB batches, partial MinIO failure doesn't block second file, session completes after all files terminal, each stored file gets its own ingestion job
- [x] Existing `UploadSubmitTests` updated to new field names and response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)