### PR TITLE
fix(ingestion): add collection fetch-runs API endpoint + rename arrivals → fetch_runs

### DIFF
--- a/georiva/src/georiva/ingestion/dashboard_views.py
+++ b/georiva/src/georiva/ingestion/dashboard_views.py
@@ -19,21 +19,21 @@ def ingestion_dashboard_api(request):
     from georiva.core.models import Collection
     from georiva.ingestion.models import FileIngestion
     from georiva.sources.models import DataFeedCollectionLink
-
+    
     collections = list(
         Collection.objects
         .select_related("catalog")
         .filter(is_active=True)
         .order_by("catalog__slug", "sort_order", "name")
     )
-
+    
     automated_collection_ids = set(
         DataFeedCollectionLink.objects.values_list('collection_id', flat=True)
     )
-
+    
     today = timezone.now().date()
     thirty_days_ago = today - timedelta(days=29)
-
+    
     # Sparkline data: one row per (FileIngestion × Collection) pair via M2M join.
     recent_logs = (
         FileIngestion.objects
@@ -42,41 +42,41 @@ def ingestion_dashboard_api(request):
         .values("collections", "status", "created_at")
         .order_by("created_at")
     )
-
+    
     logs_by_collection = defaultdict(list)
     for log in recent_logs:
         logs_by_collection[log["collections"]].append(log)
-
+    
     # Latest FileIngestion per collection (for last_run_at / last_run_status).
     collection_ids = [c.pk for c in collections]
     latest_fi_by_collection = {}
     for fi in (
-        FileIngestion.objects
-        .filter(collections__in=collection_ids)
-        .values("collections", "status", "created_at")
-        .order_by("collections", "-created_at")
-        .distinct("collections")
+            FileIngestion.objects
+                    .filter(collections__in=collection_ids)
+                    .values("collections", "status", "created_at")
+                    .order_by("collections", "-created_at")
+                    .distinct("collections")
     ):
         latest_fi_by_collection[fi["collections"]] = fi
-
+    
     result = []
-
+    
     for collection in collections:
         is_automated = collection.pk in automated_collection_ids
         logs = logs_by_collection.get(collection.pk, [])
-
+        
         sparkline = _build_sparkline(logs, today)
-
+        
         last_run_at = None
         last_run_status = None
-
+        
         latest_fi = latest_fi_by_collection.get(collection.pk)
         if latest_fi:
             last_run_at = latest_fi["created_at"].isoformat()
             last_run_status = latest_fi["status"]
-
+        
         status = _derive_status(sparkline)
-
+        
         result.append({
             "id": collection.pk,
             "slug": collection.slug,
@@ -91,7 +91,7 @@ def ingestion_dashboard_api(request):
             "status": status,
             "sparkline": sparkline,
         })
-
+    
     return JsonResponse({"collections": result})
 
 
@@ -195,16 +195,66 @@ def collection_ingestion_logs_api(request, collection_id):
     return JsonResponse({"logs": result})
 
 
+def collection_fetch_runs_api(request, collection_id):
+    """
+    Returns FetchRun history for all DataFeeds linked to one collection.
+    Used by CollectionDrawer "Loader Runs" tab for automated collections.
+    """
+    from georiva.core.models import Collection
+    from georiva.sources.models import DataFeedCollectionLink, FetchRun
+    
+    try:
+        Collection.objects.get(pk=collection_id)
+    except Collection.DoesNotExist:
+        raise Http404
+    
+    feed_ids = list(
+        DataFeedCollectionLink.objects
+        .filter(collection_id=collection_id)
+        .values_list("data_feed_id", flat=True)
+    )
+    
+    runs = (
+        FetchRun.objects
+        .filter(data_feed_id__in=feed_ids)
+        .select_related("data_feed")
+        .order_by("-started_at")[:100]
+    )
+    
+    result = []
+    for run in runs:
+        duration = None
+        if run.finished_at and run.started_at:
+            duration = (run.finished_at - run.started_at).total_seconds()
+        
+        errors = [run.error_message] if run.error_message else []
+        
+        result.append({
+            "id": run.pk,
+            "status": run.status,
+            "started_at": run.started_at.isoformat(),
+            "duration_seconds": duration,
+            "run_time": None,
+            "data_feed_name": run.data_feed.name,
+            "files_fetched": run.files_fetched,
+            "files_skipped": run.files_skipped,
+            "files_failed": run.files_failed,
+            "bytes_transferred": run.bytes_transferred,
+            "errors": errors,
+        })
+    
+    return JsonResponse({"fetch_runs": result})
+
 
 def upload_session_status_api(request, session_id):
     """Returns {id, status, files} for a single UploadSession."""
     from georiva.ingestion.models import UploadSession
-
+    
     try:
         session = UploadSession.objects.prefetch_related('uploaded_files').get(pk=session_id)
     except UploadSession.DoesNotExist:
         raise Http404
-
+    
     return JsonResponse({
         "id": session.pk,
         "status": session.status,

--- a/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
+++ b/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
@@ -15,6 +15,7 @@ User = get_user_model()
 DASHBOARD_URL = "/admin/api/ingestion/dashboard/"
 LOGS_URL = "/admin/api/ingestion/collections/{}/ingestion-logs/"
 JOBS_URL = "/admin/api/ingestion/collections/{}/ingestion-jobs/"
+FETCH_RUNS_URL = "/admin/api/ingestion/collections/{}/fetch-runs/"
 
 
 def _setup_collection(catalog_slug="cat", collection_slug="col"):
@@ -205,6 +206,72 @@ class CollectionIngestionLogsAPITests(TestCase):
 
         self.assertEqual(len(resp_x.json()["logs"]), 1)
         self.assertEqual(len(resp_y.json()["logs"]), 1)
+
+
+class CollectionFetchRunsAPITests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin5", "g@h.com", "pw")
+        self.client.force_login(self.user)
+        catalog = Catalog.objects.create(name="cat5", slug="cat5", file_format="grib2")
+        self.collection = Collection.objects.create(name="col5", slug="col5", catalog=catalog)
+        self.feed = DataFeed.objects.create(name="Test Feed")
+        DataFeedCollectionLink.objects.create(data_feed=self.feed, collection=self.collection)
+
+    def test_fetch_runs_returns_200(self):
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        self.assertEqual(response.status_code, 200)
+
+    def test_fetch_runs_returns_fetch_runs_key(self):
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        self.assertIn("fetch_runs", response.json())
+
+    def test_fetch_runs_includes_runs_for_collection_feed(self):
+        from georiva.sources.models import FetchRun
+        run = FetchRun.objects.create(data_feed=self.feed)
+
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        data = response.json()
+        self.assertEqual(len(data["fetch_runs"]), 1)
+        entry = data["fetch_runs"][0]
+        self.assertEqual(entry["id"], run.pk)
+        self.assertEqual(entry["status"], "running")
+        self.assertIn("started_at", entry)
+        self.assertIn("files_fetched", entry)
+        self.assertIn("files_skipped", entry)
+        self.assertIn("files_failed", entry)
+        self.assertIn("bytes_transferred", entry)
+        self.assertEqual(entry["data_feed_name"], self.feed.name)
+
+    def test_fetch_runs_excludes_runs_from_unrelated_feeds(self):
+        from georiva.sources.models import FetchRun
+        other_feed = DataFeed.objects.create(name="Other Feed")
+        FetchRun.objects.create(data_feed=other_feed)
+
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        self.assertEqual(len(response.json()["fetch_runs"]), 0)
+
+    def test_fetch_runs_returns_404_for_unknown_collection(self):
+        response = self.client.get(FETCH_RUNS_URL.format(99999))
+        self.assertEqual(response.status_code, 404)
+
+    def test_fetch_runs_duration_seconds_set_when_run_finished(self):
+        from django.utils import timezone
+        from georiva.sources.models import FetchRun
+        run = FetchRun.objects.create(data_feed=self.feed)
+        run.finished_at = run.started_at + timedelta(seconds=42)
+        run.save(update_fields=["finished_at"])
+
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        entry = response.json()["fetch_runs"][0]
+        self.assertAlmostEqual(entry["duration_seconds"], 42, delta=1)
+
+    def test_fetch_runs_duration_seconds_null_when_run_not_finished(self):
+        from georiva.sources.models import FetchRun
+        FetchRun.objects.create(data_feed=self.feed)
+
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        entry = response.json()["fetch_runs"][0]
+        self.assertIsNone(entry["duration_seconds"])
 
 
 def _make_job(fi, **kwargs):

--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -34,6 +34,7 @@ def register_ingestion_dashboard_urls():
         ingestion_dashboard_api,
         collection_ingestion_logs_api,
         collection_ingestion_jobs_api,
+        collection_fetch_runs_api,
     )
     from .sse_views import ingestion_events_sse, acquisition_events_sse
 
@@ -47,6 +48,8 @@ def register_ingestion_dashboard_urls():
              name="collection_ingestion_logs_api"),
         path("api/ingestion/collections/<int:collection_id>/ingestion-jobs/", collection_ingestion_jobs_api,
              name="collection_ingestion_jobs_api"),
+        path("api/ingestion/collections/<int:collection_id>/fetch-runs/", collection_fetch_runs_api,
+             name="collection_fetch_runs_api"),
     ]
 
 


### PR DESCRIPTION
## Summary

- Adds `collection_fetch_runs_api` view returning `FetchRun` history for all `DataFeed`s linked to a collection at `/api/ingestion/collections/<id>/fetch-runs/`
- Renames legacy `arrivals` URL path and response key to `fetch_runs` to align with the model name after `DataArrival` was dropped in #82
- Adds `CollectionFetchRunsAPITests` covering 200 response, correct response key, feed scoping, 404, and duration calculation

## Test plan

- [ ] `make dev-test TEST_ARGS="georiva.ingestion.tests.test_dashboard_api.CollectionFetchRunsAPITests"`
- [ ] Verify `/admin/api/ingestion/collections/<id>/fetch-runs/` returns `{"fetch_runs": [...]}` for a collection linked to a DataFeed
- [ ] Verify 404 for unknown collection id

🤖 Generated with [Claude Code](https://claude.com/claude-code)