### PR TITLE
feat(ingestion): Monitoring submenu + rename Data Feeds → Automated Sources

### DIFF
--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -1,29 +1,31 @@
 from django.urls import path, reverse_lazy
 from wagtail import hooks
-from wagtail.admin.menu import MenuItem
+from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
 
 from .panels import IngestionActivityPanel
 
 
 @hooks.register("register_admin_menu_item")
-def register_ingestion_activity_menu():
+def register_monitoring_menu():
     from django.utils.translation import gettext as _
-    return MenuItem(
-        _("Ingestion Activity"),
-        reverse_lazy("ingestion_activity_feed"),
-        icon_name="history",
+    return SubmenuMenuItem(
+        _("Monitoring"),
+        Menu(items=[
+            MenuItem(
+                _("Ingestion Activity"),
+                reverse_lazy("ingestion_activity_feed"),
+                icon_name="history",
+                order=10,
+            ),
+            MenuItem(
+                _("Acquisition Feed"),
+                reverse_lazy("acquisition_feed"),
+                icon_name="download",
+                order=20,
+            ),
+        ]),
+        icon_name="view",
         order=840,
-    )
-
-
-@hooks.register("register_admin_menu_item")
-def register_acquisition_feed_menu():
-    from django.utils.translation import gettext as _
-    return MenuItem(
-        _("Acquisition Feed"),
-        reverse_lazy("acquisition_feed"),
-        icon_name="download",
-        order=841,
     )
 
 

--- a/georiva/src/georiva/ingestion/wagtail_hooks.py
+++ b/georiva/src/georiva/ingestion/wagtail_hooks.py
@@ -25,7 +25,7 @@ def register_monitoring_menu():
             ),
         ]),
         icon_name="view",
-        order=840,
+        order=860,
     )
 
 

--- a/georiva/src/georiva/sources/wagtail_hooks.py
+++ b/georiva/src/georiva/sources/wagtail_hooks.py
@@ -57,7 +57,7 @@ def urlconf_georivasources():
 @hooks.register('register_admin_menu_item')
 def register_sources_menu():
     return MenuItem(
-        _("Data Feeds"),
+        _("Automated Sources"),
         reverse('data_feed_list'),
         icon_name='file-import',
         order=800,


### PR DESCRIPTION
## Summary

- Combines **Ingestion Activity** and **Acquisition Feed** top-level menu items into a single **Monitoring** submenu (order 860 — after Automated Sources and Manual Uploads)
- Renames **Data Feeds** menu item to **Automated Sources** for consistency with domain language

## Test plan

- [ ] Admin sidebar shows: Automated Sources → Manual Uploads → Monitoring
- [ ] Monitoring submenu expands to reveal Ingestion Activity and Acquisition Feed
- [ ] Both links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)