### PR TITLE
feat(ingestion): per-file SSE events for Acquisition Feed real-time updates

### DIFF
--- a/georiva/src/georiva/ingestion/signals.py
+++ b/georiva/src/georiva/ingestion/signals.py
@@ -56,3 +56,19 @@ def _upload_session_post_save(sender, instance, created, update_fields, **kwargs
         "id": instance.pk,
         "status": instance.status,
     })
+
+
+@receiver(post_save, sender="georivaingestion.UploadedFile")
+def _uploaded_file_post_save(sender, instance, created, update_fields, **kwargs):
+    if created:
+        return
+    if update_fields is None or "status" not in update_fields:
+        return
+    from georiva.ingestion.events import publish_event
+    publish_event({
+        "type": "uploaded_file.status_changed",
+        "id": instance.pk,
+        "session_id": instance.session_id,
+        "status": instance.status,
+        "filename": instance.original_filename or instance.file_path or "",
+    })

--- a/georiva/src/georiva/ingestion/templates/georivaingestion/acquisition_feed.html
+++ b/georiva/src/georiva/ingestion/templates/georivaingestion/acquisition_feed.html
@@ -128,17 +128,42 @@ document.addEventListener('DOMContentLoaded', function () {
         return 'acq-file-status acq-file-status--' + status;
     }
 
+    function buildFileLi(f) {
+        const name = f.filename || f.original_filename || f.file_path || '';
+        const li = document.createElement('li');
+        if (f.id) li.dataset.fileId = f.id;
+        li.innerHTML =
+            '<span class="' + fileStatusClass(f.status) + '" data-file-status>' + f.status + '</span>' +
+            '<span>' + name + '</span>' +
+            (f.error ? '<span style="color:var(--w-color-critical-200)">' + f.error + '</span>' : '');
+        return li;
+    }
+
     function buildFileList(files) {
-        if (!files || !files.length) return '';
-        const rows = files.map(function (f) {
-            const name = f.filename || f.original_filename || f.file_path || '';
-            return '<li>' +
-                '<span class="' + fileStatusClass(f.status) + '">' + f.status + '</span>' +
-                '<span>' + name + '</span>' +
-                (f.error ? '<span style="color:var(--w-color-critical-200)">' + f.error + '</span>' : '') +
-                '</li>';
-        }).join('');
-        return '<ul class="acq-files">' + rows + '</ul>';
+        if (!files || !files.length) return '<ul class="acq-files"></ul>';
+        const ul = document.createElement('ul');
+        ul.className = 'acq-files';
+        files.forEach(function (f) { ul.appendChild(buildFileLi(f)); });
+        return ul.outerHTML;
+    }
+
+    function upsertFileRow(cardBody, fileId, status, filename) {
+        let li = cardBody.querySelector('[data-file-id="' + fileId + '"]');
+        if (li) {
+            const badge = li.querySelector('[data-file-status]');
+            if (badge) {
+                badge.textContent = status;
+                badge.className = fileStatusClass(status);
+            }
+        } else {
+            let ul = cardBody.querySelector('.acq-files');
+            if (!ul) {
+                ul = document.createElement('ul');
+                ul.className = 'acq-files';
+                cardBody.appendChild(ul);
+            }
+            ul.appendChild(buildFileLi({ id: fileId, status: status, file_path: filename || '' }));
+        }
     }
 
     function buildFetchRunCard(run) {
@@ -253,6 +278,22 @@ document.addEventListener('DOMContentLoaded', function () {
 
     es.addEventListener('upload_session.status_changed', function (ev) {
         onStatusChanged('upload_session', JSON.parse(ev.data));
+    });
+
+    es.addEventListener('fetched_file.status_changed', function (ev) {
+        const data = JSON.parse(ev.data);
+        const card = findCard('fetch_run', data.fetch_run_id);
+        if (!card) return;
+        const body = card.querySelector('.acq-card-body');
+        if (body) upsertFileRow(body, data.id, data.status, data.file_path || '');
+    });
+
+    es.addEventListener('uploaded_file.status_changed', function (ev) {
+        const data = JSON.parse(ev.data);
+        const card = findCard('upload_session', data.session_id);
+        if (!card) return;
+        const body = card.querySelector('.acq-card-body');
+        if (body) upsertFileRow(body, data.id, data.status, data.filename || '');
     });
 
     es.onerror = function () {

--- a/georiva/src/georiva/ingestion/tests/test_activity_feed.py
+++ b/georiva/src/georiva/ingestion/tests/test_activity_feed.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 User = get_user_model()
 
 ACTIVITY_URL = "/admin/ingestion/activity/"
+ACQUISITION_URL = "/admin/ingestion/acquisition/"
 
 
 # =============================================================================
@@ -93,3 +94,30 @@ class DashboardPanelViewAllTests(TestCase):
         ctx = panel.get_context_data({"request": request})
         html = render_to_string(panel.template_name, ctx)
         self.assertIn("/admin/ingestion/activity/", html)
+
+
+# =============================================================================
+# Acquisition Feed template — per-file live event wiring
+# =============================================================================
+
+class AcquisitionFeedPageTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_aq", "aq@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_acquisition_feed_returns_200(self):
+        response = self.client.get(ACQUISITION_URL)
+        self.assertEqual(response.status_code, 200)
+
+    def test_acquisition_feed_connects_to_sse_endpoint(self):
+        response = self.client.get(ACQUISITION_URL)
+        self.assertContains(response, "/admin/api/ingestion/acquisition/events/")
+
+    def test_acquisition_feed_handles_fetched_file_status_changed(self):
+        response = self.client.get(ACQUISITION_URL)
+        self.assertContains(response, "fetched_file.status_changed")
+
+    def test_acquisition_feed_handles_uploaded_file_status_changed(self):
+        response = self.client.get(ACQUISITION_URL)
+        self.assertContains(response, "uploaded_file.status_changed")

--- a/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
+++ b/georiva/src/georiva/ingestion/tests/test_ingestion_events.py
@@ -227,3 +227,128 @@ class UploadSessionEventTests(IngestionEventsTestCase):
         self.assertEqual(event["type"], "upload_session.status_changed")
         self.assertEqual(event["id"], session.pk)
         self.assertEqual(event["status"], "failed")
+
+
+# =============================================================================
+# Cycle 7: Per-file acquisition events (FetchedFile, UploadedFile)
+# =============================================================================
+
+class FetchedFileEventTests(IngestionEventsTestCase):
+
+    def _make_run(self):
+        from georiva.core.models import Catalog
+        from georiva.sources.models import DataFeed, FetchRun
+        catalog = Catalog.objects.create(name="FF", slug="ff-ev", file_format="grib2")
+        feed = DataFeed.objects.create(name="FF Feed", catalog=catalog)
+        return FetchRun.objects.create(data_feed=feed)
+
+    def test_mark_fetching_publishes_status_changed_event(self):
+        from georiva.sources.models import FetchedFile
+        run = self._make_run()
+        ff = FetchedFile.objects.create(fetch_run=run, file_path="cat/file.grib2")
+        self._drain()
+
+        ff.mark_fetching()
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "fetched_file.status_changed")
+        self.assertEqual(event["id"], ff.pk)
+        self.assertEqual(event["fetch_run_id"], run.pk)
+        self.assertEqual(event["status"], "fetching")
+        self.assertEqual(event["file_path"], "cat/file.grib2")
+
+    def test_mark_stored_publishes_status_changed_event(self):
+        from georiva.sources.models import FetchedFile
+        run = self._make_run()
+        ff = FetchedFile.objects.create(fetch_run=run, file_path="cat/file2.grib2")
+        self._drain()
+
+        ff.mark_stored(bytes_transferred=1024)
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "fetched_file.status_changed")
+        self.assertEqual(event["status"], "stored")
+
+    def test_mark_failed_publishes_status_changed_event(self):
+        from georiva.sources.models import FetchedFile
+        run = self._make_run()
+        ff = FetchedFile.objects.create(fetch_run=run, file_path="cat/file3.grib2")
+        self._drain()
+
+        ff.mark_failed(error="timeout")
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "fetched_file.status_changed")
+        self.assertEqual(event["status"], "failed")
+
+    def test_creation_does_not_publish_event(self):
+        from georiva.sources.models import FetchedFile
+        run = self._make_run()
+        self._drain()
+        FetchedFile.objects.create(fetch_run=run, file_path="cat/file4.grib2")
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)
+
+
+class UploadedFileEventTests(IngestionEventsTestCase):
+
+    def _make_session(self):
+        from georiva.core.models import Catalog
+        from georiva.ingestion.models import UploadSession
+        catalog = Catalog.objects.create(name="UF", slug="uf-ev", file_format="geotiff")
+        return UploadSession.objects.create(catalog=catalog)
+
+    def test_mark_uploading_publishes_status_changed_event(self):
+        from georiva.ingestion.models import UploadedFile
+        session = self._make_session()
+        uf = UploadedFile.objects.create(session=session, original_filename="rain.tif")
+        self._drain()
+
+        uf.mark_uploading()
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "uploaded_file.status_changed")
+        self.assertEqual(event["id"], uf.pk)
+        self.assertEqual(event["session_id"], session.pk)
+        self.assertEqual(event["status"], "uploading")
+        self.assertEqual(event["filename"], "rain.tif")
+
+    def test_mark_stored_publishes_status_changed_event(self):
+        from georiva.ingestion.models import UploadedFile
+        session = self._make_session()
+        uf = UploadedFile.objects.create(session=session, original_filename="rain2.tif")
+        self._drain()
+
+        uf.mark_stored(file_path="cat/rain2.tif", bytes=512)
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "uploaded_file.status_changed")
+        self.assertEqual(event["status"], "stored")
+
+    def test_mark_failed_publishes_status_changed_event(self):
+        from georiva.ingestion.models import UploadedFile
+        session = self._make_session()
+        uf = UploadedFile.objects.create(session=session, original_filename="rain3.tif")
+        self._drain()
+
+        uf.mark_failed(error="disk full")
+
+        event = self._next_event()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["type"], "uploaded_file.status_changed")
+        self.assertEqual(event["status"], "failed")
+
+    def test_creation_does_not_publish_event(self):
+        from georiva.ingestion.models import UploadedFile
+        session = self._make_session()
+        self._drain()
+        UploadedFile.objects.create(session=session, original_filename="rain4.tif")
+
+        event = self._next_event(timeout=0.5)
+        self.assertIsNone(event)

--- a/georiva/src/georiva/sources/signals.py
+++ b/georiva/src/georiva/sources/signals.py
@@ -20,3 +20,19 @@ def _fetch_run_post_save(sender, instance, created, update_fields, **kwargs):
         "id": instance.pk,
         "status": instance.status,
     })
+
+
+@receiver(post_save, sender="georivasources.FetchedFile")
+def _fetched_file_post_save(sender, instance, created, update_fields, **kwargs):
+    if created:
+        return
+    if update_fields is None or "status" not in update_fields:
+        return
+    from georiva.ingestion.events import publish_event
+    publish_event({
+        "type": "fetched_file.status_changed",
+        "id": instance.pk,
+        "fetch_run_id": instance.fetch_run_id,
+        "status": instance.status,
+        "file_path": instance.file_path,
+    })


### PR DESCRIPTION
Closes #72

## Summary

The last gap in the acquisition tracking epic: `FetchedFile` and `UploadedFile` status changes now push SSE events, and the Acquisition Feed template wires them up for real-time per-file progress.

- **`fetched_file.status_changed`**: new signal in `sources/signals.py` fires on every `FetchedFile` status transition (fetching → stored / skipped / failed); payload carries `{id, fetch_run_id, status, file_path}`
- **`uploaded_file.status_changed`**: new signal in `ingestion/signals.py` fires on every `UploadedFile` status transition (uploading → stored / failed); payload carries `{id, session_id, status, filename}`
- **`acquisition_feed.html`**: each file `<li>` now carries `data-file-id`; `upsertFileRow()` either updates an existing row's status badge or adds a new row when the file arrived after the snapshot; event listeners wired for both new event types

## Test plan

- [x] 235 ingestion tests pass (`make dev-test TEST_ARGS="georiva.ingestion.tests"`)
- [x] `FetchedFileEventTests`: all status transitions emit the event; creation does not
- [x] `UploadedFileEventTests`: all status transitions emit the event; creation does not
- [x] `AcquisitionFeedPageTests`: template renders both event type strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)