### PR TITLE
feat(nginx): proxy public georiva-assets bucket via subpath

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -147,6 +147,23 @@ http {
             proxy_set_header X-Forwarded-Port $server_port;
         }
 
+        # Public, unsigned assets from the georiva-assets MinIO bucket.
+        # Path-style addressing means the bucket name is already the first
+        # path segment, so no rewrite is needed. The bucket's anonymous
+        # read policy (s3:GetObject only) is applied by `setup_minio`.
+        location /georiva-assets/ {
+            set $upstream georiva-minio:9000;
+
+            proxy_pass http://$upstream;
+            proxy_redirect off;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Port $server_port;
+        }
+
         location /static/ {
             alias /wagtail_static/;
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,7 +271,7 @@ services:
     restart: unless-stopped
     command: --config /config/config.yaml
     ports:
-      - "3000:3000"
+      - "3000"
     environment:
       - DATABASE_URL=postgres://${GEORIVA_DB_USER}:${GEORIVA_DB_PASSWORD}@georiva-pgbouncer:5432/${GEORIVA_DB_NAME}
     volumes:

--- a/docs/plugins/georiva-storage-architecture.md
+++ b/docs/plugins/georiva-storage-architecture.md
@@ -432,8 +432,11 @@ GEORIVA_STORAGE_BACKEND = 's3'  # or 'local'
 # Internal endpoint — Docker service name, used for read/write
 AWS_S3_ENDPOINT_URL = "http://georiva-minio:9000"
 
-# Public endpoint — what browsers can reach, used for asset URLs
-MINIO_PUBLIC_ENDPOINT = "localhost:9000"  # or "minio.georiva.io" in production
+# Public endpoint — what browsers can reach, used for asset URLs.
+# In production, point this at your app domain (no port) and serve the
+# bucket through nginx at /georiva-assets/ — no separate subdomain needed.
+MINIO_PUBLIC_ENDPOINT = "localhost:9000"  # or "georiva.example.com" in production
+MINIO_PUBLIC_ENDPOINT_USE_SSL = False     # True in production (nginx terminates TLS)
 
 # Bucket definitions with per-bucket overrides
 GEORIVA_BUCKETS = {
@@ -470,6 +473,35 @@ Private buckets (internal + signed):
 Assets bucket (public + clean):
   http://localhost:9000/georiva-assets/weather-models/gfs/temperature/2025/01/15/temp.png
 ```
+
+### Serving public assets through nginx
+
+In production MinIO's S3 port is **not** published to the host — the `georiva-web-proxy`
+(nginx) is the only public entry point. Public assets are served at a `/georiva-assets/`
+route on the app domain instead of via a separate MinIO subdomain:
+
+```nginx
+# deploy/nginx/nginx.conf
+location /georiva-assets/ {
+    set $upstream georiva-minio:9000;
+    proxy_pass http://$upstream;          # no rewrite — path already carries the bucket
+    proxy_set_header Host $http_host;
+}
+```
+
+This works cleanly because of two properties:
+
+- **Path-style addressing** (`AWS_S3_ADDRESSING_STYLE=path`) puts the bucket name in the
+  first path segment, so `/georiva-assets/<key>` maps straight to MinIO with no rewrite.
+- **Unsigned URLs** (`querystring_auth=False`) mean there are no SigV4 signatures to break
+  when nginx forwards the request, and the bucket's anonymous `s3:GetObject` policy (applied
+  by `setup_minio`) is what authorizes the read.
+
+To activate, set `MINIO_PUBLIC_ENDPOINT` to the bare app domain and
+`MINIO_PUBLIC_ENDPOINT_USE_SSL=true`. Asset URLs then resolve same-origin as
+`https://georiva.example.com/georiva-assets/...`, so no CORS config or DNS/cert work is
+needed. Object reads return `200`; bucket listing stays `403` (the anonymous policy grants
+`GetObject` only).
 
 ### Management commands
 


### PR DESCRIPTION
## Summary

Serve the public `georiva-assets` MinIO bucket through the existing nginx proxy at `/georiva-assets/`, instead of requiring a separate subdomain or a publicly exposed MinIO port. Subdomains are awkward to provision (DNS + cert SAN), so this routes asset traffic through the same domain/cert the app already uses. Also completes the "nginx is the single public door" posture by un-publishing the last directly-exposed service port (Martin).

## Why this is safe and minimal

- **No signatures to break.** Assets are served unsigned (`querystring_auth: False`); the only public traffic is anonymous `GetObject`. The hard part of proxying an S3 API — SigV4 signature-over-path breaking on rewrite — simply doesn't apply.
- **No rewrite needed.** Addressing is path-style (`AWS_S3_ADDRESSING_STYLE=path`), so the bucket name is already the first path segment. `location /georiva-assets/` → `georiva-minio:9000` passes the path through unchanged.
- **Access already scoped.** `setup_minio` applies an anonymous `s3:GetObject`-only policy to the bucket (no `ListBucket`), so object reads work but bucket listing stays `403`.
- **No app changes.** Asset URLs are derived from `MINIO_PUBLIC_ENDPOINT` / `MINIO_PUBLIC_ENDPOINT_USE_SSL` via `context_processors.py` and the assets `custom_domain` override.

Notably, in prod MinIO's `9000` is container-only (not host-published), so asset URLs were effectively unreachable before this — the proxy becomes the single public door, which is the intended posture.

## Changes

- `deploy/nginx/nginx.conf` — add a `/georiva-assets/` location proxying to `georiva-minio:9000`, matching the existing `set $upstream` + resolver pattern. Validated with `nginx -t`.
- `docker-compose.yml` — stop publishing Martin's `3000:3000` host port (container-only). Martin is already proxied at `/martin/`, so this just removes a redundant direct entry point.

## Activation (production)

Set in prod `.env`:

```
MINIO_PUBLIC_ENDPOINT=<your-domain>      # bare host, no :9000
MINIO_PUBLIC_ENDPOINT_USE_SSL=true       # nginx terminates TLS on 443
```

Then reload `georiva-web-proxy` (nginx) and redeploy `georiva` so rendered URLs pick up the new endpoint. Dev is unchanged (`localhost:9000`, direct port).

## Verification

- `curl -I https://<domain>/georiva-assets/<known-key>.png` → `200`
- `curl https://<domain>/georiva-assets/` (bucket root) → `403` (listing stays denied)
- Martin tiles still reachable at `https://<domain>/martin/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)