### PR TITLE
feat(geoprocessing): shared compute library extracted from analysis (#121)

### DIFF
--- a/georiva/src/georiva/analysis/zonal_stats/service.py
+++ b/georiva/src/georiva/analysis/zonal_stats/service.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import rasterio
-import rasterio.mask
-from rasterio.crs import CRS as RasterioCRS
-from rasterio.io import MemoryFile
+
+from georiva.geoprocessing.zonal import zonal_stats_from_array
 
 if TYPE_CHECKING:
     from adminboundarymanager.models import AdminBoundary
@@ -17,38 +16,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_BOUNDARY_CRS = RasterioCRS.from_epsg(4326)
-_EMPTY_STATS = {
-    "mean": None, "min": None, "max": None,
-    "sum": None, "std": None, "count": None,
-}
-
 
 # ---------------------------------------------------------------------------
-# Geometry helper
-# ---------------------------------------------------------------------------
-
-def _geom_to_dict(boundary: "AdminBoundary", raster_crs: RasterioCRS) -> dict:
-    """
-    Convert a Django GEOSGeometry to a GeoJSON dict in the raster's CRS.
-
-    boundary.geom.geojson returns a JSON string — parse it to dict.
-    Reproject only if the raster CRS differs from EPSG:4326 (rare for COGs).
-    """
-    geom = json.loads(boundary.geom.geojson)
-    
-    if raster_crs != _BOUNDARY_CRS:
-        from rasterio.warp import transform_geom
-        geom = transform_geom(_BOUNDARY_CRS, raster_crs, geom)
-        # transform_geom may return a string in older rasterio versions
-        if isinstance(geom, str):
-            geom = json.loads(geom)
-    
-    return geom
-
-
-# ---------------------------------------------------------------------------
-# Core computation
+# Core computation — Django adapter over geoprocessing.zonal
 # ---------------------------------------------------------------------------
 
 def compute_stats_from_array(
@@ -60,73 +30,31 @@ def compute_stats_from_array(
     """
     Compute zonal statistics for all boundaries against one 2-D numpy array.
 
-    Opens a single in-memory rasterio dataset from the array, then masks
-    each boundary against that same open dataset.  This avoids the cost of
-    creating and destroying a MemoryFile per boundary (previously ~4s/COG
-    for 105 boundaries, now ~0.5s/COG).
+    Thin Django adapter: turns each AdminBoundary into a GeoJSON geometry
+    (EPSG:4326) and delegates the actual masking/aggregation to the shared
+    ``geoprocessing.zonal`` library. Reprojection to the raster CRS happens
+    inside the library.
 
-    Parameters
-    ----------
-    data : np.ndarray
-        2-D float32 array with NaN for nodata pixels.
-    transform : affine.Affine
-        Affine geotransform (pixel → geographic coordinates).
-    crs : str
-        Raster CRS as WKT or EPSG string.
-    boundaries : list[AdminBoundary]
-        Boundaries to compute stats for.
-
-    Returns
-    -------
-    list[dict]
-        One dict per boundary: boundary_id + six stat keys.
-        Boundaries with no pixel intersection return all-None stats.
+    Returns one dict per boundary: ``boundary_id`` + six stat keys.
+    Boundaries with no pixel intersection return all-None stats.
     """
     if not boundaries:
         return []
-    
-    height, width = data.shape
-    raster_crs = RasterioCRS.from_user_input(crs)
-    
-    # Pre-parse all boundary geometries before opening the MemoryFile
-    # so any geometry error is caught early without holding the file open.
-    geoms = {}
+
+    geometries = []
     for boundary in boundaries:
         try:
-            geoms[boundary.pk] = _geom_to_dict(boundary, raster_crs)
+            geometries.append((boundary.pk, json.loads(boundary.geom.geojson)))
         except Exception as exc:
             logger.warning(
-                "Failed to parse geometry for boundary %s: %s",
-                boundary.pk, exc,
+                "Failed to parse geometry for boundary %s: %s", boundary.pk, exc,
             )
-            geoms[boundary.pk] = None
-    
-    results = []
-    
-    # Build one MemoryFile for the full COG array, open it once,
-    # and run rasterio.mask for every boundary inside the same context.
-    with MemoryFile() as memfile:
-        with memfile.open(
-                driver="GTiff",
-                height=height,
-                width=width,
-                count=1,
-                dtype=np.float32,
-                crs=raster_crs,
-                transform=transform,
-                nodata=np.nan,
-        ) as dst:
-            dst.write(data, 1)
-        
-        # Re-open read-only for masking — keeps the buffer alive
-        with memfile.open() as dataset:
-            for boundary in boundaries:
-                geom = geoms.get(boundary.pk)
-                stats = _mask_and_aggregate(dataset, geom, boundary.pk)
-                stats["boundary_id"] = boundary.pk
-                results.append(stats)
-    
-    return results
+            geometries.append((boundary.pk, None))
+
+    rows = zonal_stats_from_array(data, transform, crs, geometries)
+    for row in rows:
+        row["boundary_id"] = row.pop("key")
+    return rows
 
 
 def compute_stats_from_cog_bytes(
@@ -143,60 +71,13 @@ def compute_stats_from_cog_bytes(
         data = src.read(1).astype(np.float32)
         transform = src.transform
         crs = src.crs.to_wkt() if src.crs else "EPSG:4326"
-        
+
         if src.nodata is not None:
             data[data == src.nodata] = np.nan
-    
+
     data[~np.isfinite(data)] = np.nan
-    
+
     return compute_stats_from_array(data, transform, crs, boundaries)
-
-
-# ---------------------------------------------------------------------------
-# Masking + aggregation
-# ---------------------------------------------------------------------------
-
-def _mask_and_aggregate(dataset, geom: dict | None, boundary_pk) -> dict:
-    """
-    Apply a GeoJSON geometry mask to an open rasterio dataset and aggregate.
-
-    Returns all-None stats if the geometry is None, empty, or does not
-    intersect the raster extent.
-    """
-    if geom is None:
-        return dict(_EMPTY_STATS)
-    
-    try:
-        masked, _ = rasterio.mask.mask(
-            dataset,
-            [geom],
-            crop=False,
-            nodata=np.nan,
-            all_touched=False,
-        )
-        arr = masked[0].astype(np.float32)
-        arr[~np.isfinite(arr)] = np.nan
-        
-        valid = arr[~np.isnan(arr)]
-        
-        if len(valid) == 0:
-            return dict(_EMPTY_STATS)
-        
-        return {
-            "mean": float(np.mean(valid)),
-            "min": float(np.min(valid)),
-            "max": float(np.max(valid)),
-            "sum": float(np.sum(valid)),
-            "std": float(np.std(valid)),
-            "count": int(len(valid)),
-        }
-    
-    except Exception as exc:
-        logger.warning(
-            "Zonal stats mask failed for boundary %s: %s",
-            boundary_pk, exc,
-        )
-        return dict(_EMPTY_STATS)
 
 
 # ---------------------------------------------------------------------------

--- a/georiva/src/georiva/geoprocessing/__init__.py
+++ b/georiva/src/georiva/geoprocessing/__init__.py
@@ -1,0 +1,35 @@
+"""
+GeoRiva shared geoprocessing operations.
+
+A pure, **non-Django** compute library used by both write-side processing
+(compute-on-write) and read-side analysis (compute-on-read). Functions take
+in-memory raster objects (numpy arrays with an affine transform + CRS, or
+xarray DataArrays/Datasets) plus parameters, and return rasters or scalars.
+
+No Django, no storage, no request layer — callers own their own I/O. This
+keeps every operation unit-testable without a database and reusable on both
+sides. See docs/adr/0005-generic-derivation-engine.md.
+
+Implemented on the stack already present in the image (numpy, rasterio,
+xarray, cftime). Regridding uses ``rasterio.warp.reproject`` and calendar
+conversion uses xarray + cftime, so the library adds no new dependencies.
+"""
+
+from .algebra import EMPTY_STATS, raster_combine, safe_divide
+from .calendar import convert_calendar
+from .regrid import regrid_array
+from .temporal import anomaly, temporal_aggregate
+from .zonal import mask_and_aggregate, reproject_geometry, zonal_stats_from_array
+
+__all__ = [
+    "EMPTY_STATS",
+    "raster_combine",
+    "safe_divide",
+    "convert_calendar",
+    "regrid_array",
+    "anomaly",
+    "temporal_aggregate",
+    "mask_and_aggregate",
+    "reproject_geometry",
+    "zonal_stats_from_array",
+]

--- a/georiva/src/georiva/geoprocessing/algebra.py
+++ b/georiva/src/georiva/geoprocessing/algebra.py
@@ -1,0 +1,74 @@
+"""
+Raster algebra — element-wise combination of aligned rasters.
+
+Operates on numpy arrays or xarray DataArrays. Inputs are assumed to be
+already aligned (same grid); alignment is the caller's job (see ``regrid``).
+NaN is the nodata sentinel and propagates through operations.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# Re-exported for callers that want the zonal empty-stats sentinel from one place.
+from .zonal import EMPTY_STATS  # noqa: F401
+
+
+def safe_divide(numerator, denominator):
+    """
+    Element-wise division with divide-by-zero → NaN (not inf).
+
+    Works for numpy arrays and xarray DataArrays.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = numerator / denominator
+    # Replace inf/-inf produced by zero denominators with NaN.
+    try:
+        return result.where(np.isfinite(result))  # xarray
+    except AttributeError:
+        result = np.asarray(result, dtype="float64")
+        result[~np.isfinite(result)] = np.nan
+        return result
+
+
+def raster_combine(*arrays, op="sum", weights=None):
+    """
+    Combine aligned rasters element-wise.
+
+    Parameters
+    ----------
+    *arrays
+        Two or more aligned numpy arrays / xarray DataArrays.
+    op : {"sum", "mean", "min", "max", "product"}
+        Reduction applied across the stacked inputs.
+    weights : sequence of float, optional
+        Per-array weights, only used for ``op="mean"`` (weighted mean).
+
+    Returns the combined raster, with NaN where inputs were NaN per numpy's
+    nan-aware reductions (a cell is NaN only if all inputs are NaN).
+    """
+    if len(arrays) < 2:
+        raise ValueError("raster_combine needs at least two arrays")
+
+    stack = np.stack([np.asarray(a, dtype="float64") for a in arrays], axis=0)
+
+    if op == "sum":
+        return np.nansum(stack, axis=0)
+    if op == "product":
+        return np.nanprod(stack, axis=0)
+    if op == "min":
+        return np.nanmin(stack, axis=0)
+    if op == "max":
+        return np.nanmax(stack, axis=0)
+    if op == "mean":
+        if weights is not None:
+            w = np.asarray(weights, dtype="float64")
+            if len(w) != len(arrays):
+                raise ValueError("weights must match number of arrays")
+            mask = ~np.isnan(stack)
+            wstack = w[:, None, None] * mask
+            num = np.nansum(stack * w[:, None, None], axis=0)
+            den = np.nansum(wstack, axis=0)
+            return safe_divide(num, den)
+        return np.nanmean(stack, axis=0)
+
+    raise ValueError(f"unknown op: {op!r}")

--- a/georiva/src/georiva/geoprocessing/calendar.py
+++ b/georiva/src/georiva/geoprocessing/calendar.py
@@ -1,0 +1,30 @@
+"""
+Calendar conversion for climate time axes.
+
+CMIP6 models use non-Gregorian calendars (360-day, noleap). To align them to a
+standard output cadence the time axis must be converted. Uses xarray's native
+``convert_calendar`` (backed by cftime, already in the image) so no xclim
+dependency is required for this operation.
+"""
+from __future__ import annotations
+
+
+def convert_calendar(obj, calendar: str = "standard", *, align_on: str = "date", missing=None):
+    """
+    Convert the calendar of an xarray DataArray/Dataset.
+
+    Parameters
+    ----------
+    obj : xarray.DataArray or xarray.Dataset
+        Object with a ``time`` coordinate on some calendar.
+    calendar : str
+        Target calendar, e.g. ``"standard"`` / ``"proleptic_gregorian"``,
+        ``"noleap"``, ``"360_day"``.
+    align_on : {"date", "year", None}
+        How to map dates when converting to/from 360-day calendars.
+    missing
+        Fill value inserted for dates that don't exist in the source calendar
+        (e.g. Feb 29 when converting from noleap). If None, such dates are
+        dropped.
+    """
+    return obj.convert_calendar(calendar, align_on=align_on, missing=missing)

--- a/georiva/src/georiva/geoprocessing/regrid.py
+++ b/georiva/src/georiva/geoprocessing/regrid.py
@@ -1,0 +1,69 @@
+"""
+Regridding — resample a raster from a source grid onto a target grid.
+
+Uses ``rasterio.warp.reproject`` (already in the image) so the library needs
+no rioxarray/scipy. Operates on numpy arrays with affine transforms + CRS; the
+caller decides the target grid (the recipe's "target grid of production").
+"""
+from __future__ import annotations
+
+import numpy as np
+from rasterio.crs import CRS as RasterioCRS
+from rasterio.enums import Resampling
+from rasterio.warp import reproject
+
+_RESAMPLING = {
+    "nearest": Resampling.nearest,
+    "bilinear": Resampling.bilinear,
+    "cubic": Resampling.cubic,
+    "average": Resampling.average,
+}
+
+
+def regrid_array(
+        data,
+        src_transform,
+        src_crs,
+        dst_transform,
+        dst_crs,
+        dst_shape,
+        resampling: str = "bilinear",
+):
+    """
+    Reproject/resample a 2-D array onto a target grid.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        2-D source array (NaN = nodata).
+    src_transform, dst_transform : affine.Affine
+        Source and target affine transforms.
+    src_crs, dst_crs : str or CRS
+        Source and target CRS.
+    dst_shape : tuple[int, int]
+        Target (height, width).
+    resampling : {"nearest", "bilinear", "cubic", "average"}
+
+    Returns
+    -------
+    np.ndarray
+        2-D array on the target grid, NaN where unmapped.
+    """
+    if resampling not in _RESAMPLING:
+        raise ValueError(f"unknown resampling: {resampling!r}")
+
+    dst_height, dst_width = dst_shape
+    destination = np.full((dst_height, dst_width), np.nan, dtype="float32")
+
+    reproject(
+        source=np.asarray(data, dtype="float32"),
+        destination=destination,
+        src_transform=src_transform,
+        src_crs=RasterioCRS.from_user_input(src_crs),
+        dst_transform=dst_transform,
+        dst_crs=RasterioCRS.from_user_input(dst_crs),
+        src_nodata=np.nan,
+        dst_nodata=np.nan,
+        resampling=_RESAMPLING[resampling],
+    )
+    return destination

--- a/georiva/src/georiva/geoprocessing/temporal.py
+++ b/georiva/src/georiva/geoprocessing/temporal.py
@@ -1,0 +1,60 @@
+"""
+Temporal aggregation and anomalies over an xarray time series.
+
+These operate on xarray DataArrays with a ``time`` dimension. Cadence mismatch
+(e.g. dekadal inputs → monthly output) is handled here, not in the engine:
+the caller pulls all timesteps in a window and aggregates to the output cadence.
+"""
+from __future__ import annotations
+
+_HOW = {
+    "mean": lambda g: g.mean(),
+    "sum": lambda g: g.sum(),
+    "min": lambda g: g.min(),
+    "max": lambda g: g.max(),
+}
+
+
+def temporal_aggregate(da, freq: str | None = None, how: str = "mean", time_dim: str = "time"):
+    """
+    Aggregate a time series along ``time_dim``.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        Series with a time dimension.
+    freq : str, optional
+        A pandas/xarray resample frequency (e.g. ``"MS"``, ``"YS"``). If None,
+        collapses the whole series to a single value.
+    how : {"mean", "sum", "min", "max"}
+        Reduction.
+    """
+    if how not in _HOW:
+        raise ValueError(f"unknown how: {how!r}")
+
+    if freq is None:
+        reducer = getattr(da, how)
+        return reducer(dim=time_dim)
+
+    grouped = da.resample({time_dim: freq})
+    return _HOW[how](grouped)
+
+
+def anomaly(da, baseline, relative: bool = False, how: str = "mean", time_dim: str = "time"):
+    """
+    Anomaly of a series (or value) against a baseline period.
+
+    ``baseline`` may be a DataArray series (reduced to its climatological mean
+    via ``how``) or an already-reduced DataArray / scalar. With
+    ``relative=True`` returns ``(value - baseline) / baseline`` (relative
+    anomaly); otherwise ``value - baseline``.
+    """
+    base = baseline
+    if hasattr(baseline, "dims") and time_dim in getattr(baseline, "dims", ()):
+        base = temporal_aggregate(baseline, freq=None, how=how, time_dim=time_dim)
+
+    diff = da - base
+    if relative:
+        from .algebra import safe_divide
+        return safe_divide(diff, base)
+    return diff

--- a/georiva/src/georiva/geoprocessing/tests/test_algebra.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_algebra.py
@@ -1,0 +1,62 @@
+import unittest
+
+import numpy as np
+
+from georiva.geoprocessing.algebra import raster_combine, safe_divide
+
+
+class RasterCombineTests(unittest.TestCase):
+    def setUp(self):
+        self.a = np.array([[1.0, 2.0], [3.0, 4.0]])
+        self.b = np.array([[5.0, 6.0], [7.0, 8.0]])
+
+    def test_sum(self):
+        np.testing.assert_array_equal(
+            raster_combine(self.a, self.b, op="sum"),
+            np.array([[6.0, 8.0], [10.0, 12.0]]),
+        )
+
+    def test_mean(self):
+        np.testing.assert_array_equal(
+            raster_combine(self.a, self.b, op="mean"),
+            np.array([[3.0, 4.0], [5.0, 6.0]]),
+        )
+
+    def test_weighted_mean(self):
+        out = raster_combine(self.a, self.b, op="mean", weights=[3.0, 1.0])
+        # (3*1 + 1*5)/4 = 2.0 ; (3*2 + 1*6)/4 = 3.0
+        np.testing.assert_array_almost_equal(out, np.array([[2.0, 3.0], [4.0, 5.0]]))
+
+    def test_min_max_product(self):
+        np.testing.assert_array_equal(raster_combine(self.a, self.b, op="min"), self.a)
+        np.testing.assert_array_equal(raster_combine(self.a, self.b, op="max"), self.b)
+        np.testing.assert_array_equal(
+            raster_combine(self.a, self.b, op="product"),
+            np.array([[5.0, 12.0], [21.0, 32.0]]),
+        )
+
+    def test_nan_is_skipped_when_other_present(self):
+        a = np.array([[np.nan, 2.0]])
+        b = np.array([[5.0, 6.0]])
+        np.testing.assert_array_equal(
+            raster_combine(a, b, op="sum"), np.array([[5.0, 8.0]])
+        )
+
+    def test_requires_two_arrays(self):
+        with self.assertRaises(ValueError):
+            raster_combine(self.a, op="sum")
+
+    def test_unknown_op_raises(self):
+        with self.assertRaises(ValueError):
+            raster_combine(self.a, self.b, op="bogus")
+
+
+class SafeDivideTests(unittest.TestCase):
+    def test_divide_by_zero_is_nan_not_inf(self):
+        out = safe_divide(np.array([1.0, 2.0]), np.array([0.0, 2.0]))
+        self.assertTrue(np.isnan(out[0]))
+        self.assertAlmostEqual(out[1], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/tests/test_calendar.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_calendar.py
@@ -1,0 +1,30 @@
+import unittest
+
+import numpy as np
+import xarray as xr
+
+from georiva.geoprocessing.calendar import convert_calendar
+
+
+class ConvertCalendarTests(unittest.TestCase):
+    def test_noleap_to_standard_drops_unmapped(self):
+        # A noleap series across a leap-year Feb has no Feb 29.
+        time = xr.date_range("2020-02-26", periods=5, freq="D", calendar="noleap", use_cftime=True)
+        da = xr.DataArray(np.arange(5.0), coords={"time": time}, dims=["time"])
+
+        converted = convert_calendar(da, "standard")
+        # Standard calendar — index is real datetimes now.
+        self.assertEqual(converted["time"].dt.calendar, "proleptic_gregorian") \
+            if hasattr(converted["time"].dt, "calendar") else None
+        # No Feb 29 was invented (missing=None drops unmapped dates).
+        self.assertLessEqual(converted.sizes["time"], da.sizes["time"])
+
+    def test_360_day_to_standard_runs(self):
+        time = xr.date_range("2020-01-01", periods=12, freq="D", calendar="360_day", use_cftime=True)
+        da = xr.DataArray(np.arange(12.0), coords={"time": time}, dims=["time"])
+        converted = convert_calendar(da, "standard", align_on="date")
+        self.assertGreater(converted.sizes["time"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/tests/test_no_django.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_no_django.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+# .../georiva/src  (so the subprocess can import the georiva namespace)
+_SRC = Path(__file__).resolve().parents[3]
+_GP = Path(__file__).resolve().parents[1]
+
+
+class NoDjangoDependencyTests(unittest.TestCase):
+    def test_imports_without_configured_settings(self):
+        code = (
+            "import os; os.environ.pop('DJANGO_SETTINGS_MODULE', None)\n"
+            "import georiva.geoprocessing as g\n"
+            "for n in ['zonal_stats_from_array','regrid_array','temporal_aggregate',"
+            "'convert_calendar','raster_combine']:\n"
+            "    assert hasattr(g, n), n\n"
+            "from django.conf import settings\n"
+            "assert not settings.configured, 'geoprocessing must not require configured settings'\n"
+            "print('OK')\n"
+        )
+        env = dict(os.environ)
+        env.pop("DJANGO_SETTINGS_MODULE", None)
+        env["PYTHONPATH"] = str(_SRC)
+        r = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, env=env
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("OK", r.stdout)
+
+    def test_modules_do_not_import_django(self):
+        for f in _GP.glob("*.py"):
+            src = f.read_text()
+            self.assertNotIn("import django", src, f"{f.name} imports django")
+            self.assertNotIn("from django", src, f"{f.name} imports from django")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/tests/test_regrid.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_regrid.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+from rasterio.transform import from_bounds
+
+from georiva.geoprocessing.regrid import regrid_array
+
+
+class RegridArrayTests(unittest.TestCase):
+    def test_upsample_doubles_shape_and_preserves_range(self):
+        data = np.array([[0.0, 10.0], [20.0, 30.0]], dtype="float32")
+        src_t = from_bounds(0, 0, 2, 2, 2, 2)
+        dst_t = from_bounds(0, 0, 2, 2, 4, 4)
+
+        out = regrid_array(
+            data, src_t, "EPSG:4326", dst_t, "EPSG:4326", (4, 4),
+            resampling="nearest",
+        )
+        self.assertEqual(out.shape, (4, 4))
+        self.assertAlmostEqual(float(np.nanmin(out)), 0.0)
+        self.assertAlmostEqual(float(np.nanmax(out)), 30.0)
+
+    def test_identity_grid_returns_same_values(self):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+        t = from_bounds(0, 0, 2, 2, 2, 2)
+        out = regrid_array(data, t, "EPSG:4326", t, "EPSG:4326", (2, 2),
+                           resampling="nearest")
+        np.testing.assert_array_almost_equal(out, data)
+
+    def test_unknown_resampling_raises(self):
+        data = np.zeros((2, 2), dtype="float32")
+        t = from_bounds(0, 0, 2, 2, 2, 2)
+        with self.assertRaises(ValueError):
+            regrid_array(data, t, "EPSG:4326", t, "EPSG:4326", (2, 2),
+                         resampling="bogus")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/tests/test_temporal.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_temporal.py
@@ -1,0 +1,52 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from georiva.geoprocessing.temporal import anomaly, temporal_aggregate
+
+
+def _series(values, start="2020-01-01", freq="MS"):
+    time = pd.date_range(start, periods=len(values), freq=freq)
+    return xr.DataArray(values, coords={"time": time}, dims=["time"])
+
+
+class TemporalAggregateTests(unittest.TestCase):
+    def test_collapse_whole_series_mean(self):
+        da = _series([1.0, 2.0, 3.0, 4.0])
+        self.assertAlmostEqual(float(temporal_aggregate(da, how="mean")), 2.5)
+
+    def test_collapse_whole_series_sum(self):
+        da = _series([1.0, 2.0, 3.0, 4.0])
+        self.assertAlmostEqual(float(temporal_aggregate(da, how="sum")), 10.0)
+
+    def test_resample_monthly_to_yearly_mean(self):
+        da = _series([float(i) for i in range(24)])  # 24 months
+        yearly = temporal_aggregate(da, freq="YS", how="mean")
+        self.assertEqual(yearly.sizes["time"], 2)
+        self.assertAlmostEqual(float(yearly.isel(time=0)), 5.5)   # mean 0..11
+        self.assertAlmostEqual(float(yearly.isel(time=1)), 17.5)  # mean 12..23
+
+    def test_unknown_how_raises(self):
+        with self.assertRaises(ValueError):
+            temporal_aggregate(_series([1.0]), how="bogus")
+
+
+class AnomalyTests(unittest.TestCase):
+    def test_absolute_anomaly_against_baseline_series(self):
+        value = _series([10.0, 12.0])
+        baseline = _series([2.0, 4.0, 6.0])  # mean 4.0
+        out = anomaly(value, baseline)
+        np.testing.assert_array_almost_equal(out.values, np.array([6.0, 8.0]))
+
+    def test_relative_anomaly(self):
+        value = _series([6.0])
+        baseline = _series([4.0])  # mean 4.0
+        out = anomaly(value, baseline, relative=True)
+        # (6-4)/4 = 0.5
+        np.testing.assert_array_almost_equal(out.values, np.array([0.5]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/tests/test_zonal.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_zonal.py
@@ -1,0 +1,72 @@
+import unittest
+
+import numpy as np
+from rasterio.transform import from_bounds
+
+from georiva.geoprocessing.zonal import zonal_stats_from_array
+
+
+def _square(x0, y0, x1, y1):
+    return {
+        "type": "Polygon",
+        "coordinates": [[[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]]],
+    }
+
+
+class ZonalStatsFromArrayTests(unittest.TestCase):
+    def setUp(self):
+        # 4x4 grid over bbox (0,0,4,4), pixel size 1, values 0..15.
+        self.data = np.arange(16, dtype="float32").reshape(4, 4)
+        self.transform = from_bounds(0, 0, 4, 4, 4, 4)
+        self.crs = "EPSG:4326"
+
+    def test_full_extent_aggregates_all_pixels(self):
+        rows = zonal_stats_from_array(
+            self.data, self.transform, self.crs, [("all", _square(0, 0, 4, 4))]
+        )
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["key"], "all")
+        self.assertEqual(r["count"], 16)
+        self.assertAlmostEqual(r["min"], 0.0)
+        self.assertAlmostEqual(r["max"], 15.0)
+        self.assertAlmostEqual(r["sum"], 120.0)
+
+    def test_partial_geometry_counts_fewer_pixels(self):
+        # Bottom-left quadrant only.
+        rows = zonal_stats_from_array(
+            self.data, self.transform, self.crs, [("q", _square(0, 0, 2, 2))]
+        )
+        self.assertLess(rows[0]["count"], 16)
+        self.assertGreater(rows[0]["count"], 0)
+
+    def test_none_geometry_returns_empty_stats(self):
+        rows = zonal_stats_from_array(
+            self.data, self.transform, self.crs, [("none", None)]
+        )
+        self.assertIsNone(rows[0]["mean"])
+        self.assertIsNone(rows[0]["count"])
+        self.assertEqual(rows[0]["key"], "none")
+
+    def test_non_intersecting_geometry_returns_empty_stats(self):
+        rows = zonal_stats_from_array(
+            self.data, self.transform, self.crs, [("far", _square(100, 100, 101, 101))]
+        )
+        self.assertIsNone(rows[0]["mean"])
+
+    def test_empty_geometries_returns_empty_list(self):
+        self.assertEqual(
+            zonal_stats_from_array(self.data, self.transform, self.crs, []), []
+        )
+
+    def test_nan_pixels_excluded(self):
+        data = self.data.copy()
+        data[0, 0] = np.nan
+        rows = zonal_stats_from_array(
+            data, self.transform, self.crs, [("all", _square(0, 0, 4, 4))]
+        )
+        self.assertEqual(rows[0]["count"], 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/georiva/src/georiva/geoprocessing/zonal.py
+++ b/georiva/src/georiva/geoprocessing/zonal.py
@@ -1,0 +1,134 @@
+"""
+Zonal statistics over an in-memory raster array.
+
+Pure compute: takes a numpy array + affine transform + CRS and a set of
+geometries (GeoJSON, in EPSG:4326), and returns per-geometry stats. No Django
+models — callers build the geometries (e.g. from AdminBoundary) and own that
+adapter layer.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import numpy as np
+import rasterio.mask
+from rasterio.crs import CRS as RasterioCRS
+from rasterio.io import MemoryFile
+from rasterio.warp import transform_geom
+
+logger = logging.getLogger(__name__)
+
+_CRS_4326 = RasterioCRS.from_epsg(4326)
+
+EMPTY_STATS = {
+    "mean": None, "min": None, "max": None,
+    "sum": None, "std": None, "count": None,
+}
+
+
+def reproject_geometry(geom: dict, dst_crs, src_crs=_CRS_4326) -> dict:
+    """Reproject a GeoJSON geometry from ``src_crs`` (default EPSG:4326) to ``dst_crs``."""
+    dst = RasterioCRS.from_user_input(dst_crs)
+    if dst == src_crs:
+        return geom
+    out = transform_geom(src_crs, dst, geom)
+    if isinstance(out, str):  # older rasterio returns a JSON string
+        out = json.loads(out)
+    return out
+
+
+def mask_and_aggregate(dataset, geom: dict | None, *, label=None) -> dict:
+    """
+    Mask an open rasterio dataset by a GeoJSON geometry and aggregate to stats.
+
+    Returns all-None stats if the geometry is None/empty or does not intersect
+    the raster extent.
+    """
+    if geom is None:
+        return dict(EMPTY_STATS)
+
+    try:
+        masked, _ = rasterio.mask.mask(
+            dataset, [geom], crop=False, nodata=np.nan, all_touched=False,
+        )
+        arr = masked[0].astype(np.float32)
+        arr[~np.isfinite(arr)] = np.nan
+        valid = arr[~np.isnan(arr)]
+
+        if len(valid) == 0:
+            return dict(EMPTY_STATS)
+
+        return {
+            "mean": float(np.mean(valid)),
+            "min": float(np.min(valid)),
+            "max": float(np.max(valid)),
+            "sum": float(np.sum(valid)),
+            "std": float(np.std(valid)),
+            "count": int(len(valid)),
+        }
+    except Exception as exc:
+        logger.warning("Zonal mask failed for %s: %s", label, exc)
+        return dict(EMPTY_STATS)
+
+
+def zonal_stats_from_array(data, transform, crs, geometries) -> list[dict]:
+    """
+    Compute zonal statistics for many geometries against one 2-D array.
+
+    Opens a single in-memory rasterio dataset and masks every geometry against
+    it (one MemoryFile for all geometries, not one per geometry).
+
+    Parameters
+    ----------
+    data : np.ndarray
+        2-D float array with NaN for nodata.
+    transform : affine.Affine
+        Pixel → geographic transform.
+    crs : str
+        Raster CRS (WKT or EPSG string).
+    geometries : iterable of (key, geom)
+        ``key`` is any identifier echoed back on the result; ``geom`` is a
+        GeoJSON geometry dict in EPSG:4326 (or None).
+
+    Returns
+    -------
+    list[dict]
+        One dict per geometry: ``{"key": key, mean, min, max, sum, std, count}``.
+    """
+    geometries = list(geometries)
+    if not geometries:
+        return []
+
+    height, width = data.shape
+    raster_crs = RasterioCRS.from_user_input(crs)
+
+    # Pre-reproject all geometries before opening the MemoryFile so a bad
+    # geometry is caught early without holding the file open.
+    prepared = []
+    for key, geom in geometries:
+        if geom is None:
+            prepared.append((key, None))
+            continue
+        try:
+            prepared.append((key, reproject_geometry(geom, raster_crs)))
+        except Exception as exc:
+            logger.warning("Failed to reproject geometry %s: %s", key, exc)
+            prepared.append((key, None))
+
+    results = []
+    with MemoryFile() as memfile:
+        with memfile.open(
+                driver="GTiff", height=height, width=width, count=1,
+                dtype=np.float32, crs=raster_crs, transform=transform,
+                nodata=np.nan,
+        ) as dst:
+            dst.write(np.asarray(data, dtype=np.float32), 1)
+
+        with memfile.open() as dataset:
+            for key, geom in prepared:
+                stats = mask_and_aggregate(dataset, geom, label=key)
+                stats["key"] = key
+                results.append(stats)
+
+    return results


### PR DESCRIPTION
Implements #121.

## What this delivers

A pure, **non-Django** `geoprocessing` package so write-side processing and read-side analysis share one compute layer.

- **No Django, no storage, no request layer** — functions take in-memory raster objects (numpy + affine transform/CRS, or xarray DataArrays) and return rasters/scalars. Callers own their I/O.
- **Ops**: zonal stats (lifted from `analysis`), raster algebra (`raster_combine`, `safe_divide`), temporal aggregation + anomaly, regridding, calendar conversion.
- **No new dependencies**: built on the stack already in the image — regrid via `rasterio.warp.reproject`, calendar conversion via xarray + cftime. (`rioxarray`/`xclim` are intentionally avoided; `xclim` can be added when SPI/SPEI indices land in #123.)
- `analysis/zonal_stats` is **rewired** to call `geoprocessing.zonal`: the Django `AdminBoundary → geojson` adapter stays in `analysis`; masking/aggregation moves to the library. Backfill task + management command still import and work unchanged.

## Tests
- 24 library unit tests over in-memory arrays (zonal, algebra, temporal, regrid, calendar).
- A **purity test** that imports the package in a subprocess with no `DJANGO_SETTINGS_MODULE` and asserts settings are never configured, plus a static check that no module imports django.
- All green; `manage.py check` clean.

Refs #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)