### PR TITLE
feat(ingestion): Catalog hierarchy dashboard — Acquisition tab, SSE, filter/search

### DIFF
--- a/georiva/src/georiva/ingestion/ingestion-dashboard/src/IngestionDashboard.vue
+++ b/georiva/src/georiva/ingestion/ingestion-dashboard/src/IngestionDashboard.vue
@@ -7,33 +7,33 @@
         <div class="header-title-group">
           <h1 class="dashboard-title">Ingestion Dashboard</h1>
           <div class="header-badges">
-                        <span class="meta-badge">
-                            <i class="pi pi-database"></i>
-                            {{ collections.length }} Collections
-                        </span>
             <span class="meta-badge">
-                            <i class="pi pi-bolt"></i>
-                            {{ collections.filter(c => c.type === 'automated').length }} Automated
-                        </span>
+              <i class="pi pi-database"></i>
+              {{ allCollections.length }} Collections
+            </span>
             <span class="meta-badge">
-                            <i class="pi pi-upload"></i>
-                            {{ collections.filter(c => c.type === 'manual').length }} Manual
-                        </span>
+              <i class="pi pi-bolt"></i>
+              {{ allCollections.filter(c => c.type === 'automated').length }} Automated
+            </span>
+            <span class="meta-badge">
+              <i class="pi pi-upload"></i>
+              {{ allCollections.filter(c => c.type === 'manual').length }} Manual
+            </span>
           </div>
         </div>
 
         <div class="status-summary-group">
           <div class="summary-card success" @click="setFilter('ok')" :class="{active: activeFilter === 'ok'}">
             <span class="summary-label">Active</span>
-            <span class="summary-count">{{ summary.ok }}</span>
-          </div>
-          <div class="summary-card warning" @click="setFilter('warning')" :class="{active: activeFilter === 'warning'}">
-            <span class="summary-label">Warning</span>
-            <span class="summary-count">{{ summary.warning }}</span>
+            <span class="summary-count">{{ globalSummary.ok }}</span>
           </div>
           <div class="summary-card danger" @click="setFilter('failed')" :class="{active: activeFilter === 'failed'}">
             <span class="summary-label">Failed</span>
-            <span class="summary-count">{{ summary.failed }}</span>
+            <span class="summary-count">{{ globalSummary.failed }}</span>
+          </div>
+          <div class="summary-card info" @click="setFilter('empty')" :class="{active: activeFilter === 'empty'}">
+            <span class="summary-label">No Data</span>
+            <span class="summary-count">{{ globalSummary.empty }}</span>
           </div>
         </div>
       </div>
@@ -69,106 +69,96 @@
             label="Refresh"
             class="refresh-btn"
             :loading="loading"
-            @click="fetchCollections"
+            @click="fetchCatalogs"
         />
       </div>
 
-      <!-- Error -->
       <Message v-if="error" severity="error" class="mb-3">{{ error }}</Message>
 
-      <!-- Table -->
-      <div class="table-wrapper">
-        <DataTable
-            :value="filteredCollections"
-            :loading="loading"
-            row-hover
-            size="small"
-            paginator
-            :rows="50"
-            @row-click="onRowClick"
-            :row-class="() => 'cursor-pointer'"
-        >
-          <template #empty>
-            <div class="empty-state">No collections found.</div>
-          </template>
+      <!-- Catalog hierarchy -->
+      <div class="catalog-list" v-if="!loading || catalogs.length">
 
-          <!-- Name + catalog -->
-          <Column header="Collection" style="min-width: 16rem">
-            <template #body="{data}">
+        <div v-if="!visibleCatalogs.length" class="empty-state">No collections found.</div>
+
+        <div
+            v-for="cat in visibleCatalogs"
+            :key="cat.id"
+            class="catalog-group"
+        >
+          <!-- Catalog header row -->
+          <div class="catalog-row" @click="toggleCatalog(cat.id)">
+            <i :class="['expand-icon', 'pi', expandedCatalogs.has(cat.id) ? 'pi-chevron-down' : 'pi-chevron-right']"/>
+            <div class="catalog-name">{{ cat.name }}</div>
+            <div :class="['status-indicator', statusClass(cat.status)]">
+              <i :class="statusIcon(cat.status)"/>
+              {{ statusLabel(cat.status) }}
+            </div>
+            <div class="catalog-summary">
+              <span v-if="cat.summary.ok" class="summary-chip ok">{{ cat.summary.ok }} ok</span>
+              <span v-if="cat.summary.failed" class="summary-chip failed">{{ cat.summary.failed }} failed</span>
+              <span v-if="cat.summary.empty" class="summary-chip empty">{{ cat.summary.empty }} empty</span>
+            </div>
+            <span class="catalog-col-count">{{ cat.collections.length }} collection{{ cat.collections.length !== 1 ? 's' : '' }}</span>
+          </div>
+
+          <!-- Collection rows -->
+          <div v-if="expandedCatalogs.has(cat.id)" class="collection-list">
+            <div
+                v-for="col in cat.collections"
+                :key="col.id"
+                class="collection-row"
+                @click="openDrawer(col)"
+            >
+              <!-- Name + icon -->
               <div class="collection-cell">
                 <div class="collection-icon-box">
-                  <i :class="data.type === 'automated' ? 'pi pi-bolt' : 'pi pi-upload'"/>
+                  <i :class="col.type === 'automated' ? 'pi pi-bolt' : 'pi pi-upload'"/>
                 </div>
-                <div>
-                  <div class="cell-title">{{ data.name }}</div>
-                  <div class="sub-text">{{ data.catalog_name }}</div>
-                </div>
+                <div class="cell-title">{{ col.name }}</div>
               </div>
-            </template>
-          </Column>
 
-          <!-- Status -->
-          <Column header="Status" style="width: 9rem">
-            <template #body="{data}">
-              <div :class="['status-indicator', statusClass(data.status)]">
-                <i :class="statusIcon(data.status)"/>
-                {{ statusLabel(data.status) }}
+              <!-- Status -->
+              <div :class="['status-indicator', statusClass(col.status)]">
+                <i :class="statusIcon(col.status)"/>
+                {{ statusLabel(col.status) }}
               </div>
-            </template>
-          </Column>
 
-          <!-- Type -->
-          <Column header="Type" style="width: 8rem">
-            <template #body="{data}">
-                            <span class="type-badge" :class="data.type">
-                                {{ data.type === 'automated' ? 'Automated' : 'Manual' }}
-                            </span>
-            </template>
-          </Column>
+              <!-- Type badge -->
+              <span class="type-badge" :class="col.type">
+                {{ col.type === 'automated' ? 'Automated' : 'Manual' }}
+              </span>
 
-          <!-- Last run -->
-          <Column header="Last Run" style="width: 12rem">
-            <template #body="{data}">
-              <div class="time-cell" v-if="data.last_run_at">
-                                <span
-                                    class="time-main"
-                                    :class="{'text-danger': isStale(data.last_run_at)}"
-                                >
-                                    {{ timeAgo(data.last_run_at) }}
-                                </span>
-                <span class="time-sub">{{ formatShortDate(data.last_run_at) }}</span>
+              <!-- Last run -->
+              <div class="time-cell" v-if="col.last_run_at">
+                <span class="time-main" :class="{'text-danger': isStale(col.last_run_at)}">
+                  {{ timeAgo(col.last_run_at) }}
+                </span>
+                <span class="time-sub">{{ formatShortDate(col.last_run_at) }}</span>
               </div>
-              <span v-else class="time-main" style="color:#94a3b8">Never</span>
-            </template>
-          </Column>
+              <span v-else class="time-main never">Never</span>
 
-          <!-- Items -->
-          <Column header="Items" style="width: 6rem">
-            <template #body="{data}">
-                            <span class="font-mono" style="font-size:14px">
-                                {{ data.item_count.toLocaleString() }}
-                            </span>
-            </template>
-          </Column>
+              <!-- Items -->
+              <span class="items-count">{{ col.item_count.toLocaleString() }}</span>
 
-          <!-- Sparkline -->
-          <Column header="Last 30 Days" style="width: 14rem">
-            <template #body="{data}">
+              <!-- Sparkline -->
               <div class="sparkline">
                 <div
-                    v-for="(day, i) in data.sparkline"
+                    v-for="(day, i) in col.sparkline"
                     :key="i"
                     :class="['spark-bar', `spark-bar--${day.status}`]"
                     :title="`${day.date}: ${sparklineLabel(day.status)}`"
                 />
               </div>
-            </template>
-          </Column>
-        </DataTable>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="loading && !catalogs.length" class="loading-state">
+        <i class="pi pi-spin pi-spinner"/> Loading...
       </div>
     </div>
 
-    <!-- Drawer -->
     <CollectionDrawer
         v-model="drawerVisible"
         :collection="selectedCollection"
@@ -177,9 +167,7 @@
 </template>
 
 <script setup>
-import {computed, onMounted, ref} from "vue";
-import DataTable from "primevue/datatable";
-import Column from "primevue/column";
+import {computed, onMounted, onUnmounted, ref, watch} from "vue";
 import Button from "primevue/button";
 import Message from "primevue/message";
 import InputText from "primevue/inputtext";
@@ -189,81 +177,185 @@ const props = defineProps({
   apiUrl: {type: String, required: true},
 });
 
-const collections = ref([]);
+const catalogs = ref([]);
 const loading = ref(false);
 const error = ref(null);
 const searchQuery = ref("");
 const activeFilter = ref("all");
 const drawerVisible = ref(false);
 const selectedCollection = ref(null);
+const expandedCatalogs = ref(new Set());
+let sseSource = null;
 
 const filterOptions = [
   {label: "All", value: "all", cls: ""},
   {label: "Automated", value: "automated", cls: ""},
   {label: "Manual", value: "manual", cls: ""},
   {label: "Active", value: "ok", cls: "success"},
-  {label: "Warning", value: "warning", cls: "warning"},
   {label: "Failed", value: "failed", cls: "danger"},
+  {label: "No Data", value: "empty", cls: ""},
 ];
 
-const summary = computed(() => ({
-  ok: collections.value.filter(c => c.status === "ok").length,
-  warning: collections.value.filter(c => c.status === "warning").length,
-  failed: collections.value.filter(c => c.status === "failed").length,
+const allCollections = computed(() =>
+    catalogs.value.flatMap(cat => cat.collections)
+);
+
+const globalSummary = computed(() => ({
+  ok: allCollections.value.filter(c => c.status === "ok").length,
+  failed: allCollections.value.filter(c => c.status === "failed").length,
+  empty: allCollections.value.filter(c => c.status === "empty").length,
 }));
+
+const visibleCatalogs = computed(() => {
+  const q = searchQuery.value.toLowerCase();
+  const filter = activeFilter.value;
+  const isFiltering = q || filter !== "all";
+
+  return catalogs.value
+      .map(cat => {
+        const collections = cat.collections.filter(col => {
+          const matchesSearch = !q || col.name.toLowerCase().includes(q) || col.catalog.toLowerCase().includes(q);
+          let matchesFilter = true;
+          if (filter === "automated") matchesFilter = col.type === "automated";
+          else if (filter === "manual") matchesFilter = col.type === "manual";
+          else if (["ok", "failed", "empty"].includes(filter)) matchesFilter = col.status === filter;
+          return matchesSearch && matchesFilter;
+        });
+        return {...cat, collections};
+      })
+      .filter(cat => cat.collections.length > 0);
+});
+
+// When a filter/search is active: auto-expand matching catalogs.
+// When cleared: restore default (only failing expanded).
+watch(visibleCatalogs, (cats) => {
+  const isFiltering = searchQuery.value || activeFilter.value !== "all";
+  if (isFiltering) {
+    const next = new Set(expandedCatalogs.value);
+    cats.forEach(cat => next.add(cat.id));
+    expandedCatalogs.value = next;
+  } else {
+    applyDefaultExpansion();
+  }
+});
 
 function setFilter(value) {
   activeFilter.value = activeFilter.value === value ? "all" : value;
 }
 
-const filteredCollections = computed(() => {
-  const q = searchQuery.value.toLowerCase();
-  return collections.value.filter((c) => {
-    const matchesSearch = !q || c.name.toLowerCase().includes(q) || c.catalog.toLowerCase().includes(q);
-    let matchesFilter = true;
-    if (activeFilter.value === "automated") matchesFilter = c.type === "automated";
-    else if (activeFilter.value === "manual") matchesFilter = c.type === "manual";
-    else if (["ok", "warning", "failed", "empty"].includes(activeFilter.value))
-      matchesFilter = c.status === activeFilter.value;
-    return matchesSearch && matchesFilter;
-  });
-});
+function toggleCatalog(id) {
+  const next = new Set(expandedCatalogs.value);
+  next.has(id) ? next.delete(id) : next.add(id);
+  expandedCatalogs.value = next;
+}
 
-async function fetchCollections() {
+function applyDefaultExpansion() {
+  const next = new Set();
+  catalogs.value.forEach(cat => {
+    if (cat.status === "failed") next.add(cat.id);
+  });
+  expandedCatalogs.value = next;
+}
+
+async function fetchCatalogs() {
   loading.value = true;
   error.value = null;
   try {
     const res = await fetch(props.apiUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    collections.value = data.collections;
+    catalogs.value = data.catalogs;
+    applyDefaultExpansion();
   } catch (e) {
-    error.value = `Failed to load collections: ${e.message}`;
+    error.value = `Failed to load dashboard: ${e.message}`;
   } finally {
     loading.value = false;
   }
 }
 
-onMounted(fetchCollections);
+// Silent background re-fetch on SSE events: patches status + last_run_at only,
+// leaves sparklines intact to avoid visual noise during active ingestion.
+async function refreshStatuses() {
+  try {
+    const res = await fetch(props.apiUrl);
+    if (!res.ok) return;
+    const data = await res.json();
 
-function onRowClick({data}) {
-  selectedCollection.value = data;
+    const colIndex = {};
+    for (const cat of catalogs.value) {
+      for (const col of cat.collections) {
+        colIndex[col.id] = col;
+      }
+    }
+
+    for (const newCat of data.catalogs) {
+      for (const newCol of newCat.collections) {
+        const existing = colIndex[newCol.id];
+        if (existing) {
+          existing.status = newCol.status;
+          existing.last_run_at = newCol.last_run_at;
+          existing.last_run_status = newCol.last_run_status;
+          existing.item_count = newCol.item_count;
+        }
+      }
+    }
+
+    // Recalculate catalog badges from updated collection statuses.
+    for (const cat of catalogs.value) {
+      const statuses = cat.collections.map(c => c.status);
+      cat.status = statuses.includes("failed") ? "failed"
+          : statuses.some(s => s === "ok") ? "ok"
+              : "empty";
+      cat.summary = {
+        ok: statuses.filter(s => s === "ok").length,
+        failed: statuses.filter(s => s === "failed").length,
+        empty: statuses.filter(s => s === "empty").length,
+      };
+    }
+  } catch (_) {
+    // Silent — SSE-triggered refresh is best-effort.
+  }
+}
+
+function connectSSE() {
+  if (sseSource) return;
+  sseSource = new EventSource("/admin/api/ingestion/events/");
+  sseSource.addEventListener("file_ingestion.status_changed", refreshStatuses);
+  sseSource.onerror = () => {
+    sseSource?.close();
+    sseSource = null;
+    // Reconnect after 5s on error.
+    setTimeout(connectSSE, 5000);
+  };
+}
+
+function openDrawer(col) {
+  selectedCollection.value = col;
   drawerVisible.value = true;
 }
 
+onMounted(() => {
+  fetchCatalogs();
+  connectSSE();
+});
+
+onUnmounted(() => {
+  sseSource?.close();
+  sseSource = null;
+});
+
 function statusLabel(s) {
-  return {ok: "Active", failed: "Failed", warning: "Warning", empty: "No Data"}[s] ?? s;
+  return {ok: "Active", failed: "Failed", empty: "No Data"}[s] ?? s;
 }
 
 function statusClass(s) {
-  return {ok: "success", failed: "danger", warning: "warning", empty: "info"}[s] ?? "info";
+  return {ok: "success", failed: "danger", empty: "info"}[s] ?? "info";
 }
 
 function statusIcon(s) {
   return {
     ok: "pi pi-check-circle",
     failed: "pi pi-times-circle",
-    warning: "pi pi-exclamation-triangle",
     empty: "pi pi-minus-circle",
   }[s] ?? "pi pi-circle";
 }
@@ -346,7 +438,6 @@ function isStale(iso) {
   border: 1px solid #e2e8f0;
 }
 
-/* Summary cards */
 .status-summary-group {
   display: flex;
   gap: 12px;
@@ -367,13 +458,8 @@ function isStale(iso) {
   user-select: none;
 }
 
-.summary-card:hover {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-}
-
-.summary-card.active {
-  box-shadow: 0 0 0 2px currentColor;
-}
+.summary-card:hover { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1); }
+.summary-card.active { box-shadow: 0 0 0 2px currentColor; }
 
 .summary-label {
   font-size: 11px;
@@ -390,29 +476,12 @@ function isStale(iso) {
   line-height: 1;
 }
 
-.summary-card.success {
-  border-bottom: 3px solid #15803d;
-}
-
-.summary-card.success .summary-count {
-  color: #15803d;
-}
-
-.summary-card.warning {
-  border-bottom: 3px solid #b45309;
-}
-
-.summary-card.warning .summary-count {
-  color: #b45309;
-}
-
-.summary-card.danger {
-  border-bottom: 3px solid #b91c1c;
-}
-
-.summary-card.danger .summary-count {
-  color: #b91c1c;
-}
+.summary-card.success { border-bottom: 3px solid #15803d; }
+.summary-card.success .summary-count { color: #15803d; }
+.summary-card.danger  { border-bottom: 3px solid #b91c1c; }
+.summary-card.danger .summary-count  { color: #b91c1c; }
+.summary-card.info    { border-bottom: 3px solid #64748b; }
+.summary-card.info .summary-count    { color: #64748b; }
 
 /* Content */
 .content-section {
@@ -436,9 +505,7 @@ function isStale(iso) {
   align-items: center;
 }
 
-.search-wrapper {
-  position: relative;
-}
+.search-wrapper { position: relative; }
 
 .search-icon {
   position: absolute;
@@ -482,34 +549,11 @@ function isStale(iso) {
   transition: all 0.1s;
 }
 
-.filter-btn:last-child {
-  border-right: none;
-}
-
-.filter-btn:hover {
-  background: #f8fafc;
-  color: #0f172a;
-}
-
-.filter-btn.active {
-  background: #0f172a;
-  color: #fff;
-}
-
-.filter-btn.success.active {
-  background: #166534;
-  color: #fff;
-}
-
-.filter-btn.warning.active {
-  background: #d97706;
-  color: #fff;
-}
-
-.filter-btn.danger.active {
-  background: #dc2626;
-  color: #fff;
-}
+.filter-btn:last-child { border-right: none; }
+.filter-btn:hover { background: #f8fafc; color: #0f172a; }
+.filter-btn.active { background: #0f172a; color: #fff; }
+.filter-btn.success.active { background: #166534; color: #fff; }
+.filter-btn.danger.active  { background: #dc2626; color: #fff; }
 
 .refresh-btn {
   border: 1px solid #cbd5e1 !important;
@@ -517,51 +561,95 @@ function isStale(iso) {
   font-size: 13px !important;
 }
 
-/* Table */
-.table-wrapper {
+/* Catalog hierarchy */
+.catalog-list {
   border: 1px solid #e2e8f0;
   border-radius: 6px;
   overflow: hidden;
 }
 
-:deep(.p-datatable-thead > tr > th) {
-  background: #f1f5f9 !important;
-  color: #475569 !important;
-  font-weight: 600 !important;
-  text-transform: uppercase !important;
-  font-size: 12px !important;
-  letter-spacing: 0.05em !important;
-  padding: 14px 20px !important;
-  border-bottom: 1px solid #e2e8f0 !important;
-  border-top: none !important;
+.catalog-group + .catalog-group {
+  border-top: 1px solid #e2e8f0;
 }
 
-:deep(.p-datatable-tbody > tr > td) {
-  padding: 14px 20px !important;
-  border-bottom: 1px solid #f1f5f9 !important;
-  color: #334155;
-  font-size: 14px;
-}
-
-:deep(.p-datatable-tbody > tr:last-child > td) {
-  border-bottom: none !important;
-}
-
-:deep(.p-datatable-tbody > tr:hover > td) {
-  background: #f8fafc !important;
-  cursor: pointer;
-}
-
-/* Collection cell */
-.collection-cell {
+.catalog-row {
   display: flex;
   align-items: center;
   gap: 12px;
+  padding: 12px 20px;
+  background: #f1f5f9;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.1s;
+}
+
+.catalog-row:hover { background: #e9eef5; }
+
+.expand-icon {
+  color: #64748b;
+  font-size: 11px;
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.catalog-name {
+  font-weight: 700;
+  font-size: 14px;
+  color: #0f172a;
+  flex: 1;
+}
+
+.catalog-summary {
+  display: flex;
+  gap: 6px;
+}
+
+.summary-chip {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 10px;
+}
+
+.summary-chip.ok     { background: #dcfce7; color: #15803d; }
+.summary-chip.failed { background: #fee2e2; color: #b91c1c; }
+.summary-chip.empty  { background: #f1f5f9; color: #64748b; }
+
+.catalog-col-count {
+  font-size: 12px;
+  color: #94a3b8;
+  white-space: nowrap;
+}
+
+/* Collection rows */
+.collection-list {
+  border-top: 1px solid #e2e8f0;
+}
+
+.collection-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 20px 12px 46px;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.collection-row:last-child { border-bottom: none; }
+.collection-row:hover { background: #f8fafc; }
+
+.collection-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 14rem;
+  flex: 1;
 }
 
 .collection-icon-box {
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   background: #f1f5f9;
   border: 1px solid #e2e8f0;
   border-radius: 4px;
@@ -570,21 +658,15 @@ function isStale(iso) {
   justify-content: center;
   color: #64748b;
   flex-shrink: 0;
+  font-size: 11px;
 }
 
 .cell-title {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   color: #0f172a;
 }
 
-.sub-text {
-  font-size: 11px;
-  color: #94a3b8;
-  margin-top: 2px;
-}
-
-/* Status indicator */
 .status-indicator {
   display: inline-flex;
   align-items: center;
@@ -593,29 +675,13 @@ function isStale(iso) {
   font-weight: 600;
   padding: 3px 8px;
   border-radius: 4px;
+  white-space: nowrap;
 }
 
-.status-indicator.success {
-  background: #dcfce7;
-  color: #15803d;
-}
+.status-indicator.success { background: #dcfce7; color: #15803d; }
+.status-indicator.danger  { background: #fee2e2; color: #b91c1c; }
+.status-indicator.info    { background: #f1f5f9; color: #64748b; }
 
-.status-indicator.warning {
-  background: #fef3c7;
-  color: #b45309;
-}
-
-.status-indicator.danger {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.status-indicator.info {
-  background: #f1f5f9;
-  color: #64748b;
-}
-
-/* Type badge */
 .type-badge {
   font-size: 11px;
   font-weight: 600;
@@ -623,23 +689,13 @@ function isStale(iso) {
   border-radius: 4px;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+  white-space: nowrap;
 }
 
-.type-badge.automated {
-  background: #dbeafe;
-  color: #1d4ed8;
-}
+.type-badge.automated { background: #dbeafe; color: #1d4ed8; }
+.type-badge.manual    { background: #f1f5f9; color: #475569; }
 
-.type-badge.manual {
-  background: #f1f5f9;
-  color: #475569;
-}
-
-/* Time cell */
-.time-cell {
-  display: flex;
-  flex-direction: column;
-}
+.time-cell { display: flex; flex-direction: column; min-width: 9rem; }
 
 .time-main {
   font-weight: 500;
@@ -647,15 +703,22 @@ function isStale(iso) {
   font-size: 13px;
 }
 
-.time-main.text-danger {
-  color: #dc2626;
-}
+.time-main.text-danger { color: #dc2626; }
+.time-main.never { color: #94a3b8; }
 
 .time-sub {
   font-size: 11px;
   color: #94a3b8;
   margin-top: 2px;
   font-family: 'SF Mono', 'Roboto Mono', monospace;
+}
+
+.items-count {
+  font-size: 13px;
+  font-family: 'SF Mono', 'Roboto Mono', monospace;
+  color: #334155;
+  min-width: 4rem;
+  text-align: right;
 }
 
 /* Sparkline */
@@ -673,38 +736,21 @@ function isStale(iso) {
   transition: opacity 0.15s;
 }
 
-.spark-bar--success {
-  height: 14px;
-  background: #15803d;
-}
+.spark-bar--success { height: 14px; background: #15803d; }
+.spark-bar--failed  { height: 14px; background: #dc2626; }
+.spark-bar--empty   { height: 6px;  background: #e2e8f0; }
+.spark-bar:hover { opacity: 0.75; }
 
-.spark-bar--failed {
-  height: 14px;
-  background: #dc2626;
-}
-
-.spark-bar--empty {
-  height: 6px;
-  background: #e2e8f0;
-}
-
-.spark-bar:hover {
-  opacity: 0.75;
-}
-
-.empty-state {
+.empty-state, .loading-state {
   padding: 40px;
   text-align: center;
   color: #64748b;
+  font-size: 14px;
 }
 
 @media (max-width: 768px) {
-  .header-top-row, .controls-left, .status-summary-group {
-    flex-direction: column;
-  }
-
-  .search-input {
-    width: 100%;
-  }
+  .header-top-row, .controls-left, .status-summary-group { flex-direction: column; }
+  .search-input { width: 100%; }
+  .collection-row { flex-wrap: wrap; padding-left: 20px; }
 }
 </style>

--- a/georiva/src/georiva/ingestion/ingestion-dashboard/src/components/CollectionDrawer.vue
+++ b/georiva/src/georiva/ingestion/ingestion-dashboard/src/components/CollectionDrawer.vue
@@ -27,34 +27,32 @@
 
     <div v-if="collection" class="drawer-body">
 
-      <!-- Tabs: automated gets loader tab; all get ingestion logs + jobs -->
       <div class="tab-bar">
+        <!-- Acquisition tab — always visible, content varies by type -->
         <button
-            v-if="collection.type === 'automated'"
-            :class="['tab-btn', {active: activeTab === 'loader'}]"
-            @click="activeTab = 'loader'"
+            :class="['tab-btn', {active: activeTab === 'acquisition'}]"
+            @click="activeTab = 'acquisition'"
         >
-          <i class="pi pi-sync"/> Loader Runs
-          <span v-if="runs.length" class="tab-count">{{ runs.length }}</span>
+          <i class="pi pi-cloud-download"/> Acquisition
+          <span v-if="acquisitionCount" class="tab-count">{{ acquisitionCount }}</span>
         </button>
         <button
-            :class="['tab-btn', {active: activeTab === 'ingestion'}]"
-            @click="activeTab = 'ingestion'"
+            :class="['tab-btn', {active: activeTab === 'file-history'}]"
+            @click="activeTab = 'file-history'"
         >
-          <i class="pi pi-inbox"/> Ingestion Logs
+          <i class="pi pi-inbox"/> File History
           <span v-if="logs.length" class="tab-count">{{ logs.length }}</span>
         </button>
         <button
-            :class="['tab-btn', {active: activeTab === 'jobs'}]"
-            @click="activeTab = 'jobs'"
+            :class="['tab-btn', {active: activeTab === 'active-jobs'}]"
+            @click="activeTab = 'active-jobs'"
         >
-          <i class="pi pi-cog"/> Ingestion Jobs
+          <i class="pi pi-cog"/> Active Jobs
           <span v-if="activeJobCount" :class="['tab-count', 'tab-count--active']">{{ activeJobCount }}</span>
           <span v-else-if="jobs.length" class="tab-count">{{ jobs.length }}</span>
         </button>
       </div>
 
-      <!-- Loading state -->
       <div v-if="loading" class="loading-state">
         <i class="pi pi-spin pi-spinner"/> Loading...
       </div>
@@ -63,130 +61,101 @@
         <i class="pi pi-exclamation-triangle"/> {{ error }}
       </div>
 
-      <!-- Loader Runs tab -->
-      <div v-else-if="activeTab === 'loader'" class="tab-content">
-        <div v-if="!runs.length" class="empty-state">No loader runs found.</div>
+      <!-- Acquisition tab -->
+      <div v-else-if="activeTab === 'acquisition'" class="tab-content">
 
-        <div v-for="run in runs" :key="run.id" class="run-row">
-          <div class="run-row__top">
-            <div class="run-row__left">
-              <span :class="['status-pill', loaderStatusClass(run.status)]">
-                <i :class="loaderStatusIcon(run.status)"/>
-                {{ run.status }}
-              </span>
-              <span class="run-time" :title="formatDateTime(run.started_at)">
-                {{ timeAgo(run.started_at) }}
-              </span>
-              <span class="run-date">{{ formatShortDate(run.started_at) }}</span>
+        <!-- Automated: FetchRuns -->
+        <template v-if="collection.type === 'automated'">
+          <div v-if="!runs.length" class="empty-state">No fetch runs found.</div>
+          <div v-for="run in runs" :key="run.id" class="run-row">
+            <div class="run-row__top">
+              <div class="run-row__left">
+                <span :class="['status-pill', loaderStatusClass(run.status)]">
+                  <i :class="loaderStatusIcon(run.status)"/>
+                  {{ run.status }}
+                </span>
+                <span class="run-time" :title="formatDateTime(run.started_at)">
+                  {{ timeAgo(run.started_at) }}
+                </span>
+                <span class="run-date">{{ formatShortDate(run.started_at) }}</span>
+              </div>
+              <div class="run-row__right">
+                <span v-if="run.duration_seconds != null" class="run-duration">
+                  <i class="pi pi-clock"/> {{ formatDuration(run.duration_seconds) }}
+                </span>
+                <span class="run-feed">{{ run.data_feed_name }}</span>
+              </div>
             </div>
-            <div class="run-row__right">
-              <span v-if="run.duration_seconds != null" class="run-duration">
-                <i class="pi pi-clock"/> {{ formatDuration(run.duration_seconds) }}
+            <div class="run-row__counts">
+              <span class="count-chip fetched">
+                <i class="pi pi-download"/> {{ run.files_fetched }} fetched
               </span>
-              <span v-if="run.run_time" class="run-ref">
-                <i class="pi pi-calendar"/> {{ formatShortDate(run.run_time) }}
+              <span class="count-chip skipped">
+                <i class="pi pi-forward"/> {{ run.files_skipped }} skipped
+              </span>
+              <span class="count-chip failed" v-if="run.files_failed > 0">
+                <i class="pi pi-times"/> {{ run.files_failed }} failed
+              </span>
+              <span class="count-chip bytes" v-if="run.bytes_transferred > 0">
+                <i class="pi pi-arrow-right-arrow-left"/> {{ formatBytes(run.bytes_transferred) }}
               </span>
             </div>
-          </div>
-
-          <!-- File counts -->
-          <div class="run-row__counts">
-            <span class="count-chip fetched">
-              <i class="pi pi-download"/> {{ run.files_fetched }} fetched
-            </span>
-            <span class="count-chip skipped">
-              <i class="pi pi-forward"/> {{ run.files_skipped }} skipped
-            </span>
-            <span class="count-chip failed" v-if="run.files_failed > 0">
-              <i class="pi pi-times"/> {{ run.files_failed }} failed
-            </span>
-            <span class="count-chip bytes" v-if="run.bytes_transferred > 0">
-              <i class="pi pi-arrow-right-arrow-left"/> {{ formatBytes(run.bytes_transferred) }}
-            </span>
-          </div>
-
-          <!-- Errors (collapsible) -->
-          <div v-if="run.errors?.length" class="run-errors">
-            <button class="error-toggle" @click="toggleRunErrors(run.id)">
-              <i class="pi pi-exclamation-triangle"/>
-              {{ run.errors.length }} error{{ run.errors.length > 1 ? 's' : '' }}
-              <i :class="expandedRunErrors.has(run.id) ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"/>
-            </button>
-            <div v-if="expandedRunErrors.has(run.id)" class="error-list">
-              <div v-for="(err, i) in run.errors" :key="i" class="error-item">
-                {{ err }}
+            <div v-if="run.errors?.length" class="run-errors">
+              <button class="error-toggle" @click="toggleRunErrors(run.id)">
+                <i class="pi pi-exclamation-triangle"/>
+                {{ run.errors.length }} error{{ run.errors.length > 1 ? 's' : '' }}
+                <i :class="expandedRunErrors.has(run.id) ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"/>
+              </button>
+              <div v-if="expandedRunErrors.has(run.id)" class="error-list">
+                <div v-for="(err, i) in run.errors" :key="i" class="error-item">{{ err }}</div>
               </div>
             </div>
           </div>
-        </div>
+        </template>
+
+        <!-- Manual: UploadSessions -->
+        <template v-else>
+          <div v-if="!uploadSessions.length" class="empty-state">No upload sessions found.</div>
+          <div v-for="session in uploadSessions" :key="session.id" class="run-row">
+            <div class="run-row__top">
+              <div class="run-row__left">
+                <span :class="['status-pill', uploadSessionStatusClass(session.status)]">
+                  <i :class="uploadSessionStatusIcon(session.status)"/>
+                  {{ session.status }}
+                </span>
+                <span class="run-time" :title="formatDateTime(session.started_at)">
+                  {{ timeAgo(session.started_at) }}
+                </span>
+                <span class="run-date">{{ formatShortDate(session.started_at) }}</span>
+              </div>
+              <div class="run-row__right">
+                <span v-if="session.duration_seconds != null" class="run-duration">
+                  <i class="pi pi-clock"/> {{ formatDuration(session.duration_seconds) }}
+                </span>
+                <span class="run-feed">{{ session.uploaded_by ?? 'Manual upload' }}</span>
+              </div>
+            </div>
+            <div class="run-row__counts">
+              <span class="count-chip fetched">
+                <i class="pi pi-upload"/> {{ session.files_stored }}/{{ session.files_count }} stored
+              </span>
+              <span class="count-chip failed" v-if="session.files_failed > 0">
+                <i class="pi pi-times"/> {{ session.files_failed }} failed
+              </span>
+            </div>
+          </div>
+        </template>
       </div>
 
-      <!-- Ingestion Jobs tab -->
-      <div v-else-if="activeTab === 'jobs'" class="tab-content">
-        <div v-if="!jobs.length" class="empty-state">No ingestion jobs found.</div>
-
-        <div v-for="job in jobs" :key="job.id" class="log-row">
-          <div class="log-row__top">
-            <span :class="['status-pill', jobStatusClass(job.state)]">
-              <i :class="jobStatusIcon(job.state)"/>
-              {{ job.state }}
-            </span>
-            <span class="run-time" :title="formatDateTime(job.created_at)">
-              {{ timeAgo(job.created_at) }}
-            </span>
-            <span class="run-date">{{ formatShortDate(job.created_at) }}</span>
-          </div>
-
-          <!-- File path -->
-          <div class="log-filepath">
-            <i class="pi pi-file"/> {{ fileName(job.file_path) }}
-            <span class="log-filepath__dir">{{ fileDir(job.file_path) }}</span>
-          </div>
-
-          <!-- Progress bar (active jobs only) -->
-          <div v-if="job.state === 'started'" class="job-progress">
-            <div class="progress-bar-wrap">
-              <div class="progress-bar-fill" :style="{width: job.progress_percentage + '%'}"/>
-            </div>
-            <div class="progress-label">
-              {{ job.progress_percentage }}%
-              <span v-if="job.progress_state" class="progress-state">— {{ job.progress_state }}</span>
-            </div>
-          </div>
-
-          <!-- Stats chips (finished jobs) -->
-          <div v-if="job.state === 'finished'" class="log-row__stats">
-            <span class="count-chip fetched">
-              <i class="pi pi-box"/> {{ job.items_created }} items
-            </span>
-            <span class="count-chip fetched">
-              <i class="pi pi-images"/> {{ job.assets_created }} assets
-            </span>
-          </div>
-
-          <!-- Error (collapsible) -->
-          <div v-if="job.error" class="run-errors">
-            <button class="error-toggle" @click="toggleJobError(job.id)">
-              <i class="pi pi-exclamation-triangle"/>
-              Error
-              <i :class="expandedJobErrors.has(job.id) ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"/>
-            </button>
-            <div v-if="expandedJobErrors.has(job.id)" class="error-list">
-              <div class="error-item">{{ job.error }}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Ingestion Logs tab -->
-      <div v-else-if="activeTab === 'ingestion'" class="tab-content">
-        <div v-if="!logs.length" class="empty-state">No ingestion logs found.</div>
+      <!-- File History tab -->
+      <div v-else-if="activeTab === 'file-history'" class="tab-content">
+        <div v-if="!logs.length" class="empty-state">No file history found.</div>
 
         <div v-for="log in logs" :key="log.id" class="log-row">
           <div class="log-row__top">
             <span :class="['status-pill', ingestionStatusClass(log.status)]">
-                <i :class="ingestionStatusIcon(log.status)"/>
-                {{ log.status }}
+              <i :class="ingestionStatusIcon(log.status)"/>
+              {{ log.status }}
             </span>
             <span class="run-time" :title="formatDateTime(log.created_at)">
               {{ timeAgo(log.created_at) }}
@@ -196,14 +165,10 @@
               {{ log.retry_count }} retr{{ log.retry_count > 1 ? 'ies' : 'y' }}
             </span>
           </div>
-
-          <!-- File path -->
           <div class="log-filepath">
             <i class="pi pi-file"/> {{ fileName(log.file_path) }}
             <span class="log-filepath__dir">{{ fileDir(log.file_path) }}</span>
           </div>
-
-          <!-- Stats row -->
           <div class="log-row__stats">
             <span v-if="log.reference_time" class="count-chip bytes">
               <i class="pi pi-calendar"/> {{ formatShortDate(log.reference_time) }}
@@ -215,8 +180,6 @@
               <i class="pi pi-images"/> {{ log.assets_created }} assets
             </span>
           </div>
-
-          <!-- Error (collapsible) -->
           <div v-if="log.error" class="run-errors">
             <button class="error-toggle" @click="toggleLogError(log.id)">
               <i class="pi pi-exclamation-triangle"/>
@@ -227,6 +190,87 @@
               <div class="error-item">{{ log.error }}</div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <!-- Active Jobs tab -->
+      <div v-else-if="activeTab === 'active-jobs'" class="tab-content">
+
+        <!-- Live queue -->
+        <template v-if="liveJobs.length">
+          <div class="section-label">Live</div>
+          <div v-for="job in liveJobs" :key="job.id" class="log-row log-row--active">
+            <div class="log-row__top">
+              <span :class="['status-pill', jobStatusClass(job.state)]">
+                <i :class="jobStatusIcon(job.state)"/>
+                {{ job.state }}
+              </span>
+              <span class="run-time" :title="formatDateTime(job.created_at)">
+                {{ timeAgo(job.created_at) }}
+              </span>
+              <span class="run-date">{{ formatShortDate(job.created_at) }}</span>
+            </div>
+            <div class="log-filepath">
+              <i class="pi pi-file"/> {{ fileName(job.file_path) }}
+              <span class="log-filepath__dir">{{ fileDir(job.file_path) }}</span>
+            </div>
+            <div v-if="job.state === 'started'" class="job-progress">
+              <div class="progress-bar-wrap">
+                <div class="progress-bar-fill" :style="{width: job.progress_percentage + '%'}"/>
+              </div>
+              <div class="progress-label">
+                {{ job.progress_percentage }}%
+                <span v-if="job.progress_state" class="progress-state">— {{ job.progress_state }}</span>
+              </div>
+            </div>
+            <div v-if="job.error" class="run-errors">
+              <button class="error-toggle" @click="toggleJobError(job.id)">
+                <i class="pi pi-exclamation-triangle"/> Error
+                <i :class="expandedJobErrors.has(job.id) ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"/>
+              </button>
+              <div v-if="expandedJobErrors.has(job.id)" class="error-list">
+                <div class="error-item">{{ job.error }}</div>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <!-- Recent section -->
+        <template v-if="recentJobs.length">
+          <div class="section-label" :class="{'section-label--mt': liveJobs.length}">Recent</div>
+          <div v-for="job in recentJobs" :key="job.id" class="log-row">
+            <div class="log-row__top">
+              <span :class="['status-pill', jobStatusClass(job.state)]">
+                <i :class="jobStatusIcon(job.state)"/>
+                {{ job.state }}
+              </span>
+              <span class="run-time" :title="formatDateTime(job.created_at)">
+                {{ timeAgo(job.created_at) }}
+              </span>
+              <span class="run-date">{{ formatShortDate(job.created_at) }}</span>
+            </div>
+            <div class="log-filepath">
+              <i class="pi pi-file"/> {{ fileName(job.file_path) }}
+              <span class="log-filepath__dir">{{ fileDir(job.file_path) }}</span>
+            </div>
+            <div v-if="job.state === 'finished'" class="log-row__stats">
+              <span class="count-chip fetched"><i class="pi pi-box"/> {{ job.items_created }} items</span>
+              <span class="count-chip fetched"><i class="pi pi-images"/> {{ job.assets_created }} assets</span>
+            </div>
+            <div v-if="job.error" class="run-errors">
+              <button class="error-toggle" @click="toggleJobError(job.id)">
+                <i class="pi pi-exclamation-triangle"/> Error
+                <i :class="expandedJobErrors.has(job.id) ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"/>
+              </button>
+              <div v-if="expandedJobErrors.has(job.id)" class="error-list">
+                <div class="error-item">{{ job.error }}</div>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <div v-if="!liveJobs.length && !recentJobs.length" class="empty-state">
+          No jobs found.
         </div>
       </div>
 
@@ -243,15 +287,16 @@ const props = defineProps({
   collection: {type: Object, default: null},
 });
 
-const emit = defineEmits(["update:modelValue"])
+const emit = defineEmits(["update:modelValue"]);
 
 const visibleProxy = computed({
   get: () => props.modelValue,
   set: (value) => emit("update:modelValue", value),
 });
 
-const activeTab = ref("loader");
+const activeTab = ref("file-history");
 const runs = ref([]);
+const uploadSessions = ref([]);
 const logs = ref([]);
 const jobs = ref([]);
 const loading = ref(false);
@@ -265,11 +310,18 @@ const activeJobCount = computed(() =>
     jobs.value.filter(j => j.state === "pending" || j.state === "started").length
 );
 
-function closeDrawer() {
-  emit("update:modelValue", false);
-}
+const liveJobs = computed(() =>
+    jobs.value.filter(j => j.state === "pending" || j.state === "started")
+);
 
-// When collection changes or drawer opens, fetch data
+const recentJobs = computed(() =>
+    jobs.value.filter(j => j.state === "finished" || j.state === "failed" || j.state === "cancelled")
+);
+
+const acquisitionCount = computed(() =>
+    props.collection?.type === "automated" ? runs.value.length : uploadSessions.value.length
+);
+
 watch(
     () => [props.modelValue, props.collection?.id],
     async ([visible, collectionId]) => {
@@ -279,8 +331,9 @@ watch(
         return;
       }
 
-      activeTab.value = props.collection.type === "automated" ? "loader" : "ingestion";
+      activeTab.value = "file-history";
       runs.value = [];
+      uploadSessions.value = [];
       logs.value = [];
       jobs.value = [];
       expandedRunErrors.value = new Set();
@@ -291,12 +344,17 @@ watch(
     }
 );
 
-// Also fetch when tab switches if data not yet loaded
 watch(activeTab, async (tab) => {
   if (!props.collection) return;
-  if (tab === "loader" && !runs.value.length) await fetchRuns(props.collection.id);
-  if (tab === "ingestion" && !logs.value.length) await fetchLogs(props.collection.id);
-  if (tab === "jobs") {
+  if (tab === "acquisition") {
+    if (props.collection.type === "automated" && !runs.value.length) {
+      await fetchRuns(props.collection.id);
+    } else if (props.collection.type === "manual" && !uploadSessions.value.length) {
+      await fetchUploadSessions(props.collection.id);
+    }
+  }
+  if (tab === "file-history" && !logs.value.length) await fetchLogs(props.collection.id);
+  if (tab === "active-jobs") {
     await fetchJobs(props.collection.id);
     startJobPolling(props.collection.id);
   } else {
@@ -310,6 +368,7 @@ async function fetchAll(collection) {
   try {
     const promises = [fetchLogs(collection.id)];
     if (collection.type === "automated") promises.push(fetchRuns(collection.id));
+    else promises.push(fetchUploadSessions(collection.id));
     await Promise.all(promises);
   } catch (e) {
     error.value = e.message;
@@ -319,10 +378,17 @@ async function fetchAll(collection) {
 }
 
 async function fetchRuns(id) {
-  const res = await fetch(`/admin/api/ingestion/collections/${id}/arrivals/`);
+  const res = await fetch(`/admin/api/ingestion/collections/${id}/fetch-runs/`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
-  runs.value = data.arrivals;
+  runs.value = data.fetch_runs;
+}
+
+async function fetchUploadSessions(id) {
+  const res = await fetch(`/admin/api/ingestion/collections/${id}/upload-sessions/`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  uploadSessions.value = data.upload_sessions;
 }
 
 async function fetchLogs(id) {
@@ -373,26 +439,26 @@ function toggleJobError(id) {
   expandedJobErrors.value = s;
 }
 
-// --- Status helpers ---
 function loaderStatusClass(s) {
-  return {
-    success: "success",
-    partial: "warning",
-    failed: "danger",
-    running: "info",
-    empty: "neutral",
-    queued: "neutral"
-  }[s] ?? "neutral";
+  return {completed: "success", partial: "warning", failed: "danger", running: "info", empty: "neutral", queued: "neutral"}[s] ?? "neutral";
 }
 
 function loaderStatusIcon(s) {
   return {
-    success: "pi pi-check-circle",
-    partial: "pi pi-exclamation-triangle",
-    failed: "pi pi-times-circle",
-    running: "pi pi-spin pi-spinner",
-    empty: "pi pi-minus-circle",
-    queued: "pi pi-clock"
+    completed: "pi pi-check-circle", partial: "pi pi-exclamation-triangle",
+    failed: "pi pi-times-circle", running: "pi pi-spin pi-spinner",
+    empty: "pi pi-minus-circle", queued: "pi pi-clock",
+  }[s] ?? "pi pi-circle";
+}
+
+function uploadSessionStatusClass(s) {
+  return {completed: "success", failed: "danger", cancelled: "neutral", active: "info"}[s] ?? "neutral";
+}
+
+function uploadSessionStatusIcon(s) {
+  return {
+    completed: "pi pi-check-circle", failed: "pi pi-times-circle",
+    cancelled: "pi pi-ban", active: "pi pi-spin pi-spinner",
   }[s] ?? "pi pi-circle";
 }
 
@@ -402,10 +468,8 @@ function ingestionStatusClass(s) {
 
 function ingestionStatusIcon(s) {
   return {
-    completed: "pi pi-check-circle",
-    failed: "pi pi-times-circle",
-    processing: "pi pi-spin pi-spinner",
-    pending: "pi pi-clock"
+    completed: "pi pi-check-circle", failed: "pi pi-times-circle",
+    processing: "pi pi-spin pi-spinner", pending: "pi pi-clock",
   }[s] ?? "pi pi-circle";
 }
 
@@ -415,15 +479,11 @@ function jobStatusClass(s) {
 
 function jobStatusIcon(s) {
   return {
-    pending: "pi pi-clock",
-    started: "pi pi-spin pi-spinner",
-    finished: "pi pi-check-circle",
-    failed: "pi pi-times-circle",
-    cancelled: "pi pi-ban",
+    pending: "pi pi-clock", started: "pi pi-spin pi-spinner",
+    finished: "pi pi-check-circle", failed: "pi pi-times-circle", cancelled: "pi pi-ban",
   }[s] ?? "pi pi-circle";
 }
 
-// --- Formatters ---
 function timeAgo(iso) {
   const diff = Date.now() - new Date(iso).getTime();
   const mins = Math.floor(diff / 60000);
@@ -474,7 +534,6 @@ function fileDir(path) {
   font-size: 10px;
 }
 
-
 .drawer-header {
   display: flex;
   flex-direction: column;
@@ -511,7 +570,6 @@ function fileDir(path) {
   color: #334155;
 }
 
-/* Tabs */
 .tab-bar {
   display: flex;
   border-bottom: 2px solid #e2e8f0;
@@ -558,7 +616,11 @@ function fileDir(path) {
   color: #fff;
 }
 
-/* Content area */
+.tab-count--active {
+  background: #dbeafe !important;
+  color: #1d4ed8 !important;
+}
+
 .tab-content {
   display: flex;
   flex-direction: column;
@@ -576,7 +638,19 @@ function fileDir(path) {
   color: #dc2626;
 }
 
-/* Run row */
+.section-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  padding: 4px 0 2px;
+}
+
+.section-label--mt {
+  margin-top: 12px;
+}
+
 .run-row, .log-row {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -585,6 +659,11 @@ function fileDir(path) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.log-row--active {
+  border-color: #bfdbfe;
+  background: #eff6ff;
 }
 
 .run-row:hover, .log-row:hover {
@@ -612,7 +691,6 @@ function fileDir(path) {
   flex-wrap: wrap;
 }
 
-/* Status pill */
 .status-pill {
   display: inline-flex;
   align-items: center;
@@ -624,30 +702,11 @@ function fileDir(path) {
   text-transform: capitalize;
 }
 
-.status-pill.success {
-  background: #dcfce7;
-  color: #15803d;
-}
-
-.status-pill.warning {
-  background: #fef3c7;
-  color: #b45309;
-}
-
-.status-pill.danger {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.status-pill.info {
-  background: #dbeafe;
-  color: #1d4ed8;
-}
-
-.status-pill.neutral {
-  background: #f1f5f9;
-  color: #64748b;
-}
+.status-pill.success { background: #dcfce7; color: #15803d; }
+.status-pill.warning { background: #fef3c7; color: #b45309; }
+.status-pill.danger  { background: #fee2e2; color: #b91c1c; }
+.status-pill.info    { background: #dbeafe; color: #1d4ed8; }
+.status-pill.neutral { background: #f1f5f9; color: #64748b; }
 
 .run-time {
   font-size: 13px;
@@ -661,7 +720,7 @@ function fileDir(path) {
   font-family: 'SF Mono', 'Roboto Mono', monospace;
 }
 
-.run-duration, .run-ref {
+.run-duration, .run-feed {
   font-size: 12px;
   color: #64748b;
   display: flex;
@@ -678,7 +737,6 @@ function fileDir(path) {
   border-radius: 4px;
 }
 
-/* Count chips */
 .run-row__counts, .log-row__stats {
   display: flex;
   gap: 6px;
@@ -695,27 +753,11 @@ function fileDir(path) {
   border-radius: 4px;
 }
 
-.count-chip.fetched {
-  background: #dcfce7;
-  color: #166534;
-}
+.count-chip.fetched { background: #dcfce7; color: #166534; }
+.count-chip.skipped { background: #f1f5f9; color: #475569; }
+.count-chip.failed  { background: #fee2e2; color: #b91c1c; }
+.count-chip.bytes   { background: #ede9fe; color: #6d28d9; }
 
-.count-chip.skipped {
-  background: #f1f5f9;
-  color: #475569;
-}
-
-.count-chip.failed {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.count-chip.bytes {
-  background: #ede9fe;
-  color: #6d28d9;
-}
-
-/* File path */
 .log-filepath {
   font-size: 12px;
   color: #334155;
@@ -738,7 +780,6 @@ function fileDir(path) {
   white-space: nowrap;
 }
 
-/* Error toggle */
 .run-errors {
   margin-top: 2px;
 }
@@ -758,9 +799,7 @@ function fileDir(path) {
   transition: background 0.1s;
 }
 
-.error-toggle:hover {
-  background: #fecaca;
-}
+.error-toggle:hover { background: #fecaca; }
 
 .error-list {
   margin-top: 6px;
@@ -782,13 +821,6 @@ function fileDir(path) {
   word-break: break-all;
 }
 
-/* Active tab count badge (blue for live jobs) */
-.tab-count--active {
-  background: #dbeafe;
-  color: #1d4ed8;
-}
-
-/* Progress bar */
 .job-progress {
   display: flex;
   flex-direction: column;
@@ -818,7 +850,5 @@ function fileDir(path) {
   gap: 4px;
 }
 
-.progress-state {
-  color: #94a3b8;
-}
+.progress-state { color: #94a3b8; }
 </style>


### PR DESCRIPTION
## Summary

- Replaces the flat PrimeVue DataTable with a collapsible **Catalog → Collection** hierarchy; failing catalogs auto-expand on initial load
- **CollectionDrawer** tabs renamed to **Acquisition** / **File History** / **Active Jobs**; Acquisition tab is now unified — renders FetchRuns for automated collections and UploadSessions for manual collections
- SSE `EventSource` subscription silently patches volatile fields (`status`, `last_run_at`, `item_count`) without wiping sparklines; reconnects on error
- Filter/search hides non-matching catalogs entirely; clearing restores the default collapsed state (only failing catalogs expanded)

Closes #91 #92 #93 #94 #95 #96

## Test plan

- [ ] All 46 backend tests pass (`make dev-test TEST_ARGS="georiva.ingestion.tests.test_dashboard_api"`)
- [ ] Dashboard loads with catalogs collapsed; any with `status=failed` auto-expand
- [ ] Clicking a catalog row toggles expansion; clicking a collection row opens the drawer
- [ ] Drawer "Acquisition" tab shows FetchRuns for an automated collection and UploadSessions for a manual collection
- [ ] Filter by status / type narrows the catalog list and auto-expands matching ones; clearing restores defaults
- [ ] Search narrows by collection name similarly
- [ ] SSE events (`file_ingestion.status_changed`) silently update status badges and catalog summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)