### PR TITLE
fix(core): make get_full_url_by_request idempotent for absolute URLs

### DIFF
--- a/georiva/src/georiva/core/utils.py
+++ b/georiva/src/georiva/core/utils.py
@@ -5,6 +5,12 @@ from wagtail.models import Site
 
 
 def get_full_url_by_request(request, path):
+    # Already an absolute URL — return as-is (mirrors build_absolute_uri,
+    # which is idempotent for absolute inputs). Prevents double-prefixing
+    # things like S3/MinIO asset URLs that are already fully qualified.
+    if path and urlsplit(force_str(path)).scheme:
+        return path
+
     site = Site.find_for_request(request)
     if site is None:
         # No Wagtail Site matches the request host; fall back to the request.


### PR DESCRIPTION
## Problem

STAC asset hrefs for `.tif` files came out **double-prefixed** in production:

```
https://georiva-demo.climtech.africahttps://georiva-demo.climtech.africa/georiva-assets/chirps/.../precip_000000.tif
```

## Root cause

Regression from #117. `STACAssetSerializer` calls:

```python
data['href'] = get_full_url_by_request(request, instance.url)
```

where `instance.url` is the **already-absolute** S3/MinIO storage URL (`https://host/georiva-assets/...`). The previous code used `request.build_absolute_uri(instance.url)`, which is **idempotent** for absolute inputs. The new helper did a naive `base_url + path`, so it prepended the host a second time.

(The guard `not data['href'].startswith('http')` doesn't help — the serializer field reads `instance.href`, the *relative* stored path, which never starts with `http`.)

## Fix

Make `get_full_url_by_request` return the path unchanged when it already has a URL scheme — restoring `build_absolute_uri` semantics and protecting every call site, not just the asset href.

## Verification

Reproduced and confirmed fixed through the actual serializer:

```
before: http://localhosthttp://localhost:9000/georiva-assets/.../2t_....tif
after : http://localhost:9000/georiva-assets/.../2t_....tif
```

Relative paths still get the Site prefix; absolute http/https URLs pass through untouched. `georiva.stac.tests` + `georiva.core.tests` — 21 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)