### PR TITLE
feat(ingestion): catalog-grouped dashboard API, upload-sessions endpoint, File History sort + cleanup

### DIFF
--- a/georiva/src/georiva/ingestion/dashboard_views.py
+++ b/georiva/src/georiva/ingestion/dashboard_views.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 
+from django.db import models
 from django.http import JsonResponse, Http404
 from django.utils import timezone
 
@@ -14,27 +15,26 @@ logger = logging.getLogger(__name__)
 
 def ingestion_dashboard_api(request):
     """
-    Returns collection list with ingestion health data for the dashboard.
+    Returns collections grouped under their parent Catalog with health roll-ups.
     """
-    from georiva.core.models import Collection
+    from georiva.core.models import Catalog, Collection
     from georiva.ingestion.models import FileIngestion
     from georiva.sources.models import DataFeedCollectionLink
-    
+
     collections = list(
         Collection.objects
         .select_related("catalog")
         .filter(is_active=True)
         .order_by("catalog__slug", "sort_order", "name")
     )
-    
+
     automated_collection_ids = set(
         DataFeedCollectionLink.objects.values_list('collection_id', flat=True)
     )
-    
+
     today = timezone.now().date()
     thirty_days_ago = today - timedelta(days=29)
-    
-    # Sparkline data: one row per (FileIngestion × Collection) pair via M2M join.
+
     recent_logs = (
         FileIngestion.objects
         .filter(created_at__date__gte=thirty_days_ago)
@@ -42,57 +42,68 @@ def ingestion_dashboard_api(request):
         .values("collections", "status", "created_at")
         .order_by("created_at")
     )
-    
+
     logs_by_collection = defaultdict(list)
     for log in recent_logs:
         logs_by_collection[log["collections"]].append(log)
-    
-    # Latest FileIngestion per collection (for last_run_at / last_run_status).
+
     collection_ids = [c.pk for c in collections]
     latest_fi_by_collection = {}
     for fi in (
-            FileIngestion.objects
-                    .filter(collections__in=collection_ids)
-                    .values("collections", "status", "created_at")
-                    .order_by("collections", "-created_at")
-                    .distinct("collections")
+        FileIngestion.objects
+        .filter(collections__in=collection_ids)
+        .values("collections", "status", "created_at")
+        .order_by("collections", "-created_at")
+        .distinct("collections")
     ):
         latest_fi_by_collection[fi["collections"]] = fi
-    
-    result = []
-    
+
+    # Build per-collection entries grouped by catalog pk.
+    collections_by_catalog = defaultdict(list)
+    catalog_index = {}
+
     for collection in collections:
-        is_automated = collection.pk in automated_collection_ids
         logs = logs_by_collection.get(collection.pk, [])
-        
         sparkline = _build_sparkline(logs, today)
-        
-        last_run_at = None
-        last_run_status = None
-        
+
         latest_fi = latest_fi_by_collection.get(collection.pk)
-        if latest_fi:
-            last_run_at = latest_fi["created_at"].isoformat()
-            last_run_status = latest_fi["status"]
-        
-        status = _derive_status(sparkline)
-        
-        result.append({
+        last_run_at = latest_fi["created_at"].isoformat() if latest_fi else None
+        last_run_status = latest_fi["status"] if latest_fi else None
+
+        col_entry = {
             "id": collection.pk,
             "slug": collection.slug,
             "name": collection.name,
             "catalog": collection.catalog.slug,
             "catalog_name": collection.catalog.name,
-            "type": "automated" if is_automated else "manual",
+            "type": "automated" if collection.pk in automated_collection_ids else "manual",
             "is_active": collection.is_active,
             "item_count": collection.item_count,
             "last_run_at": last_run_at,
             "last_run_status": last_run_status,
-            "status": status,
+            "status": _derive_status(sparkline),
             "sparkline": sparkline,
+        }
+
+        catalog = collection.catalog
+        catalog_index[catalog.pk] = catalog
+        collections_by_catalog[catalog.pk].append(col_entry)
+
+    result = []
+    for catalog_pk, col_entries in collections_by_catalog.items():
+        catalog = catalog_index[catalog_pk]
+        cat_status, summary = _derive_catalog_status(col_entries)
+        result.append({
+            "id": catalog.pk,
+            "slug": catalog.slug,
+            "name": catalog.name,
+            "status": cat_status,
+            "summary": summary,
+            "collections": col_entries,
         })
-    
-    return JsonResponse({"collections": result})
+
+    result.sort(key=lambda c: c["slug"])
+    return JsonResponse({"catalogs": result})
 
 
 # =============================================================================
@@ -174,7 +185,15 @@ def collection_ingestion_logs_api(request, collection_id):
     logs = (
         FileIngestion.objects
         .filter(collections=collection)
-        .order_by("-created_at")[:200]
+        .order_by(
+            # Failed records first, then most-recent-first within each group.
+            models.Case(
+                models.When(status=FileIngestion.Status.FAILED, then=0),
+                default=1,
+                output_field=models.IntegerField(),
+            ),
+            "-created_at",
+        )[:200]
     )
     
     result = []
@@ -234,7 +253,6 @@ def collection_fetch_runs_api(request, collection_id):
             "status": run.status,
             "started_at": run.started_at.isoformat(),
             "duration_seconds": duration,
-            "run_time": None,
             "data_feed_name": run.data_feed.name,
             "files_fetched": run.files_fetched,
             "files_skipped": run.files_skipped,
@@ -244,6 +262,62 @@ def collection_fetch_runs_api(request, collection_id):
         })
     
     return JsonResponse({"fetch_runs": result})
+
+
+def collection_upload_sessions_api(request, collection_id):
+    """
+    Returns UploadSession records associated with a Collection via FileIngestion.collections M2M.
+    Used by the CollectionDrawer Acquisition tab for manual Collections.
+    """
+    from georiva.core.models import Collection
+    from georiva.ingestion.models import FileIngestion, UploadedFile, UploadSession
+
+    try:
+        Collection.objects.get(pk=collection_id)
+    except Collection.DoesNotExist:
+        raise Http404
+
+    fi_paths = (
+        FileIngestion.objects
+        .filter(collections=collection_id)
+        .values_list("file_path", flat=True)
+    )
+
+    session_ids = (
+        UploadedFile.objects
+        .filter(file_path__in=fi_paths)
+        .values_list("session_id", flat=True)
+        .distinct()
+    )
+
+    sessions = (
+        UploadSession.objects
+        .filter(pk__in=session_ids)
+        .select_related("user")
+        .prefetch_related("uploaded_files")
+        .order_by("-started_at")[:100]
+    )
+
+    result = []
+    for session in sessions:
+        duration = None
+        if session.completed_at and session.started_at:
+            duration = (session.completed_at - session.started_at).total_seconds()
+
+        files = list(session.uploaded_files.all())
+        result.append({
+            "id": session.pk,
+            "status": session.status,
+            "started_at": session.started_at.isoformat(),
+            "completed_at": session.completed_at.isoformat() if session.completed_at else None,
+            "duration_seconds": duration,
+            "files_count": len(files),
+            "files_stored": sum(1 for f in files if f.status == "stored"),
+            "files_failed": sum(1 for f in files if f.status == "failed"),
+            "uploaded_by": session.user.username if session.user else None,
+        })
+
+    return JsonResponse({"upload_sessions": result})
 
 
 def upload_session_status_api(request, session_id):
@@ -297,6 +371,20 @@ def _build_sparkline(logs, today):
         sparkline.append({"date": str(d), "status": status})
     
     return sparkline
+
+
+def _derive_catalog_status(col_entries):
+    statuses = [c["status"] for c in col_entries]
+    summary = {
+        "ok": statuses.count("ok"),
+        "failed": statuses.count("failed"),
+        "empty": statuses.count("empty"),
+    }
+    if summary["failed"] > 0:
+        return "failed", summary
+    if summary["ok"] > 0:
+        return "ok", summary
+    return "empty", summary
 
 
 def _derive_status(sparkline):

--- a/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
+++ b/georiva/src/georiva/ingestion/tests/test_dashboard_api.py
@@ -16,6 +16,7 @@ DASHBOARD_URL = "/admin/api/ingestion/dashboard/"
 LOGS_URL = "/admin/api/ingestion/collections/{}/ingestion-logs/"
 JOBS_URL = "/admin/api/ingestion/collections/{}/ingestion-jobs/"
 FETCH_RUNS_URL = "/admin/api/ingestion/collections/{}/fetch-runs/"
+UPLOAD_SESSIONS_URL = "/admin/api/ingestion/collections/{}/upload-sessions/"
 
 
 def _setup_collection(catalog_slug="cat", collection_slug="col"):
@@ -35,6 +36,94 @@ def _make_file_ingestion(collection, file_path=None, status=FileIngestion.Status
     return fi
 
 
+class DashboardCatalogGroupedTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_cg", "cg@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(name="CHIRPS", slug="chirps", file_format="grib2")
+        self.collection = Collection.objects.create(name="Daily", slug="daily", catalog=self.catalog)
+
+    def test_dashboard_returns_catalogs_key(self):
+        response = self.client.get(DASHBOARD_URL)
+        self.assertIn("catalogs", response.json())
+
+    def test_collections_nested_under_parent_catalog(self):
+        response = self.client.get(DASHBOARD_URL)
+        catalogs = response.json()["catalogs"]
+        cat = next(c for c in catalogs if c["id"] == self.catalog.pk)
+        col_ids = [c["id"] for c in cat["collections"]]
+        self.assertIn(self.collection.pk, col_ids)
+
+    def test_catalog_entry_has_required_fields(self):
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        for field in ("id", "slug", "name", "status", "summary", "collections"):
+            self.assertIn(field, cat)
+
+    def test_catalog_status_is_failed_when_any_child_is_failed(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.FAILED)
+        col2 = Collection.objects.create(name="Monthly", slug="monthly", catalog=self.catalog)
+        _make_file_ingestion(col2, status=FileIngestion.Status.COMPLETED)
+
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        self.assertEqual(cat["status"], "failed")
+
+    def test_catalog_status_is_empty_when_all_children_are_empty(self):
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        self.assertEqual(cat["status"], "empty")
+
+    def test_catalog_status_is_ok_when_no_child_is_failed(self):
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
+
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        self.assertEqual(cat["status"], "ok")
+
+    def test_catalog_summary_counts_are_accurate(self):
+        col2 = Collection.objects.create(name="Monthly", slug="monthly", catalog=self.catalog)
+        col3 = Collection.objects.create(name="Weekly", slug="weekly", catalog=self.catalog)
+        _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
+        _make_file_ingestion(col2, status=FileIngestion.Status.FAILED)
+        # col3 has no FileIngestion → empty
+
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        self.assertEqual(cat["summary"]["ok"], 1)
+        self.assertEqual(cat["summary"]["failed"], 1)
+        self.assertEqual(cat["summary"]["empty"], 1)
+
+    def test_catalog_with_no_active_collections_excluded(self):
+        empty_catalog = Catalog.objects.create(name="Empty", slug="empty-cat", file_format="grib2")
+        col = Collection.objects.create(name="col", slug="col-e", catalog=empty_catalog)
+        col.is_active = False
+        col.save()
+
+        response = self.client.get(DASHBOARD_URL)
+        catalog_ids = [c["id"] for c in response.json()["catalogs"]]
+        self.assertNotIn(empty_catalog.pk, catalog_ids)
+
+    def test_per_collection_fields_preserved_in_nested_entry(self):
+        response = self.client.get(DASHBOARD_URL)
+        cat = next(c for c in response.json()["catalogs"] if c["id"] == self.catalog.pk)
+        col = next(c for c in cat["collections"] if c["id"] == self.collection.pk)
+        for field in ("id", "slug", "name", "type", "status", "sparkline", "last_run_at", "item_count"):
+            self.assertIn(field, col)
+
+
+def _find_collection_in_response(data, collection_pk):
+    for cat in data["catalogs"]:
+        for col in cat["collections"]:
+            if col["id"] == collection_pk:
+                return col
+    return None
+
+
+def _all_collections_in_response(data):
+    return [col for cat in data["catalogs"] for col in cat["collections"]]
+
+
 class DashboardCollectionListTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_superuser("admin", "admin@test.com", "pw")
@@ -43,8 +132,7 @@ class DashboardCollectionListTests(TestCase):
 
     def test_collection_with_no_file_ingestions_has_null_last_run_fields(self):
         response = self.client.get(DASHBOARD_URL)
-        data = response.json()
-        col = next(c for c in data["collections"] if c["id"] == self.collection.pk)
+        col = _find_collection_in_response(response.json(), self.collection.pk)
 
         self.assertIsNone(col["last_run_at"])
         self.assertIsNone(col["last_run_status"])
@@ -58,12 +146,11 @@ class DashboardCollectionListTests(TestCase):
             self.collection, file_path="cat/col/new.grib2",
             status=FileIngestion.Status.FAILED,
         )
-        # Force newer to have a later created_at
         newer.created_at = older.created_at + timedelta(seconds=10)
         newer.save(update_fields=["created_at"])
 
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        col = _find_collection_in_response(response.json(), self.collection.pk)
 
         self.assertEqual(col["last_run_status"], FileIngestion.Status.FAILED)
 
@@ -73,7 +160,7 @@ class DashboardCollectionListTests(TestCase):
         inactive.save()
 
         response = self.client.get(DASHBOARD_URL)
-        ids = [c["id"] for c in response.json()["collections"]]
+        ids = [c["id"] for c in _all_collections_in_response(response.json())]
         self.assertNotIn(inactive.pk, ids)
 
     def test_type_field_is_automated_when_data_feed_link_exists(self):
@@ -82,45 +169,43 @@ class DashboardCollectionListTests(TestCase):
         DataFeedCollectionLink.objects.create(data_feed=feed, collection=automated_col)
 
         response = self.client.get(DASHBOARD_URL)
-        by_id = {c["id"]: c for c in response.json()["collections"]}
+        by_id = {c["id"]: c for c in _all_collections_in_response(response.json())}
 
         self.assertEqual(by_id[automated_col.pk]["type"], "automated")
         self.assertEqual(by_id[self.collection.pk]["type"], "manual")
 
     def test_derived_status_is_empty_when_no_file_ingestion_logs(self):
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        col = _find_collection_in_response(response.json(), self.collection.pk)
         self.assertEqual(col["status"], "empty")
 
     def test_derived_status_is_ok_when_completed_file_ingestion_linked_via_m2m(self):
         _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
 
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        col = _find_collection_in_response(response.json(), self.collection.pk)
         self.assertEqual(col["status"], "ok")
 
     def test_derived_status_is_failed_when_failed_file_ingestion_linked_via_m2m(self):
         _make_file_ingestion(self.collection, status=FileIngestion.Status.FAILED)
 
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
+        col = _find_collection_in_response(response.json(), self.collection.pk)
         self.assertEqual(col["status"], "failed")
 
     def test_grib_collection_shows_success_sparkline_via_m2m(self):
         _make_file_ingestion(self.collection, status=FileIngestion.Status.COMPLETED)
 
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
-        today_entry = col["sparkline"][-1]
-        self.assertEqual(today_entry["status"], "success")
+        col = _find_collection_in_response(response.json(), self.collection.pk)
+        self.assertEqual(col["sparkline"][-1]["status"], "success")
 
     def test_grib_collection_shows_failed_sparkline_when_no_items_created(self):
         _make_file_ingestion(self.collection, status=FileIngestion.Status.FAILED)
 
         response = self.client.get(DASHBOARD_URL)
-        col = next(c for c in response.json()["collections"] if c["id"] == self.collection.pk)
-        today_entry = col["sparkline"][-1]
-        self.assertEqual(today_entry["status"], "failed")
+        col = _find_collection_in_response(response.json(), self.collection.pk)
+        self.assertEqual(col["sparkline"][-1]["status"], "failed")
 
     def test_multi_collection_grib_independent_sparkline_statuses(self):
         catalog = Catalog.objects.create(name="shared-cat", slug="shared-cat", file_format="grib2")
@@ -142,7 +227,7 @@ class DashboardCollectionListTests(TestCase):
         fi_b.collections.add(col_b)
 
         response = self.client.get(DASHBOARD_URL)
-        by_id = {c["id"]: c for c in response.json()["collections"]}
+        by_id = {c["id"]: c for c in _all_collections_in_response(response.json())}
 
         self.assertEqual(by_id[col_a.pk]["sparkline"][-1]["status"], "success")
         self.assertEqual(by_id[col_b.pk]["sparkline"][-1]["status"], "failed")
@@ -188,6 +273,44 @@ class CollectionIngestionLogsAPITests(TestCase):
     def test_ingestion_logs_returns_404_for_unknown_collection(self):
         response = self.client.get(LOGS_URL.format(99999))
         self.assertEqual(response.status_code, 404)
+
+    def test_failed_records_appear_before_non_failed_records(self):
+        # The completed record is created AFTER the failed one — so plain
+        # most-recent-first ordering would put it first. Pinning must override this.
+        fi_fail = _make_file_ingestion(
+            self.collection, file_path="cat3/col3/fail.grib2",
+            status=FileIngestion.Status.FAILED,
+        )
+        fi_ok = _make_file_ingestion(
+            self.collection, file_path="cat3/col3/ok.grib2",
+            status=FileIngestion.Status.COMPLETED,
+        )
+        fi_ok.created_at = fi_fail.created_at + timedelta(seconds=5)
+        fi_ok.save(update_fields=["created_at"])
+
+        response = self.client.get(LOGS_URL.format(self.collection.pk))
+        logs = response.json()["logs"]
+        statuses = [l["status"] for l in logs]
+        failed_indices = [i for i, s in enumerate(statuses) if s == "failed"]
+        non_failed_indices = [i for i, s in enumerate(statuses) if s != "failed"]
+        self.assertTrue(all(f < nf for f in failed_indices for nf in non_failed_indices))
+
+    def test_within_failed_group_most_recent_first(self):
+        fi1 = _make_file_ingestion(
+            self.collection, file_path="cat3/col3/fail1.grib2",
+            status=FileIngestion.Status.FAILED,
+        )
+        fi2 = _make_file_ingestion(
+            self.collection, file_path="cat3/col3/fail2.grib2",
+            status=FileIngestion.Status.FAILED,
+        )
+        fi2.created_at = fi1.created_at + timedelta(seconds=10)
+        fi2.save(update_fields=["created_at"])
+
+        response = self.client.get(LOGS_URL.format(self.collection.pk))
+        logs = response.json()["logs"]
+        self.assertEqual(logs[0]["id"], fi2.pk)
+        self.assertEqual(logs[1]["id"], fi1.pk)
 
     def test_ingestion_logs_for_grib_collection_linked_via_m2m(self):
         catalog = Catalog.objects.create(name="grib-cat", slug="grib-cat", file_format="grib2")
@@ -273,6 +396,14 @@ class CollectionFetchRunsAPITests(TestCase):
         entry = response.json()["fetch_runs"][0]
         self.assertIsNone(entry["duration_seconds"])
 
+    def test_fetch_runs_does_not_include_run_time_field(self):
+        from georiva.sources.models import FetchRun
+        FetchRun.objects.create(data_feed=self.feed)
+
+        response = self.client.get(FETCH_RUNS_URL.format(self.collection.pk))
+        entry = response.json()["fetch_runs"][0]
+        self.assertNotIn("run_time", entry)
+
 
 def _make_job(fi, **kwargs):
     ct = ContentType.objects.get_for_model(FileIngestionJob)
@@ -334,3 +465,74 @@ class CollectionIngestionJobsAPITests(TestCase):
     def test_ingestion_jobs_returns_404_for_unknown_collection(self):
         response = self.client.get(JOBS_URL.format(99999))
         self.assertEqual(response.status_code, 404)
+
+
+def _make_upload_session(catalog, user=None, file_path=None, collection=None):
+    """Create an UploadSession with one UploadedFile, optionally linked via FileIngestion."""
+    from georiva.ingestion.models import UploadSession, UploadedFile
+    session = UploadSession.objects.create(catalog=catalog, user=user)
+    fp = file_path or f"{catalog.slug}/file.grib2"
+    uf = UploadedFile.objects.create(session=session, original_filename="file.grib2", file_path=fp)
+    if collection is not None:
+        fi = FileIngestion.objects.create(bucket=BucketType.SOURCES, file_path=fp)
+        fi.collections.add(collection)
+    return session
+
+
+class CollectionUploadSessionsAPITests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_us", "us@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(name="cat-us", slug="cat-us", file_format="grib2")
+        self.collection = Collection.objects.create(name="col-us", slug="col-us", catalog=self.catalog)
+
+    def test_upload_sessions_returns_200_with_upload_sessions_key(self):
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("upload_sessions", response.json())
+
+    def test_upload_sessions_returns_sessions_linked_via_file_ingestion_m2m(self):
+        session = _make_upload_session(self.catalog, collection=self.collection)
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        ids = [s["id"] for s in response.json()["upload_sessions"]]
+        self.assertIn(session.pk, ids)
+
+    def test_upload_sessions_excludes_unlinked_sessions(self):
+        other_collection = Collection.objects.create(
+            name="other", slug="other-col", catalog=self.catalog
+        )
+        _make_upload_session(self.catalog, collection=other_collection)
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        self.assertEqual(len(response.json()["upload_sessions"]), 0)
+
+    def test_upload_sessions_returns_404_for_unknown_collection(self):
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(99999))
+        self.assertEqual(response.status_code, 404)
+
+    def test_upload_sessions_duration_seconds_set_when_completed(self):
+        from georiva.ingestion.models import UploadSession
+        session = _make_upload_session(self.catalog, collection=self.collection)
+        session.completed_at = session.started_at + timedelta(seconds=30)
+        session.save(update_fields=["completed_at"])
+
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        entry = response.json()["upload_sessions"][0]
+        self.assertAlmostEqual(entry["duration_seconds"], 30, delta=1)
+
+    def test_upload_sessions_duration_seconds_null_when_not_completed(self):
+        _make_upload_session(self.catalog, collection=self.collection)
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        entry = response.json()["upload_sessions"][0]
+        self.assertIsNone(entry["duration_seconds"])
+
+    def test_upload_sessions_uploaded_by_is_username(self):
+        _make_upload_session(self.catalog, user=self.user, collection=self.collection)
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        entry = response.json()["upload_sessions"][0]
+        self.assertEqual(entry["uploaded_by"], self.user.username)
+
+    def test_upload_sessions_uploaded_by_is_null_for_anonymous(self):
+        _make_upload_session(self.catalog, user=None, collection=self.collection)
+        response = self.client.get(UPLOAD_SESSIONS_URL.format(self.collection.pk))
+        entry = response.json()["upload_sessions"][0]
+        self.assertIsNone(entry["uploaded_by"])

--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -35,6 +35,7 @@ def register_ingestion_dashboard_urls():
         collection_ingestion_logs_api,
         collection_ingestion_jobs_api,
         collection_fetch_runs_api,
+        collection_upload_sessions_api,
     )
     from .sse_views import ingestion_events_sse, acquisition_events_sse
 
@@ -50,6 +51,8 @@ def register_ingestion_dashboard_urls():
              name="collection_ingestion_jobs_api"),
         path("api/ingestion/collections/<int:collection_id>/fetch-runs/", collection_fetch_runs_api,
              name="collection_fetch_runs_api"),
+        path("api/ingestion/collections/<int:collection_id>/upload-sessions/", collection_upload_sessions_api,
+             name="collection_upload_sessions_api"),
     ]
 
 


### PR DESCRIPTION
## Summary

Implements the four unblocked API slices from the Collection Health Panel redesign (#86).

- **#87** — Removes the dead `run_time: None` field from the `collection_fetch_runs_api` response
- **#88** — Rewrites `ingestion_dashboard_api` to return Collections grouped under their parent Catalog: `{"catalogs": [...]}` with worst-case health badge (`ok`/`failed`/`empty`) and summary counts per Catalog. Extracts `_derive_catalog_status` helper.
- **#89** — Adds `collection_upload_sessions_api` at `/admin/api/ingestion/collections/<id>/upload-sessions/` — resolves `UploadSession` records for a Collection via `FileIngestion.collections` M2M (no schema change)
- **#90 (API)** — Pins `failed` `FileIngestion` records to the top of `collection_ingestion_logs_api` via `Case/When`, then most-recent-first within each group

## Test plan

- [ ] `make dev-test TEST_ARGS="georiva.ingestion.tests.test_dashboard_api"` — 46 tests, all green
- [ ] `GET /admin/api/ingestion/dashboard/` returns `{"catalogs": [...]}` with nested collections
- [ ] `GET /admin/api/ingestion/collections/<id>/upload-sessions/` returns `{"upload_sessions": [...]}`
- [ ] `GET /admin/api/ingestion/collections/<id>/ingestion-logs/` returns failed records first

## Unblocks

- #91 (Vue Catalog hierarchy) — now has the grouped API it depends on
- #92 (Acquisition tab FetchRuns) — `run_time` field removed
- #93 (Acquisition tab UploadSessions) — upload-sessions endpoint now exists
- #94 (Active Jobs tab) — depends on #90 tab rename (Vue only, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)