### PR TITLE
Dashboard summary cards + installed plugins page

### DIFF
--- a/georiva/src/georiva/core/plugins.py
+++ b/georiva/src/georiva/core/plugins.py
@@ -1,0 +1,81 @@
+"""Helpers for introspecting installed GeoRiva plugins.
+
+A "plugin" is one of the packages discovered from ``GEORIVA_PLUGIN_DIRS`` and
+added to ``INSTALLED_APPS`` at startup (see ``config/settings/base.py``); their
+import-package names are exposed as ``settings.GEORIVA_PLUGIN_NAMES``.
+
+Metadata is read from the installed distribution via ``importlib.metadata``.
+"""
+import importlib.metadata
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+
+_url_validator = URLValidator()
+
+
+def _valid_url(value):
+    if not value:
+        return None
+    try:
+        _url_validator(value)
+    except ValidationError:
+        return None
+    return value
+
+
+def _distribution_name(module_name):
+    """Map an import-package name (e.g. ``georiva_cds``) to its distribution
+    name (e.g. ``georiva-cds``). ``packages_distributions`` handles the case
+    where they differ; fall back to the module name, which importlib also
+    normalizes."""
+    mapping = importlib.metadata.packages_distributions()
+    dists = mapping.get(module_name)
+    if dists:
+        return dists[0]
+    return module_name
+
+
+def _home_page(meta):
+    """Prefer the Home-page metadata field; fall back to a Project-URL entry
+    (newer setuptools puts the URL there instead)."""
+    home_page = _valid_url(meta.get("Home-page"))
+    if home_page:
+        return home_page
+    for entry in meta.get_all("Project-URL") or []:
+        # entries look like "Homepage, https://example.com"
+        _, _, url = entry.partition(",")
+        url = _valid_url(url.strip())
+        if url:
+            return url
+    return None
+
+
+def get_plugin_metadata(module_name):
+    """Return a metadata dict for a single installed plugin package.
+
+    On failure (package not installed / no metadata) returns a dict with the
+    module name and ``available=False`` so callers can still render a row."""
+    try:
+        dist = importlib.metadata.distribution(_distribution_name(module_name))
+    except importlib.metadata.PackageNotFoundError:
+        return {"name": module_name, "module": module_name, "available": False}
+    
+    meta = dist.metadata
+    return {
+        "module": module_name,
+        "name": meta.get("Name") or module_name,
+        "version": meta.get("Version"),
+        "summary": meta.get("Summary"),
+        "author": meta.get("Author") or meta.get("Author-email"),
+        "license": meta.get("License"),
+        "home_page": _home_page(meta),
+        "available": True,
+    }
+
+
+def get_installed_plugins():
+    """Metadata for every discovered plugin, sorted by display name."""
+    plugins = [get_plugin_metadata(name) for name in settings.GEORIVA_PLUGIN_NAMES]
+    return sorted(plugins, key=lambda p: (p.get("name") or "").lower())

--- a/georiva/src/georiva/core/summary_items.py
+++ b/georiva/src/georiva/core/summary_items.py
@@ -1,0 +1,72 @@
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from wagtail.admin.site_summary import SummaryItem
+
+from georiva.core.models import Catalog, Collection
+
+
+class _CountSummaryItem(SummaryItem):
+    """Base for a dashboard tile showing a count, a label and a link.
+
+    Subclasses set ``label_singular`` / ``label_plural`` and ``icon_name`` and
+    implement ``get_count`` / ``get_link``."""
+
+    template_name = "core/summary_count.html"
+    icon_name = "doc-empty"
+    label_singular = ""
+    label_plural = ""
+
+    def get_count(self):
+        raise NotImplementedError
+
+    def get_link(self):
+        raise NotImplementedError
+
+    def get_context_data(self, parent_context):
+        return {
+            "count": self.get_count(),
+            "label_singular": self.label_singular,
+            "label_plural": self.label_plural,
+            "icon_name": self.icon_name,
+            "link": self.get_link(),
+        }
+
+
+class CatalogSummaryItem(_CountSummaryItem):
+    order = 100
+    icon_name = "globe"
+    label_singular = _("Catalog")
+    label_plural = _("Catalogs")
+
+    def get_count(self):
+        return Catalog.objects.count()
+
+    def get_link(self):
+        return reverse("catalog:index")
+
+
+class CollectionSummaryItem(_CountSummaryItem):
+    order = 110
+    icon_name = "folder-open-inverse"
+    label_singular = _("Collection")
+    label_plural = _("Collections")
+
+    def get_count(self):
+        return Collection.objects.count()
+
+    def get_link(self):
+        return reverse("catalog:index")
+
+
+class PluginSummaryItem(_CountSummaryItem):
+    order = 120
+    icon_name = "puzzle-piece"
+    label_singular = _("Plugin")
+    label_plural = _("Plugins")
+
+    def get_count(self):
+        return len(settings.GEORIVA_PLUGIN_NAMES)
+
+    def get_link(self):
+        return reverse("plugin_list")

--- a/georiva/src/georiva/core/templates/core/plugin_list.html
+++ b/georiva/src/georiva/core/templates/core/plugin_list.html
@@ -1,0 +1,141 @@
+{% extends "wagtailadmin/generic/base.html" %}
+
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}
+    {% trans "Installed Plugins" %}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .pl-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+            gap: 1rem;
+            margin-top: 1.5rem;
+        }
+
+        .pl-card {
+            display: flex;
+            flex-direction: column;
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+            background: var(--w-color-surface-field);
+            overflow: hidden;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+            transition: box-shadow 0.15s ease;
+        }
+
+        .pl-card:hover {
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.08);
+        }
+
+        .pl-card-header {
+            display: flex;
+            align-items: baseline;
+            gap: 0.5rem;
+            padding: 1rem 1.25rem 0.5rem;
+        }
+
+        .pl-name {
+            font-weight: 600;
+            font-size: 1rem;
+            color: var(--w-color-text-label);
+        }
+
+        .pl-version {
+            font-size: 0.8rem;
+            color: var(--w-color-grey-400);
+        }
+
+        .pl-summary {
+            flex: 1 1 auto;
+            padding: 0 1.25rem 1rem;
+            color: var(--w-color-text-context);
+        }
+
+        .pl-card-footer {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.5rem 0.75rem;
+            padding: 0.75rem 1.25rem;
+            border-top: 1px solid var(--w-color-border-furniture);
+            background: var(--w-color-surface-page);
+            font-size: 0.85rem;
+            color: var(--w-color-grey-400);
+        }
+
+        .pl-card-footer .pl-sep {
+            color: var(--w-color-border-furniture);
+        }
+
+        .pl-link {
+            margin-left: auto;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            white-space: nowrap;
+        }
+
+        .pl-link .icon {
+            height: 1rem;
+            margin: .5rem 0;
+            min-width: 1rem;
+            width: 1rem;
+        }
+
+        .pl-unavailable {
+            padding: 0 1.25rem 1rem;
+            color: var(--w-color-grey-400);
+        }
+
+        .pl-empty {
+            margin-top: 1.5rem;
+            color: var(--w-color-grey-400);
+        }
+    </style>
+{% endblock %}
+
+{% block main_content %}
+    {% if not plugins %}
+        <p class="pl-empty">{% trans "No plugins are installed." %}</p>
+    {% else %}
+        <div class="pl-grid">
+            {% for plugin in plugins %}
+                <div class="pl-card">
+                    <div class="pl-card-header">
+                        <span class="pl-name">{{ plugin.name }}</span>
+                        {% if plugin.version %}
+                            <span class="pl-version">v{{ plugin.version }}</span>
+                        {% endif %}
+                    </div>
+
+                    {% if plugin.available %}
+                        {% if plugin.summary %}
+                            <div class="pl-summary">{{ plugin.summary }}</div>
+                        {% else %}
+                            <div class="pl-summary"></div>
+                        {% endif %}
+
+                        <div class="pl-card-footer">
+                            {% if plugin.author %}<span>{{ plugin.author }}</span>{% endif %}
+                            {% if plugin.author and plugin.license %}<span class="pl-sep">&middot;</span>{% endif %}
+                            {% if plugin.license %}<span>{{ plugin.license }}</span>{% endif %}
+                            {% if plugin.home_page %}
+                                <a class="pl-link" href="{{ plugin.home_page }}" target="_blank"
+                                   rel="noopener noreferrer">
+                                    {% icon name="link-external" %}
+                                    {% trans "Visit" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    {% else %}
+                        <div class="pl-unavailable">{% trans "Metadata unavailable" %}</div>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/georiva/src/georiva/core/templates/core/summary_count.html
+++ b/georiva/src/georiva/core/templates/core/summary_count.html
@@ -1,0 +1,9 @@
+{% load i18n wagtailadmin_tags %}
+
+<li>
+    {% icon name=icon_name %}
+    <a href="{{ link }}">
+        {{ count }}
+        {% if count == 1 %}{{ label_singular }}{% else %}{{ label_plural }}{% endif %}
+    </a>
+</li>

--- a/georiva/src/georiva/core/tests.py
+++ b/georiva/src/georiva/core/tests.py
@@ -230,3 +230,73 @@ class CatalogIndexTests(TestCase):
         
         page2 = self.client.get(self.url, {"p": 2})
         self.assertEqual(len(page2.context["catalog_panels"]), 5)
+
+
+class DashboardSummaryTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_dash", "dash@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def _request(self):
+        from django.test import RequestFactory
+        request = RequestFactory().get("/admin/")
+        request.user = self.user
+        return request
+
+    def test_summary_item_counts(self):
+        from django.conf import settings
+        from georiva.core.summary_items import (
+            CatalogSummaryItem, CollectionSummaryItem, PluginSummaryItem,
+        )
+
+        cat = Catalog.objects.create(name="A", slug="a", file_format="grib2")
+        Catalog.objects.create(name="B", slug="b", file_format="grib2")
+        Collection.objects.create(catalog=cat, name="c1", slug="c1")
+
+        request = self._request()
+        self.assertEqual(CatalogSummaryItem(request).get_count(), 2)
+        self.assertEqual(CollectionSummaryItem(request).get_count(), 1)
+        self.assertEqual(
+            PluginSummaryItem(request).get_count(), len(settings.GEORIVA_PLUGIN_NAMES)
+        )
+
+    def test_dashboard_renders_three_cards(self):
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        # Substrings match both singular/plural label forms (the count drives
+        # which is shown, and the test environment may have exactly 1 plugin).
+        self.assertContains(response, "Catalog")
+        self.assertContains(response, "Collection")
+        self.assertContains(response, "Plugin")
+        # Catalog/Collection cards link to the accordion; Plugins card to its page.
+        self.assertContains(response, reverse("catalog:index"))
+        self.assertContains(response, reverse("plugin_list"))
+
+
+class PluginListTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_plugins", "pl@test.com", "pw")
+        self.client.force_login(self.user)
+        self.url = reverse("plugin_list")
+
+    def test_page_renders(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Plugins")
+
+    def test_metadata_for_installed_package(self):
+        # Use a package guaranteed to be installed to exercise the helper
+        # independently of which plugins happen to be loaded.
+        from georiva.core.plugins import get_plugin_metadata
+
+        meta = get_plugin_metadata("wagtail")
+        self.assertTrue(meta["available"])
+        self.assertTrue(meta["name"])
+        self.assertTrue(meta["version"])
+
+    def test_metadata_for_missing_package(self):
+        from georiva.core.plugins import get_plugin_metadata
+
+        meta = get_plugin_metadata("definitely_not_a_real_package_xyz")
+        self.assertFalse(meta["available"])
+        self.assertEqual(meta["name"], "definitely_not_a_real_package_xyz")

--- a/georiva/src/georiva/core/views.py
+++ b/georiva/src/georiva/core/views.py
@@ -256,3 +256,19 @@ def collection_items_list(request, collection_pk):
     }
     
     return render(request, "core/collection_items.html", context)
+
+
+def plugin_list(request):
+    """Admin page listing all installed GeoRiva plugins and their metadata."""
+    from .plugins import get_installed_plugins
+    
+    context = {
+        "header_title": _("Installed Plugins"),
+        "header_icon": "puzzle-piece",
+        "breadcrumbs_items": [
+            {"url": reverse("wagtailadmin_home"), "label": _("Home")},
+            {"url": "", "label": _("Plugins")},
+        ],
+        "plugins": get_installed_plugins(),
+    }
+    return render(request, "core/plugin_list.html", context)

--- a/georiva/src/georiva/core/wagtail_hooks.py
+++ b/georiva/src/georiva/core/wagtail_hooks.py
@@ -3,7 +3,8 @@ from django.urls import path
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 
-from .views import collection_items_list
+from .summary_items import CatalogSummaryItem, CollectionSummaryItem, PluginSummaryItem
+from .views import collection_items_list, plugin_list
 from .viewsets import BoundaryChooserViewSet, admin_viewsets
 from .viewsets import ItemViewSet, AssetViewSet
 
@@ -12,6 +13,7 @@ from .viewsets import ItemViewSet, AssetViewSet
 def urlconf_georivacore():
     return [
         path('collection/<int:collection_pk>/items/', collection_items_list, name="collection_items_list"),
+        path('plugins/', plugin_list, name="plugin_list"),
     ]
 
 
@@ -40,7 +42,11 @@ def construct_homepage_summary_items(request, summary_items):
     
     summary_items[:] = [item for item in summary_items if item.__class__.__name__ not in hidden_summary_items]
     
-    summary_items[:] = []
+    summary_items[:] = [
+        CatalogSummaryItem(request),
+        CollectionSummaryItem(request),
+        PluginSummaryItem(request),
+    ]
 
 
 @hooks.register("register_icons")


### PR DESCRIPTION
Adds dashboard summary tiles for catalogs/collections/plugins and a page listing installed plugins.

## What changed
- **Dashboard summary cards** (Wagtail homepage): **Catalogs**, **Collections**, **Plugins**.
  - Catalogs = `Catalog.objects.count()` (fixes the previous item that counted *Collections* but was labelled "Catalogs"), Collections = `Collection.objects.count()`, Plugins = `len(settings.GEORIVA_PLUGIN_NAMES)`.
  - Catalogs/Collections link to the catalog accordion (`catalog:index`); Plugins links to the new plugins page.
  - One shared, singular/plural-aware template; shown to all admin users.
- **Installed plugins page** at `/admin/plugins/` (name `plugin_list`), reached from the Plugins card (no left-nav item). Responsive **card grid** — name, version, summary, author, license, and a home-page link (new tab); cards have a subtle shadow that lifts on hover. Per-plugin "metadata unavailable" state and an empty state.
- **Plugin metadata helper** (`core/plugins.py`) over `importlib.metadata`, enumerating `settings.GEORIVA_PLUGIN_NAMES`. Maps import-package → distribution via `packages_distributions()` (e.g. `georiva_cds` → `georiva-cds`) and falls back from `Home-page` to a `Project-URL` entry.

## Tests
`DashboardSummaryTests` (summary counts; dashboard renders all three cards + links) and `PluginListTests` (page renders; helper resolves an installed package and gracefully handles a missing one). Full `georiva.core.tests`: 21/21 pass.

JS/visual hover behavior is CSS-only; template render is covered by the page test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)