### PR TITLE
feat(sources): declarative source→output unit conversion for plugins

### DIFF
--- a/docs/architecture/plugin-parameter-contract.md
+++ b/docs/architecture/plugin-parameter-contract.md
@@ -291,8 +291,9 @@ dekadal at 10 days).
 class CollectionVariable:
     key: str  # Variable.slug
     name: str  # Variable.name
-    units: str  # Unit.symbol (created if absent)
-    source: SourceKey | None = None  # passthrough
+    source_units: str  # raw unit of the source data (Unit.symbol, created if absent)
+    output_units: str | None = None  # exposed unit; converted from source_units (defaults to source_units)
+    source_variable: SourceKey | None = None  # passthrough: which variable/band to read
     transform: str = 'passthrough'  # 'passthrough' | 'vector_magnitude' | 'vector_direction'
     components: dict[str, SourceKey] | None = None  # derived: {'u': SourceKey, 'v': SourceKey}
     description: str = ''
@@ -338,8 +339,8 @@ COLLECTIONS = {
             {
                 "key": "precip",
                 "name": "Precipitation",
-                "units": "mm",
-                "source": "band_1",  # string shorthand for SourceKey(name='band_1')
+                "source_units": "mm",  # raw unit; no output_units -> exposed as-is
+                "source_variable": "band_1",  # string shorthand for SourceKey(name='band_1')
                 "value_range": (0.0, 2000.0),
             }
         ],
@@ -352,15 +353,28 @@ def get_collection_definitions(cls):
     return parse_collection_defs(COLLECTIONS)
 ```
 
-**Variable source shorthand:** `"source": "band_1"` is equivalent to
+**Variable source shorthand:** `"source_variable": "band_1"` is equivalent to
 `SourceKey(name="band_1")`. For levelled sources pass a dict:
 
 ```python
-"source": {
+"source_variable": {
     "name": "2t",
     "level": {"type": "heightAboveGround", "value": 2, "dimension": "heightAboveGround", "unit": "m"}
 }
 ```
+
+**Unit conversion:** `source_units` is required (the raw unit). Add `output_units`
+only to convert — e.g. `"source_units": "K", "output_units": "degC"`. Omit
+`output_units` to expose the source unit unchanged.
+
+Conversion runs through [pint](https://pint.readthedocs.io) at ingestion time
+(`source_unit` → `unit` on the resulting `Variable`), so both units must be
+parseable by the registry in `core/unit_utils.py` (it accepts UDUNITS-style
+strings like `"kg kg-1"`, `"m2 s-2"`). Beyond simple scaling, the registry
+enables a **geopotential** context plus a `gpdam` (geopotential decametre) unit,
+so geopotential converts across dimensions to chart-faithful height — e.g.
+`"source_units": "m2 s-2", "output_units": "gpdam"` (divides by g, then by 10).
+Offset conversions (e.g. `K` → `degC`) are likewise supported.
 
 **Derived (vector) variables:**
 
@@ -368,7 +382,7 @@ def get_collection_definitions(cls):
 {
     "key": "wind_speed_10m",
     "name": "10m Wind Speed",
-    "units": "m/s",
+    "source_units": "m/s",
     "transform": "vector_magnitude",
     "components": {
         "u": {"name": "10u", "level": {"type": "heightAboveGround", "value": 10, ...}},

--- a/georiva/src/georiva/core/unit_utils.py
+++ b/georiva/src/georiva/core/unit_utils.py
@@ -54,7 +54,16 @@ def setup_registry(reg):
     
     # Alias geopotential meters (gpm) to just meters
     reg.define('@alias meter = gpm')
-    
+
+    # Geopotential decametre (gpdam) — the unit ECMWF charts plot geopotential
+    # height in (1 gpdam = 10 gpm). Defined explicitly because pint has no
+    # decametre alias to hang it off.
+    reg.define('gpdam = 10 * meter')
+
+    # Geopotential Φ is a specific energy (J/kg = m²/s²). Naming the dimension
+    # lets the geopotential context below bridge it to [length].
+    reg.define('[specific_enthalpy] = [energy] / [mass]')
+
     # custom contexts
     
     # Define a context for precipitation
@@ -80,7 +89,27 @@ def setup_registry(reg):
                                      lambda reg, x: x * reg('mm/h') / reg('kg/m^2/h'))
     
     reg.add_context(precipitation)
-    
+
+    # Define a context for geopotential <-> geopotential height
+    geopotential = pint.Context('geopotential')
+
+    # Geopotential height Z = Φ / g, with g = standard gravity (9.80665 m/s²).
+    # This bridges specific energy ([length]²/[time]²) to length, which pint
+    # otherwise refuses as dimensionally inconsistent. Combined with the gpdam
+    # unit, m²/s² → gpdam divides by g then by 10 in a single conversion.
+    geopotential.add_transformation('[length] ** 2 / [time] ** 2', '[length]',
+                                    lambda reg, x: x / reg('9.80665 m/s**2'))
+    geopotential.add_transformation('[length]', '[length] ** 2 / [time] ** 2',
+                                    lambda reg, x: x * reg('9.80665 m/s**2'))
+
+    reg.add_context(geopotential)
+
+    # Geopotential height conversion is physically unambiguous (it only ever
+    # fires for m²/s² <-> length), so enable it globally — callers of
+    # apply_unit_conversion need not name the context. Precipitation stays
+    # opt-in because mm <-> kg/m² is genuinely ambiguous.
+    reg.enable_contexts('geopotential')
+
     return reg
 
 

--- a/georiva/src/georiva/sources/collection_definitions.py
+++ b/georiva/src/georiva/sources/collection_definitions.py
@@ -17,26 +17,39 @@ class CollectionVariable:
     """
     One variable within a CollectionDefinition.
 
-    Scalar variables use transform='passthrough' (default) and source.
+    Scalar variables use transform='passthrough' (default) and source_variable.
     Vector-derived variables (wind speed, wind direction) use
     transform='vector_magnitude' or 'vector_direction' and components instead
-    of source.
+    of source_variable.
+
+    source_units (required) is the raw unit of the data as it leaves the source
+    file (or, for transforms, as it leaves the transform). output_units is the
+    unit this variable is exposed in: when set and different from source_units,
+    the ingestion pipeline converts source_units -> output_units via pint. When
+    output_units is None it defaults to source_units, i.e. no conversion.
     """
     key: str
     name: str
-    units: str
-    source: Optional[SourceKey] = None
+    source_units: str
+    output_units: Optional[str] = None
+    source_variable: Optional[SourceKey] = None
     transform: str = 'passthrough'
     components: Optional[dict[str, SourceKey]] = None
     description: str = ''
     value_range: Optional[tuple[float, float]] = None
     palette: Optional[str] = None
-    
+
     def __post_init__(self):
-        if self.transform == 'passthrough' and self.source is None:
-            raise ValueError(f"CollectionVariable '{self.key}': passthrough transform requires 'source'")
+        if self.transform == 'passthrough' and self.source_variable is None:
+            raise ValueError(f"CollectionVariable '{self.key}': passthrough transform requires 'source_variable'")
         if self.transform != 'passthrough' and self.components is None:
             raise ValueError(f"CollectionVariable '{self.key}': derived transform requires 'components'")
+
+    @property
+    def exposed_units(self) -> str:
+        """Unit this variable is exposed in: output_units, or source_units when
+        no conversion is declared."""
+        return self.output_units or self.source_units
 
 
 @dataclass(frozen=True)
@@ -138,8 +151,9 @@ def parse_collection_defs(raw: dict) -> list['CollectionDefinition']:
                     {
                         "key": "precip",            # optional; slugified from name if absent
                         "name": "Precipitation",    # required
-                        "units": "mm",             # required
-                        "source": "band_1",        # str shorthand, OR dict with name/level
+                        "source_units": "m",       # required (raw unit of source data)
+                        "output_units": "mm",      # optional; exposed unit (defaults to source_units)
+                        "source_variable": "band_1",  # str shorthand, OR dict with name/level
                         "value_range": (0.0, 2000.0),  # optional
                         "description": "",         # optional
                         "palette": None,           # optional
@@ -153,8 +167,8 @@ def parse_collection_defs(raw: dict) -> list['CollectionDefinition']:
 
         return parse_collection_defs(COLLECTIONS)
 
-    Source shorthand: ``"source": "band_1"`` is equivalent to
-    ``"source": {"name": "band_1", "level": None}``.
+    Source shorthand: ``"source_variable": "band_1"`` is equivalent to
+    ``"source_variable": {"name": "band_1", "level": None}``.
     """
     return [_parse_collection(key, data) for key, data in raw.items()]
 
@@ -182,19 +196,21 @@ def _parse_variable(v: dict) -> CollectionVariable:
         return CollectionVariable(
             key=key,
             name=v['name'],
-            units=v['units'],
-            source=_parse_source_key(v['source']),
+            source_units=v['source_units'],
+            output_units=v.get('output_units'),
+            source_variable=_parse_source_key(v['source_variable']),
             description=v.get('description', ''),
             value_range=tuple(v['value_range']) if v.get('value_range') else None,
             palette=v.get('palette'),
         )
-    
+
     # Vector-derived variable
     components = {k: _parse_source_key(s) for k, s in v['components'].items()}
     return CollectionVariable(
         key=key,
         name=v['name'],
-        units=v['units'],
+        source_units=v['source_units'],
+        output_units=v.get('output_units'),
         transform=transform,
         components=components,
         description=v.get('description', ''),

--- a/georiva/src/georiva/sources/setup_service.py
+++ b/georiva/src/georiva/sources/setup_service.py
@@ -174,20 +174,25 @@ class SourceSetupService:
         from georiva.core.models import Variable
         
         slug = slugify(var_def.key)
-        unit = self._get_or_create_unit(var_def.units)
-        
+        source_unit = self._get_or_create_unit(var_def.source_units)
+        output_unit = (
+            self._get_or_create_unit(var_def.output_units)
+            if var_def.output_units
+            else source_unit
+        )
+
         base_defaults = {
             "name": var_def.name,
             "description": var_def.description,
-            "unit": unit,
-            "source_unit": unit,
+            "unit": output_unit,
+            "source_unit": source_unit,
             "value_min": var_def.value_range[0] if var_def.value_range else 0.0,
             "value_max": var_def.value_range[1] if var_def.value_range else 1.0,
         }
         
         if var_def.transform == 'passthrough':
             transform = Variable.TransformType.PASSTHROUGH
-            sources_data = [self._source_key_to_block("primary", var_def.source)]
+            sources_data = [self._source_key_to_block("primary", var_def.source_variable)]
         elif var_def.transform == 'vector_magnitude':
             transform = Variable.TransformType.VECTOR_MAGNITUDE
             sources_data = [

--- a/georiva/src/georiva/sources/templates/georivasources/definition_collection_form.html
+++ b/georiva/src/georiva/sources/templates/georivasources/definition_collection_form.html
@@ -180,7 +180,7 @@
                                         <input type="checkbox" class="add-var-cb" name="variables"
                                                value="{{ var.key }}" data-group="{{ grp.key }}" checked>
                                         <span class="dcf-var-name">{{ var.name }}</span>
-                                        <span class="dcf-var-units">({{ var.units }})</span>
+                                        <span class="dcf-var-units">({{ var.exposed_units }})</span>
                                     </div>
                                 {% endfor %}
                             </div>

--- a/georiva/src/georiva/sources/templates/georivasources/definition_collection_vars.html
+++ b/georiva/src/georiva/sources/templates/georivasources/definition_collection_vars.html
@@ -181,7 +181,7 @@
                                     {{ entry.var_def.name }}
                                 </span>
                                 <span class="dcv-var-units">
-                                    ({{ entry.var_def.units }})
+                                    ({{ entry.var_def.exposed_units }})
                                 </span>
                             </div>
                         {% endfor %}

--- a/georiva/src/georiva/sources/templates/georivasources/wizard_step3_collections.html
+++ b/georiva/src/georiva/sources/templates/georivasources/wizard_step3_collections.html
@@ -309,7 +309,7 @@
                                     {% if not entry.multi_variable %}
                                         &nbsp;·&nbsp;
                                         {% for var in defn.variables %}
-                                            <span class="gcol-single-var-tag">{{ var.name }} ({{ var.units }})</span>
+                                            <span class="gcol-single-var-tag">{{ var.name }} ({{ var.exposed_units }})</span>
                                         {% endfor %}
                                     {% else %}
                                         &nbsp;·&nbsp;{% blocktrans count n=defn.variables|length %}{{ n }} variable
@@ -376,7 +376,7 @@
                                                             {{ var.name }}
                                                         </span>
                                                         <span class="gcol-var-units">
-                                                            ({{ var.units }})
+                                                            ({{ var.exposed_units }})
                                                         </span>
                                                     </div>
                                                 {% endfor %}

--- a/georiva/src/georiva/sources/tests/test_setup_service.py
+++ b/georiva/src/georiva/sources/tests/test_setup_service.py
@@ -1,0 +1,59 @@
+"""
+Tests for SourceSetupService variable provisioning, focused on the
+source_units -> units split that drives ingestion-time unit conversion.
+"""
+from django.test import TestCase
+
+from georiva.core.models import Catalog, Collection
+from georiva.core.unit_utils import ureg
+from georiva.sources.collection_definitions import CollectionVariable
+from georiva.sources.parameters import SourceKey
+from georiva.sources.setup_service import SourceSetupService
+
+
+def _collection():
+    catalog = Catalog.objects.create(name="Cat", slug="cat", file_format="grib2")
+    return Collection.objects.create(name="Col", slug="col", catalog=catalog)
+
+
+class UpsertVariableUnitsTests(TestCase):
+    def setUp(self):
+        self.service = SourceSetupService()
+        self.collection = _collection()
+
+    def test_source_units_creates_distinct_source_and_output_units(self):
+        var_def = CollectionVariable(
+            key="2t",
+            name="2m Temperature",
+            source_units="K",
+            output_units="degC",
+            source_variable=SourceKey(name="2t"),
+            value_range=(-60.0, 60.0),
+        )
+
+        variable = self.service._upsert_variable(self.collection, var_def)
+
+        self.assertEqual(variable.unit.symbol, "degC")
+        self.assertEqual(variable.source_unit.symbol, "K")
+        self.assertNotEqual(variable.unit_id, variable.source_unit_id)
+
+    def test_omitted_output_units_defaults_output_to_source_unit(self):
+        var_def = CollectionVariable(
+            key="wind",
+            name="10m Wind Speed",
+            source_units="m/s",
+            source_variable=SourceKey(name="10u"),
+        )
+
+        variable = self.service._upsert_variable(self.collection, var_def)
+
+        # No output_units declared -> the variable is exposed in its source
+        # unit, so source and output units resolve to the same row (no-op).
+        self.assertEqual(variable.unit_id, variable.source_unit_id)
+        self.assertEqual(variable.unit.symbol, "m/s")
+
+    def test_geopotential_context_converts_specific_energy_to_decametres(self):
+        # m2/s2 -> gpdam rides the global geopotential context (divide by g)
+        # plus the gpdam definition (divide by 10), in a single pint conversion.
+        q = ureg.Quantity(54000.0, "m2 s-2")
+        self.assertAlmostEqual(q.to("gpdam").magnitude, 550.65, places=1)

--- a/source-plugin-boilerplate/{{ cookiecutter.project_slug }}/plugins/{{ cookiecutter.project_module }}/src/{{ cookiecutter.project_module }}/models.py
+++ b/source-plugin-boilerplate/{{ cookiecutter.project_slug }}/plugins/{{ cookiecutter.project_module }}/src/{{ cookiecutter.project_module }}/models.py
@@ -40,8 +40,9 @@ COLLECTIONS = {
             {
                 "key": "example_var",
                 "name": "Example Variable",
-                "units": "",
-                "source": "band_1",
+                "source_units": "",          # raw unit of the source data (required)
+                # "output_units": "",        # optional; exposed unit if converting
+                "source_variable": "band_1",
                 # "value_range": (0.0, 100.0),
             },
         ],


### PR DESCRIPTION
## What

Adds **unit conversion** to the source-plugin `CollectionVariable` contract so plugins expose data in commonly-used units instead of raw source units.

### Contract changes
- **`source_units`** (required) — the raw unit of the source data, always declared as ground truth.
- **`output_units`** (optional) — the exposed unit. When set and different from `source_units`, ingestion converts `source_units → output_units` via pint. Omitted ⇒ exposed in source unit (no-op).
- Rename `source` → **`source_variable`** for an unambiguous `source_*` family (which band to read + its raw unit).
- New `CollectionVariable.exposed_units` (`output_units or source_units`); wizard templates use it.

### Conversion engine
`setup_service` provisions the `Variable` with distinct `source_unit`/`unit`, so the existing pint path (`extractor.extract` → `apply_unit_conversion`) converts at extraction time. Adds a globally-enabled **`geopotential`** pint context (Φ/g, g=9.80665) + a **`gpdam`** unit so geopotential `m²/s²` converts across dimensions to chart-faithful decametres — no new transform type.

## Tests
- `georiva.sources.tests.test_setup_service` — source/output unit split, omitted-output no-op, geopotential context math.
- Full `georiva.sources` suite: 18/18 pass.

## ⚠️ Breaking — coordinated merge required
`source_units` is now required and the dict key is `source_variable`. Source plugins must update in lock-step:
- wmo-raf/georiva-source-ecmwf#1
- wmo-raf/georiva-source-chirps#1
- wmo-raf/georiva-source-cds#1

Merge/deploy core **with** all three plugins.

## Rollout
Purge + re-ingest ECMWF collections (old assets carry pre-conversion encoding ranges). `z_*` per-level `value_range` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)