### PR TITLE
fix(plugins): default DOCKER_USER in install_plugin.sh

### DIFF
--- a/deploy/plugins/install_plugin.sh
+++ b/deploy/plugins/install_plugin.sh
@@ -20,6 +20,10 @@ A GeoRiva plugin is a folder named after the plugin. This must be a valid Python
 
 source /georiva/plugins/utils.sh
 
+# The builder stage doesn't export DOCKER_USER (only runtime-base does), so
+# default it to the user created in both stages.
+DOCKER_USER="${DOCKER_USER:-georiva}"
+
 # First parse the args using getopt
 VALID_ARGS=$(getopt -o u:dhf:rg:o --long hash:,url:,git:,help,dev,folder:,runtime,overwrite -- "$@")
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
## Problem

Build-time plugin installs fail with:

```
/georiva/plugins/install_plugin.sh: line 189: DOCKER_USER: unbound variable
```

The Docker **builder** stage creates a `georiva` user but never exports `DOCKER_USER` — only the `runtime-base` stage sets `ENV DOCKER_USER=georiva` (`Dockerfile:94`). Since `install_plugin.sh` runs under `set -euo pipefail`, the unbound reference aborts the build when plugins are baked in via `plugins.toml`.

## Fix

Default `DOCKER_USER` to `georiva` in `install_plugin.sh`, matching the user created in both the builder and runtime-base stages. This covers all uses (`chown` at lines 189/262-263 and the `gosu` call at 220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)