### PR TITLE
docs: staging tier + derivation engine ADRs and glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,83 @@ formats, and indexes it as STAC-compliant catalogs for African National Meteorol
 
 ## Language
 
+### Data tiers
+
+**Staging**:
+Fetched or uploaded raw artifacts held as STAC-shaped, **source-grained**, **not-served** data — inputs that still
+require a transform before they can be served. Mirrors the STAC *spec* (Collection/Item/Asset) but follows the
+**source/acquisition** shape, not the product shape. Lives in a dedicated `staging` data app. Raw-ness is expressed
+as the asset role `source`, not by the tier name. A `StagingItem` is **not** a TimescaleDB hypertable; it carries a
+flexible STAC temporal extent (nullable `datetime` plus optional `start_datetime`/`end_datetime`).
+_Avoid_: Raw (as a tier name), Raw tier
+
+**Published**:
+Product-grained, **served** STAC data — the existing `core` `Collection`/`Item`/`Asset`. "Served" always means
+Published. A published `Item` is a TimescaleDB hypertable (one row per timestep). Reached either directly
+(Direct → Published, for ready products needing only inline normalization) or via Derivation from Staging.
+A Published `Collection` carries a `visibility` (`public | internal`); serving exposes only `public`.
+_Avoid_: Processed tier, Analysis-ready (as a tier name — those are MinIO buckets, not tiers)
+
+**Intermediate product**:
+A derived product that is itself an input to a further Derivation (e.g. an anomaly feeding the Combined Drought
+Indicator). Lives in **Published** as a normal `core.Item`/`Collection` with `visibility=internal` — **not** in
+Staging (it is product-shaped and derived, not raw acquisition). Internal collections are read freely by the engine
+but never served.
+_Avoid_: pre-final artifact, internal staging
+
+### Derivation & lineage
+
+**Derivation**:
+The **write-side** act of transforming Staging (and/or Published) inputs into Published products and persisting the
+result. "Derivation = analysis you persist." Distinct from read-side **Analysis** (compute-on-read, not persisted).
+Performed by the Derivation Engine in the `processing` app, never in `analysis`.
+_Avoid_: processing (as a synonym for the phase), import, analysis (for the write-side act)
+
+**DerivationLink**:
+A lineage edge recording that one Published `Item` was derived from one input Item (Staging or Published). One row
+per (output, input) edge, tagged with recipe id/version and an input hash. Item-level granularity. Lives in the
+`staging` data app, written by the engine. Cross-tier and descriptive provenance — **not** an execution plan.
+_Avoid_: provenance link, lineage record (as model names), derived_from (as a model name)
+
+### Derivation engine
+
+**Derivation Engine**:
+The generic, domain-agnostic orchestrator in the `processing` app — the write-side counterpart of the Loader. Owns
+the run loop: enumerate units → resolve inputs → check readiness → compute → write asset → register Published
+items/assets → write DerivationLinks → emit events → idempotency/versioning. Knows nothing about climate semantics
+(seasons, baselines, indices). The same primitive `run(recipe, selector)` serves event-driven, scheduled/backfill,
+and manual invocation.
+_Avoid_: processing engine, pipeline engine
+
+**Recipe**:
+A declarative plugin registered against the engine that describes a single family of derivation. Declares: named
+**input selectors** (over Staging/Published, parameterized by a unit's coordinates), how to **enumerate units**,
+a **readiness** predicate, a **pure transform**, and an **outputs** descriptor. Does **not** own its run loop (the
+engine does), but may override individual steps via hooks. Recipe families (Climatology & Indices, ML/Forecast
+post-processing, Impact-based) register without editing the engine.
+_Avoid_: processor, operator, derivation (Recipe is the spec; Derivation is the act)
+
+**Production Unit**:
+The atomic, opaque, hashable coordinate the engine iterates over — one unit produces one output slice. Its
+**semantics are owned by the Recipe**, not the engine (e.g. climatology = `(variable, period, season, quantity,
+baseline)`; CDI = `(region, month)`; promotion = the staging item, 1:1). The recipe's `outputs(unit)` maps a unit
+onto the Published schema (Collection slug + Item key); the engine treats it only as an idempotency key.
+_Avoid_: target slice, slice, tile (as the model name)
+
+**DerivationRun**:
+The per-Production-Unit tracking record for one engine execution — the write-side analogue of `FileIngestion`.
+Serves three roles: distributed **lock** (prevents two workers computing the same unit), **state machine**
+(`pending → running → completed / failed`, the only record of a failed/in-progress unit since those produce no
+Published item), and **monitoring** surface. Carries `recipe_type`, `recipe_version`, serialized `unit_key`,
+`input_hash`, timing, error, and FK(s) to produced item(s). Lives in the `processing` (engine) app, **not** the data
+layer — it is engine bookkeeping and is removed with the engine, while `DerivationLink` and Items survive.
+_Avoid_: DerivationLog, RecipeRun, ProcessingRun
+
+**Promotion**:
+The degenerate identity Derivation — a ready Staging item normalized (clip/unit-convert/COG/register) into a
+Published item with no real transform. The base case proving the engine handles the 1:1 path.
+_Avoid_: copy, publish (as a verb for this), passthrough
+
 ### Pipeline phases
 
 **Fetch**:

--- a/docs/adr/0004-staging-tier-and-abstract-stac-models.md
+++ b/docs/adr/0004-staging-tier-and-abstract-stac-models.md
@@ -1,0 +1,103 @@
+# Staging Tier and Abstract STAC Models
+
+## Context
+
+GeoRiva's current data flow couples acquisition to materialization: a `DataFeed` fetch lands a file in the
+`georiva-sources` bucket, the MinIO consumer reacts to the bucket event, and `FileIngestion` materializes it
+straight into served Published `Item`/`Asset` rows. Every fetched file becomes served layers.
+
+This breaks for inputs that require a transform before they mean anything to a user. The concrete driver is CDS /
+CMIP6: the plugin downloads raw multi-temporal NetCDF (one long series per `variable × experiment`, subset to a
+country). What users actually see are **derived** climatologies (`period × season × quantity × baseline`). Forcing
+that raw NetCDF through the current path would shred it into thousands of useless per-timestep served layers — and
+there is nowhere to *hold* the raw input while it awaits derivation.
+
+We need a second data tier that holds raw inputs as first-class, STAC-shaped, **not-served** data — without
+inflating it into the Published catalog, and without coupling its existence to the derivation engine that will
+later consume it.
+
+## Decision
+
+**Introduce two STAC tiers that mirror the same spec but play different roles.**
+
+- **Published** — the existing `core` `Collection`/`Item`/`Asset`. Product-grained, served. `Item` keeps
+  `TimescaleModel` (hypertable, one row per timestep).
+- **Staging** — new `StagingCollection`/`StagingItem`/`StagingAsset`. Source/acquisition-grained, **not served**.
+  A `StagingItem` is **not** a hypertable; it carries a flexible STAC temporal extent (nullable `datetime` plus
+  optional `start_datetime`/`end_datetime`) — one item per raw file, not per timestep. Its temporal fields are
+  **approximate Gregorian index bounds**; the authoritative time (and calendar, e.g. CMIP6 360-day) is read from
+  file content at derivation time.
+
+Raw-ness is expressed as an **asset role** (`source`), not by the tier name — hence "Staging", not "Raw".
+
+**Staging lives in its own `staging` data app.** The tier boundary becomes a real import boundary
+(`from staging.models import StagingItem`), so "not served" is visible at the import site and `core` does not
+accumulate a second item lifecycle.
+
+**Shared structure via abstract base models, not multi-table inheritance or proxies.** Extract
+`AbstractCollection`, `AbstractSpatialItem`, `AbstractAsset` into `core`. The bases hold only the
+**non-relational** fields (bounds, geometry, raster dims, crs, properties; href, media_type, roles, format,
+file_size, checksum, stats, extra_fields) **plus the shared `variable` FK** (both tiers reference the same
+`core.Variable`). Each concrete model adds its own relations: `Item`/`StagingItem` add their `collection` FK and
+their own temporal fields; `Asset`/`StagingAsset` add their own `item` ParentalKey.
+
+**Lineage is a `DerivationLink`, written by the engine, living in the data layer.** One row per (output, input)
+edge:
+
+- `derived_item` → `core.Item` (output, always Published);
+- exactly one of `source_staging_item` → `staging.StagingItem` or `source_published_item` → `core.Item`
+  (enforced by a check constraint);
+- provenance tags: `recipe_id`, `recipe_version`, `input_hash`.
+
+Granularity is **item-level**. `DerivationLink` lives in the **`staging` app** — `staging` already depends on
+`core` (it imports the abstract bases), so the dependency direction stays `staging → core` and `core` remains
+dependency-free. (Putting it in `core`, as an early sketch did, would force `core` to depend on `staging`.)
+
+**Intermediate products stay in Published, marked internal.** A derived product that is itself an input to a
+further derivation (e.g. an anomaly feeding the Combined Drought Indicator) is product-shaped, not raw — so it does
+**not** go in Staging. Instead, `Collection` gains `visibility = public | internal` (collection-grained). Serving
+exposes only `public`; the engine reads `internal` collections freely. This keeps Staging meaning exactly one
+thing (raw inputs awaiting derivation) and keeps lineage/versioning uniform (intermediates are `core.Item`s, so
+`DerivationLink.source_published_item` and forward invalidation cover them with no special-casing).
+
+**The dependency rule:** the data layer (`core`, `staging`) depends on nothing above it; producers (`sources`,
+`processing`) and consumers (`serving`, `monitoring`) depend on the data layer; the derivation engine is removable
+without touching the schema.
+
+## Alternatives considered
+
+**Single tier with an `is_raw` / `served` flag on `core.Item`** — rejected. Staging and Published have genuinely
+different shapes: Published is a hypertable with one row per timestep; Staging is one item per file with a range
+extent and no hypertable. A flag cannot reconcile those storage semantics, and it would put raw multi-temporal
+inputs into the same table the serving layer queries.
+
+**Multi-table inheritance (a shared parent table)** — rejected. MTI adds an implicit join on every query and a
+shared PK space across tiers; it couples the two tiers at the database level precisely where we want them
+independent.
+
+**Proxy models** — rejected. Proxies share one table, so they cannot give Staging a different schema (no
+hypertable, range extent) — they only relabel behavior on identical storage.
+
+**Name the tier "Raw"** — rejected. Raw-ness is a property of an *asset* (role `source`), not of the tier; a
+staging item can also hold non-raw companion assets. "Staging" names the role (held, awaiting derivation) without
+overloading it with format/provenance meaning.
+
+**`DerivationLink` via GenericForeignKey** — rejected. GFK loses DB-level referential integrity, cascade, and
+cheap reverse queries. With only two tiers, two nullable FKs + a check constraint is the pragmatic
+integrity-preserving choice; a unified `ItemRef` indirection table only pays off at three or more tiers.
+
+**Intermediate products as Staging items** — rejected. Anomalies are derived, product-shaped time-series wanting
+the hypertable and `data`-role COGs — not acquisition artifacts. Folding them into Staging would conflate "raw
+input awaiting derivation" with "derived product not meant for serving" and force CDI's lineage to span both FK
+types for one conceptual edge.
+
+## Consequences
+
+- New `staging` app: `StagingCollection`, `StagingItem`, `StagingAsset`, plus `DerivationLink`.
+- `core` gains `AbstractCollection`, `AbstractSpatialItem`, `AbstractAsset`; concrete `Collection`/`Item`/`Asset`
+  reparented onto them (Meta, temporal fields, and tier-specific relations kept on the concretes).
+- `Asset.Role` gains `source`. `Collection` gains `visibility` (`public | internal`); serving queries filter to
+  `public`.
+- The data layer stays dependency-free of the engine; `DerivationLink` is written by `processing` but owned by
+  the `staging` schema and survives engine removal.
+- The app is pre-1.0; migrations for the reparenting are reset rather than preserved as no-ops.

--- a/docs/adr/0005-generic-derivation-engine.md
+++ b/docs/adr/0005-generic-derivation-engine.md
@@ -1,0 +1,134 @@
+# Generic Derivation Engine
+
+## Context
+
+[ADR-0004](./0004-staging-tier-and-abstract-stac-models.md) introduces a Staging tier that holds raw inputs
+awaiting a transform. Something has to turn those inputs (and/or existing Published products) into served Published
+products, recording lineage. GeoRiva has no first-class concept for this.
+
+The driving requirement is an Atlas-like experience (Copernicus Interactive Climate Atlas), but the capability must
+be **general**, not CDS-specific. The products span a wide space: single-input promotions, climatology families
+(`period × season × quantity × baseline`), SPI/SPEI indices, and multi-input cross-collection products like the
+Combined Drought Indicator (precip + soil moisture + vegetation anomalies). The hard part is making one engine
+serve all of these without learning what a "season" or a "drought index" is — and without every product family
+re-implementing idempotency, locking, and lineage.
+
+This is the write-side counterpart of the existing Loader plugin system, where `DataSource.generate_requests()`
+only *declares* what to fetch, `FetchStrategy` is the pluggable mechanism, and `Loader` is the generic
+orchestrator.
+
+This is **derivation** (compute-on-write, persisted) and must be kept distinct from **analysis** (compute-on-read,
+not persisted). "Derivation = analysis you persist."
+
+## Decision
+
+**A new `processing` app owns a generic, domain-agnostic Derivation Engine.** Recipe families register against it;
+adding a family never edits the engine.
+
+**Recipes are declarative + a pure transform; the engine owns the run loop.** A `Recipe` declares — it does not
+execute:
+
+- named **input selectors** over Staging/Published, parameterized by a unit's coordinates;
+- how to **enumerate units** (declarative default = cartesian product over declared dimensions, temporal dims
+  clipped to the trigger range);
+- a **readiness** predicate;
+- a pure **`transform(resolved_inputs) → outputs`**;
+- an **outputs** descriptor.
+
+The engine does resolve → readiness → compute → write → register → link → event → idempotency, generically. A
+recipe may override individual *steps* via hooks (e.g. `enumerate_units`, `resolve_inputs`) when the declarative
+form can't express something — imperative *within* a declared step, never instead of the loop.
+
+**The engine iterates over an opaque `ProductionUnit`.** A unit is a hashable coordinate whose semantics the
+**recipe** owns (climatology = `(variable, period, season, quantity, baseline)`; CDI = `(region, month)`;
+promotion = the staging item, 1:1). The engine has **no built-in notion of "slice = (collection, time)"** —
+mapping a unit onto the Published schema (Collection slug + Item key, including categorical dims that don't fit
+`Item`'s `(collection, time[, reference_time])` key) lives entirely in the recipe's `outputs(unit)`. The engine
+treats the unit only as an idempotency key.
+
+**Readiness is a join with no late-arrival state machine.** Candidate generation (`candidate_units(trigger)`) maps
+an arriving input back to the units it feeds (or, for backfill, enumerates over a range). The default readiness
+predicate = all `required` selectors resolve to a complete result; optional inputs pass to the transform as
+present-or-`None`. Quorum/tolerance ("≥2 of 3", "wait then proceed") is an override hook, not a built-in. Late or
+partial units simply stay unmaterialized and are re-evaluated on the next relevant event and by a periodic
+**backfill sweep** — the write-side mirror of `sweep_unprocessed`. Cadence mismatch is absorbed by selectors
+(declare a `time_window(unit)`, pull all timesteps) and the transform (aggregate), never by the engine.
+
+**Alignment lives in recipe transforms, never the engine.** The engine hands in-memory rasters (possibly on
+different grids/CRS/cadences/calendars) to the transform, which harmonizes onto a recipe-declared target grid via
+the shared geoprocessing library. For multi-input recipes (CDI) we **harmonize eagerly**: upstream intermediates
+are written to internal Published collections already on a common analysis grid, so the regrid cost is paid once
+and the multi-input transform is trivial. Calendar conversion (e.g. CMIP6 360-day → Gregorian) is a geoprocessing
+op.
+
+**Versioning is overwrite-in-place.** An input's version is its `Asset.checksum`; a unit's `input_hash` =
+`hash(sorted(input checksums) + recipe_version)`. Idempotency: if a Published item for the unit already records a
+matching `input_hash` + `recipe_version`, no-op; else (re)compute and update the item's assets in place. No
+parallel item history (the `Item` unique constraint forbids two items per slice anyway). Staleness propagates
+**forward** by walking `DerivationLink` from a changed input to its derived items (transitively through internal
+intermediates), plus the sweep comparing recorded vs current checksums.
+
+**`DerivationRun` tracks each unit's execution** — the write-side analogue of `FileIngestion`, living in
+`processing` (engine bookkeeping, not catalog data). It is the distributed **lock** (preventing two workers
+computing the same unit), the **state machine** (`pending → running → completed / failed` — the only record of a
+failed or in-progress unit, since those produce no Published item), and the **monitoring** surface.
+
+**One invocation primitive: `run(recipe, selector)`.** It enumerates candidate units and fans out one per-unit
+Celery task each (each task takes the `DerivationRun` lock). Event-driven, scheduled/backfill, and manual
+invocation are all thin callers differing only in how wide a selector they build — backfill and streaming share
+one code path. Per-unit compute runs on a **dedicated `georiva-processing` queue**, isolated from
+`georiva-ingestion`, so a multi-year backfill cannot starve live ingestion.
+
+**Compute is a shared, pure library.** `geoprocessing` is a non-Django package (no models, no migrations) holding
+raster algebra, regridding, temporal aggregation, calendar conversion, and zonal stats. Functions take in-memory
+raster objects in and return rasters/scalars out — no MinIO, no models, no request layer. Both write-side
+processing and read-side analysis call it; callers own their own I/O. It is extracted from `analysis`
+incrementally, op-by-op, as recipes need each operation.
+
+**Recipes are code-registered for v1; DB configuration is deferred.** Like `BaseDataSource`/format plugins,
+recipes register in code; invocation is event hooks + management command + Celery beat + a thin admin trigger. A
+DB `DerivationConfig` + admin wizard (the `DataFeed` analogue) is deferred until 2–3 recipe families stabilize
+their parameters.
+
+## Alternatives considered
+
+**Imperative recipes that own their run loop** — rejected. Every recipe would re-implement (and could get wrong)
+idempotency, locking, lineage, and versioning — the exact cross-cutting concerns we want centralized. Declarative
+recipes + an engine-owned loop are the only shape where "adding a family must not edit the engine" is structurally
+enforced rather than hoped for. Override hooks recover the needed flexibility without surrendering the loop.
+
+**Engine knows "slice = (collection, time)"** — rejected. Simpler for promotion and CDI, but it breaks on
+climatology's categorical dimensions (season, quantity, baseline) which don't fit `Item`'s key, and it leaks
+product semantics into the engine. An opaque unit + recipe-owned `outputs` mapping keeps the engine domain-blind.
+
+**Put derivation in the `analysis` app** — rejected. Analysis is read-side, request-scoped, and unpersisted.
+Derivation is write-side, scheduled, and persisted with lineage. Sharing the app would conflate two lifecycles;
+sharing the *compute* (via the `geoprocessing` library) gives the reuse without the conflation.
+
+**A first-class late/partial-input state machine in v1** (windows, deadlines, wait-then-proceed) — rejected as
+premature. Event re-evaluation + a periodic sweep covers the common case with machinery you already trust;
+deadline/quorum semantics go in an override hook for the recipes that actually need them.
+
+**Keep history (versioned items) instead of overwrite-in-place** — rejected. No v1 product reads an old version;
+retaining them multiplies storage and forces serving to choose a version. `DerivationLink` rows already preserve
+*what* changed over time.
+
+**Share the `georiva-ingestion` queue** — rejected. A heavy, long-running CMIP6 backfill on the ingestion queue
+would starve newly-fetched operational data. A dedicated queue isolates the two.
+
+**A DB `DerivationConfig` model in v1** — rejected for now. The config surface a recipe family needs is unknown
+until families exist; modeling it prematurely would churn. Code registration is enough to ship the first families.
+
+## Consequences
+
+- New `processing` app: the engine (`run`, resolve/readiness/compute/register/link), the `Recipe` contract +
+  registry, and the `DerivationRun` model.
+- New `geoprocessing` package extracted incrementally from `analysis`; read-side analysis rewired to call it.
+- New `georiva-processing` Celery queue and worker; a periodic backfill sweep task.
+- Depends on ADR-0004: `DerivationLink`, the `source` asset role, and `Collection.visibility`.
+- STAC has no recipe/derivation concept — the engine is entirely ours; `DerivationLink` is descriptive provenance,
+  not an execution plan.
+- The Phase-0 metadata contract (crs, resolution, bounds, exact time + calendar, nodata, **populated
+  `Asset.checksum` on staging assets**) is a prerequisite: alignment and versioning both depend on it.
+- Ensemble-dependent products (GWL composites, model-agreement hatching, 1-in-20-yr extremes) remain out of scope
+  until CMIP6 post-processing stops collapsing to the ensemble mean; the design incurs no debt by deferring them.


### PR DESCRIPTION
## Summary

Records the design decisions from the staging/derivation grilling session as ADRs and glossary terms. Docs only — no code or schema changes.

- **ADR-0004** — two STAC tiers (Staging vs Published) via abstract base models; `DerivationLink` two-FK lineage in the `staging` app; `Collection.visibility` for intermediate products. Captures rejected alternatives (single-flag, MTI, proxies, "Raw" naming, GFK, intermediates-as-staging).
- **ADR-0005** — generic derivation engine: declarative `Recipe` + opaque `ProductionUnit` + engine-owned loop in a new `processing` app; readiness/join without a state machine; engine-ignorant alignment with eager harmonization; overwrite-in-place versioning; `DerivationRun` as lock/state/monitoring; `run(recipe, selector)` + dedicated `georiva-processing` queue; shared non-Django `geoprocessing` library.
- **CONTEXT.md** — adds tier and derivation vocabulary: Staging, Published, Intermediate product, Derivation, DerivationLink, Derivation Engine, Recipe, Production Unit, Promotion, DerivationRun.

## Context

These ADRs back the PRD in #119 and its implementation slices #120–#125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)