### PR TITLE
feat(geoprocessing): season-aware climatology for Climatology & Indices recipe family

### DIFF
--- a/georiva/src/georiva/geoprocessing/__init__.py
+++ b/georiva/src/georiva/geoprocessing/__init__.py
@@ -18,7 +18,13 @@ conversion uses xarray + cftime, so the library adds no new dependencies.
 from .algebra import EMPTY_STATS, raster_combine, safe_divide
 from .calendar import convert_calendar
 from .regrid import regrid_array
-from .temporal import anomaly, temporal_aggregate
+from .temporal import (
+    SEASONS,
+    anomaly,
+    climatology,
+    select_season,
+    temporal_aggregate,
+)
 from .zonal import mask_and_aggregate, reproject_geometry, zonal_stats_from_array
 
 __all__ = [
@@ -27,7 +33,10 @@ __all__ = [
     "safe_divide",
     "convert_calendar",
     "regrid_array",
+    "SEASONS",
     "anomaly",
+    "climatology",
+    "select_season",
     "temporal_aggregate",
     "mask_and_aggregate",
     "reproject_geometry",

--- a/georiva/src/georiva/geoprocessing/temporal.py
+++ b/georiva/src/georiva/geoprocessing/temporal.py
@@ -1,9 +1,15 @@
 """
-Temporal aggregation and anomalies over an xarray time series.
+Temporal aggregation, seasonal climatologies, and anomalies over an xarray
+time series.
 
 These operate on xarray DataArrays with a ``time`` dimension. Cadence mismatch
 (e.g. dekadal inputs → monthly output) is handled here, not in the engine:
 the caller pulls all timesteps in a window and aggregates to the output cadence.
+
+Season selection reads the calendar month from the series' own time coordinate,
+so non-standard calendars (e.g. CMIP6 360-day) need no special-casing — the
+Climatology recipe family computes ``value``/``anomaly``/``relative anomaly``
+per season by composing :func:`climatology` and :func:`anomaly`.
 """
 from __future__ import annotations
 
@@ -13,6 +19,33 @@ _HOW = {
     "min": lambda g: g.min(),
     "max": lambda g: g.max(),
 }
+
+# Standard meteorological 3-month seasons, by calendar month number. ``annual``
+# (or None) selects every month. Months are read from the series' own time
+# coordinate, so this works on any calendar (Gregorian, 360-day, …).
+SEASONS = {
+    "DJF": (12, 1, 2),
+    "MAM": (3, 4, 5),
+    "JJA": (6, 7, 8),
+    "SON": (9, 10, 11),
+}
+
+
+def select_season(da, season, time_dim: str = "time"):
+    """
+    Filter a time series to the timesteps belonging to ``season``.
+
+    ``season`` is a key of :data:`SEASONS` (e.g. ``"DJF"``), or ``"annual"`` /
+    ``None`` to keep every timestep. Selection is by calendar month taken from
+    the series' time coordinate, so non-standard calendars (e.g. CMIP6 360-day)
+    are handled the same way.
+    """
+    if season is None or season == "annual":
+        return da
+    if season not in SEASONS:
+        raise ValueError(f"unknown season: {season!r}")
+    months = da[time_dim].dt.month
+    return da.sel({time_dim: months.isin(SEASONS[season])})
 
 
 def temporal_aggregate(da, freq: str | None = None, how: str = "mean", time_dim: str = "time"):
@@ -38,6 +71,19 @@ def temporal_aggregate(da, freq: str | None = None, how: str = "mean", time_dim:
 
     grouped = da.resample({time_dim: freq})
     return _HOW[how](grouped)
+
+
+def climatology(da, season=None, how: str = "mean", time_dim: str = "time"):
+    """
+    Climatological statistic of a series over a season.
+
+    Selects the timesteps in ``season`` (see :func:`select_season`) and collapses
+    the whole window to a single value with ``how``. This is the ``value``
+    quantity for the Climatology recipe family; ``anomaly`` is computed against a
+    second baseline-window climatology.
+    """
+    selected = select_season(da, season, time_dim=time_dim)
+    return temporal_aggregate(selected, freq=None, how=how, time_dim=time_dim)
 
 
 def anomaly(da, baseline, relative: bool = False, how: str = "mean", time_dim: str = "time"):

--- a/georiva/src/georiva/geoprocessing/tests/test_temporal.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_temporal.py
@@ -4,12 +4,28 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from georiva.geoprocessing.temporal import anomaly, temporal_aggregate
+from georiva.geoprocessing.temporal import (
+    anomaly,
+    climatology,
+    select_season,
+    temporal_aggregate,
+)
 
 
 def _series(values, start="2020-01-01", freq="MS"):
     time = pd.date_range(start, periods=len(values), freq=freq)
     return xr.DataArray(values, coords={"time": time}, dims=["time"])
+
+
+def _spatial_series(monthly_scalars, ny=2, nx=3, start="2020-01-01", freq="MS"):
+    """(time, y, x) cube; every pixel at time t equals monthly_scalars[t]."""
+    time = pd.date_range(start, periods=len(monthly_scalars), freq=freq)
+    data = np.broadcast_to(
+        np.asarray(monthly_scalars, dtype=float)[:, None, None], (len(time), ny, nx)
+    )
+    return xr.DataArray(
+        data, coords={"time": time}, dims=["time", "y", "x"]
+    )
 
 
 class TemporalAggregateTests(unittest.TestCase):
@@ -46,6 +62,67 @@ class AnomalyTests(unittest.TestCase):
         out = anomaly(value, baseline, relative=True)
         # (6-4)/4 = 0.5
         np.testing.assert_array_almost_equal(out.values, np.array([0.5]))
+
+    def test_seasonal_anomaly_against_baseline_window(self):
+        # JJA value period averages 13; JJA baseline period averages 10.
+        value_window = _spatial_series([13.0] * 12)              # one year
+        baseline_window = _spatial_series([10.0] * 24)           # two-year baseline
+        value = climatology(value_window, season="JJA")
+        baseline = climatology(baseline_window, season="JJA")
+
+        absolute = anomaly(value, baseline)
+        np.testing.assert_array_almost_equal(absolute.values, np.full((2, 3), 3.0))
+
+        relative = anomaly(value, baseline, relative=True)
+        np.testing.assert_array_almost_equal(relative.values, np.full((2, 3), 0.3))
+
+
+class SelectSeasonTests(unittest.TestCase):
+    def test_djf_keeps_only_dec_jan_feb(self):
+        # Two full years of monthly data starting Jan 2020.
+        da = _series([float(i) for i in range(24)], start="2020-01-01", freq="MS")
+        djf = select_season(da, "DJF")
+        months = sorted(set(int(m) for m in djf["time"].dt.month.values))
+        self.assertEqual(months, [1, 2, 12])
+        # 2 Januaries + 2 Februaries + 2 Decembers = 6 timesteps.
+        self.assertEqual(djf.sizes["time"], 6)
+
+    def test_annual_and_none_keep_all_timesteps(self):
+        da = _series([float(i) for i in range(12)])
+        self.assertEqual(select_season(da, "annual").sizes["time"], 12)
+        self.assertEqual(select_season(da, None).sizes["time"], 12)
+
+    def test_unknown_season_raises(self):
+        with self.assertRaises(ValueError):
+            select_season(_series([1.0, 2.0, 3.0]), "WET")
+
+    def test_selects_by_month_on_360_day_calendar(self):
+        # CMIP6-style 360-day calendar: months come from the file's time axis,
+        # not a Gregorian assumption.
+        time = xr.date_range(
+            "2020-01-01", periods=24, freq="MS", calendar="360_day", use_cftime=True
+        )
+        da = xr.DataArray(
+            np.arange(24, dtype=float), coords={"time": time}, dims=["time"]
+        )
+        djf = select_season(da, "DJF")
+        months = sorted(set(int(m) for m in djf["time"].dt.month.values))
+        self.assertEqual(months, [1, 2, 12])
+        self.assertEqual(djf.sizes["time"], 6)
+
+
+class ClimatologyTests(unittest.TestCase):
+    def test_seasonal_mean_reduces_time_to_a_raster(self):
+        # value at month m == m, for one year.
+        cube = _spatial_series([float(m) for m in range(1, 13)])
+        clim = climatology(cube, season="JJA")  # months 6,7,8 -> mean 7.0
+        self.assertEqual(set(clim.dims), {"y", "x"})
+        self.assertNotIn("time", clim.dims)
+        np.testing.assert_array_almost_equal(clim.values, np.full((2, 3), 7.0))
+
+    def test_no_season_collapses_whole_series_like_aggregate(self):
+        da = _series([1.0, 2.0, 3.0, 4.0])
+        self.assertAlmostEqual(float(climatology(da)), 2.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the calculation foundation for the **Climatology & Indices** recipe family (#123), scoped to the `value`, `anomaly`, and `relative anomaly` quantities. Pure `geoprocessing` library work — no Django, no engine wiring yet.

The one real gap was **season awareness**: `value` is a seasonal climatology, and `anomaly`/`relative anomaly` (which already existed in `temporal.anomaly`) need season-filtered inputs to be meaningful.

## What's new

In `geoprocessing/temporal.py` (exported from the package):

- **`SEASONS`** — the four standard meteorological 3-month seasons by month.
- **`select_season(da, season, time_dim="time")`** — filters a series to a season (`DJF`/`MAM`/`JJA`/`SON`); `"annual"`/`None` keeps all; unknown season raises `ValueError`.
- **`climatology(da, season=None, how="mean", time_dim="time")`** — the `value` quantity: select season → collapse time to a raster/scalar.

`anomaly` (absolute + relative) is unchanged and **composes** with `climatology` — the recipe computes `anomaly(climatology(value_window, s), climatology(baseline_window, s))`.

Season selection reads the calendar month from the series' **own time axis**, so CMIP6 360-day calendars need no special-casing — addressing the issue's calendar criterion (time from file content, not index bounds).

## Tests (TDD, red→green vertical slices)

Covered over in-memory xarray arrays — no DB, no storage:

- `select_season` keeps only DJF months; `"annual"`/`None` keep all; unknown season raises
- `climatology(season="JJA")` reduces **only** time, leaving a `(y,x)` raster; no-season matches `temporal_aggregate`
- composition: seasonal value vs seasonal baseline → correct absolute + relative anomaly
- season selection correct on a CMIP6 360-day cftime calendar

34/34 geoprocessing tests green, including the no-Django import guard.

## Scope / follow-ups (deferred)

- `trend` quantity (numpy/xarray, no new deps)
- SPI/SPEI indices — needs adding `xclim` to `requirements.txt`
- `ClimatologyRecipe` itself + engine `run()` integration

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)