### PR TITLE
fix(api): derive absolute URLs from Wagtail Site to emit https in prod

### DIFF
--- a/georiva/src/georiva/core/utils.py
+++ b/georiva/src/georiva/core/utils.py
@@ -6,13 +6,17 @@ from wagtail.models import Site
 
 def get_full_url_by_request(request, path):
     site = Site.find_for_request(request)
+    if site is None:
+        # No Wagtail Site matches the request host; fall back to the request.
+        return request.build_absolute_uri(path)
+
     base_url = site.root_url
-    
+
     # We only want the scheme and netloc
     base_url_parsed = urlsplit(force_str(base_url))
-    
+
     base_url = base_url_parsed.scheme + "://" + base_url_parsed.netloc
-    
+
     return base_url + path
 
 

--- a/georiva/src/georiva/edr/serializers.py
+++ b/georiva/src/georiva/edr/serializers.py
@@ -23,6 +23,7 @@ from itertools import groupby
 from rest_framework import serializers
 
 from georiva.core.models import Collection, Item
+from georiva.core.utils import get_base_stac_api_url, get_full_url_by_request
 
 
 # =============================================================================
@@ -35,14 +36,12 @@ class EDRBaseURLMixin:
     def _get_base_url(self) -> str:
         request = self.context.get('request')
         if request:
-            return request.build_absolute_uri('/api/edr/')
+            return get_full_url_by_request(request, '/api/edr/')
         return '/api/edr/'
-    
+
     def _get_stac_base_url(self) -> str:
         request = self.context.get('request')
-        if request:
-            return request.build_absolute_uri('/api/stac/')
-        return '/api/stac/'
+        return get_base_stac_api_url(request)
 
 
 # =============================================================================

--- a/georiva/src/georiva/edr/views.py
+++ b/georiva/src/georiva/edr/views.py
@@ -32,6 +32,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from georiva.core.models import Collection, Item
+from georiva.core.utils import get_base_stac_api_url, get_full_url_by_request
 from .renderers import EDRJSONRenderer
 from .serializers import (
     EDRCollectionSerializer,
@@ -64,7 +65,7 @@ class EDRLandingPageView(EDRAPIView):
     """
     
     def get(self, request: Request) -> Response:
-        base_url = request.build_absolute_uri('/api/edr/')
+        base_url = get_full_url_by_request(request, '/api/edr/')
         
         return Response({
             "title": "GeoRiva EDR API",
@@ -93,7 +94,7 @@ class EDRLandingPageView(EDRAPIView):
                 },
                 {
                     "rel": "related",
-                    "href": request.build_absolute_uri('/api/stac/'),
+                    "href": get_base_stac_api_url(request),
                     "type": "application/json",
                     "title": "GeoRiva STAC API",
                 },
@@ -151,7 +152,7 @@ class EDRCollectionListView(EDRAPIView):
     """
     
     def get(self, request: Request) -> Response:
-        base_url = request.build_absolute_uri('/api/edr/')
+        base_url = get_full_url_by_request(request, '/api/edr/')
         
         queryset = Collection.objects.filter(
             is_active=True,

--- a/georiva/src/georiva/stac/openapi.py
+++ b/georiva/src/georiva/stac/openapi.py
@@ -9,11 +9,13 @@ from rest_framework.decorators import api_view
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from georiva.core.utils import get_base_stac_api_url
+
 
 def get_openapi_schema(request: Request) -> dict:
     """Generate OpenAPI 3.0 schema for STAC API."""
-    
-    base_url = request.build_absolute_uri('/api/stac/')
+
+    base_url = get_base_stac_api_url(request)
     
     return {
         "openapi": "3.0.3",

--- a/georiva/src/georiva/stac/serializers.py
+++ b/georiva/src/georiva/stac/serializers.py
@@ -25,7 +25,7 @@ from urllib.parse import urlencode
 
 from rest_framework import serializers
 
-from georiva.core.utils import get_base_stac_api_url
+from georiva.core.utils import get_base_stac_api_url, get_full_url_by_request
 
 
 class STACBaseURLMixin:
@@ -66,7 +66,7 @@ class STACAssetSerializer(serializers.Serializer):
         
         # Build absolute href
         if request and not data['href'].startswith('http'):
-            data['href'] = request.build_absolute_uri(instance.url)
+            data['href'] = get_full_url_by_request(request, instance.url)
         else:
             data['href'] = instance.url
         
@@ -345,7 +345,7 @@ class STACItemSerializer(serializers.Serializer, STACBaseURLMixin):
             f"?{urlencode(params)}"
         )
         if request:
-            return request.build_absolute_uri(path)
+            return get_full_url_by_request(request, path)
         return path
     
     def get_collection(self, obj):
@@ -838,7 +838,7 @@ class STACItemCollectionSerializer(serializers.Serializer):
         links = []
         
         if request:
-            current_url = request.build_absolute_uri()
+            current_url = get_full_url_by_request(request, request.get_full_path())
             links.append({
                 "rel": "self", "href": current_url,
                 "type": "application/geo+json",
@@ -848,7 +848,7 @@ class STACItemCollectionSerializer(serializers.Serializer):
             variable = self.context.get('variable')
             collection = obj.get('collection')
             if collection and variable:
-                base_url = request.build_absolute_uri('/api/stac/')
+                base_url = get_base_stac_api_url(request)
                 collection_url = (
                     f"{base_url}collections/"
                     f"{collection.catalog.slug}/{collection.slug}/{variable.slug}/"

--- a/georiva/src/georiva/stac/views.py
+++ b/georiva/src/georiva/stac/views.py
@@ -34,6 +34,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from georiva.core.models import Catalog, Collection, Item, Variable
+from georiva.core.utils import get_full_url_by_request
 from .renderers import STACJSONRenderer, GeoJSONRenderer
 from .serializers import (
     STACRootCatalogSerializer,
@@ -811,8 +812,8 @@ class STACQueryablesView(STACAPIView):
             collection_slug: str = None,
             variable_slug: str = None,
     ) -> Response:
-        base_url = request.build_absolute_uri()
-        
+        base_url = get_full_url_by_request(request, request.get_full_path())
+
         queryables = {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": base_url,


### PR DESCRIPTION
## Problem

STAC thumbnails (and other API links) loaded as `http://` in production. Behind the Nginx TLS-terminating proxy, requests reach Gunicorn over plain HTTP, so `request.build_absolute_uri()` returned `http://` URLs even on HTTPS pages — `SECURE_PROXY_SSL_HEADER` was never set.

## Fix

Route all absolute-URL construction in the STAC and EDR APIs through `get_full_url_by_request()`, which takes scheme/host from the Wagtail **Site** record rather than the proxied request. Added a `None`-guard so it falls back to `request.build_absolute_uri()` when no Site matches the request host.

Converted call sites:

| File | What |
|------|------|
| `core/utils.py` | `None`-guard fallback in `get_full_url_by_request` |
| `stac/serializers.py` | asset href, thumbnail href, feature-collection `self` link, collection link |
| `stac/openapi.py` | OpenAPI schema base URL |
| `stac/views.py` | queryables `$id` |
| `edr/serializers.py` | EDR/STAC base URLs in mixin |
| `edr/views.py` | EDR landing `self`/`conformance`/`data` + related STAC link |

The two no-arg `build_absolute_uri()` calls use `request.get_full_path()` to preserve path + query string.

## ⚠️ Deployment note

The `http`→`https` outcome depends on the prod Wagtail **Site port being 443**. Verify with:

```bash
georiva shell_plus -c "from wagtail.models import Site; print([(s.hostname, s.port, s.root_url) for s in Site.objects.all()])"
```

## Tests

`georiva.stac.tests` + `georiva.core.tests` — 21 passing. (`georiva/edr/` has no test module yet — worth adding.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)