### PR TITLE
feat(geoprocessing): trend quantity for Climatology & Indices recipe family

### DIFF
--- a/georiva/src/georiva/geoprocessing/__init__.py
+++ b/georiva/src/georiva/geoprocessing/__init__.py
@@ -24,6 +24,7 @@ from .temporal import (
     climatology,
     select_season,
     temporal_aggregate,
+    trend,
 )
 from .zonal import mask_and_aggregate, reproject_geometry, zonal_stats_from_array
 
@@ -38,6 +39,7 @@ __all__ = [
     "climatology",
     "select_season",
     "temporal_aggregate",
+    "trend",
     "mask_and_aggregate",
     "reproject_geometry",
     "zonal_stats_from_array",

--- a/georiva/src/georiva/geoprocessing/temporal.py
+++ b/georiva/src/georiva/geoprocessing/temporal.py
@@ -1,6 +1,6 @@
 """
-Temporal aggregation, seasonal climatologies, and anomalies over an xarray
-time series.
+Temporal aggregation, seasonal climatologies, anomalies, and trends over an
+xarray time series.
 
 These operate on xarray DataArrays with a ``time`` dimension. Cadence mismatch
 (e.g. dekadal inputs → monthly output) is handled here, not in the engine:
@@ -9,7 +9,8 @@ the caller pulls all timesteps in a window and aggregates to the output cadence.
 Season selection reads the calendar month from the series' own time coordinate,
 so non-standard calendars (e.g. CMIP6 360-day) need no special-casing — the
 Climatology recipe family computes ``value``/``anomaly``/``relative anomaly``
-per season by composing :func:`climatology` and :func:`anomaly`.
+per season by composing :func:`climatology` and :func:`anomaly`, and the
+``trend`` quantity via :func:`trend`.
 """
 from __future__ import annotations
 
@@ -84,6 +85,23 @@ def climatology(da, season=None, how: str = "mean", time_dim: str = "time"):
     """
     selected = select_season(da, season, time_dim=time_dim)
     return temporal_aggregate(selected, freq=None, how=how, time_dim=time_dim)
+
+
+def trend(da, season=None, how: str = "mean", time_dim: str = "time"):
+    """
+    Inter-annual linear trend (slope **per year**) of a seasonal series.
+
+    Selects the timesteps in ``season`` (see :func:`select_season`), reduces each
+    calendar year to a single value with ``how``, then fits a degree-1 polynomial
+    of value vs. year. The slope is returned in per-year units (the year is taken
+    from the time coordinate, so any calendar works).
+    """
+    if how not in _HOW:
+        raise ValueError(f"unknown how: {how!r}")
+    selected = select_season(da, season, time_dim=time_dim)
+    yearly = _HOW[how](selected.groupby(selected[time_dim].dt.year))
+    fit = yearly.polyfit(dim="year", deg=1)
+    return fit.polyfit_coefficients.sel(degree=1, drop=True)
 
 
 def anomaly(da, baseline, relative: bool = False, how: str = "mean", time_dim: str = "time"):

--- a/georiva/src/georiva/geoprocessing/tests/test_temporal.py
+++ b/georiva/src/georiva/geoprocessing/tests/test_temporal.py
@@ -9,6 +9,7 @@ from georiva.geoprocessing.temporal import (
     climatology,
     select_season,
     temporal_aggregate,
+    trend,
 )
 
 
@@ -123,6 +124,57 @@ class ClimatologyTests(unittest.TestCase):
     def test_no_season_collapses_whole_series_like_aggregate(self):
         da = _series([1.0, 2.0, 3.0, 4.0])
         self.assertAlmostEqual(float(climatology(da)), 2.5)
+
+
+class TrendTests(unittest.TestCase):
+    def test_linear_increase_gives_slope_per_year(self):
+        # One value per year, rising 2.0/year over 2000..2003.
+        time = pd.date_range("2000-01-01", periods=4, freq="YS")
+        da = xr.DataArray(
+            [0.0, 2.0, 4.0, 6.0], coords={"time": time}, dims=["time"]
+        )
+        self.assertAlmostEqual(float(trend(da)), 2.0)
+
+    def test_flat_series_has_zero_slope(self):
+        time = pd.date_range("2000-01-01", periods=5, freq="YS")
+        da = xr.DataArray([7.0] * 5, coords={"time": time}, dims=["time"])
+        self.assertAlmostEqual(float(trend(da)), 0.0)
+
+    def test_season_aware_ignores_other_months(self):
+        # 3 years monthly. JJA rises 10->12->14 (slope 2/yr); other months are
+        # junk that would wreck the fit if season filtering didn't apply.
+        values = []
+        for t in range(36):
+            year_idx, month = t // 12, t % 12 + 1
+            values.append(10.0 + 2 * year_idx if month in (6, 7, 8) else 99999.0)
+        time = pd.date_range("2000-01-01", periods=36, freq="MS")
+        da = xr.DataArray(values, coords={"time": time}, dims=["time"])
+        self.assertAlmostEqual(float(trend(da, season="JJA")), 2.0)
+
+    def test_spatial_returns_slope_raster(self):
+        cube = _spatial_series([0.0, 2.0, 4.0, 6.0], freq="YS")
+        slope = trend(cube)
+        self.assertEqual(set(slope.dims), {"y", "x"})
+        self.assertNotIn("time", slope.dims)
+        np.testing.assert_array_almost_equal(slope.values, np.full((2, 3), 2.0))
+
+    def test_trend_on_360_day_calendar(self):
+        # JJA rises 10->12->14 over 3 years on a CMIP6 360-day calendar.
+        values = []
+        for t in range(36):
+            year_idx, month = t // 12, t % 12 + 1
+            values.append(10.0 + 2 * year_idx if month in (6, 7, 8) else 99999.0)
+        time = xr.date_range(
+            "2000-01-01", periods=36, freq="MS", calendar="360_day", use_cftime=True
+        )
+        da = xr.DataArray(values, coords={"time": time}, dims=["time"])
+        self.assertAlmostEqual(float(trend(da, season="JJA")), 2.0)
+
+    def test_unknown_how_raises(self):
+        time = pd.date_range("2000-01-01", periods=3, freq="YS")
+        da = xr.DataArray([1.0, 2.0, 3.0], coords={"time": time}, dims=["time"])
+        with self.assertRaises(ValueError):
+            trend(da, how="bogus")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the **`trend`** quantity to the `geoprocessing` library for the Climatology & Indices recipe family (#123). Follows #130 (which added `value`/`anomaly`/`relative anomaly`). Pure library work — no Django, no engine wiring.

With this, all four climatology quantities — `value`, `anomaly`, `relative anomaly`, `trend` — now compute via `geoprocessing`.

## What's new

`trend(da, season=None, how="mean", time_dim="time")` in `geoprocessing/temporal.py` (exported from the package):

- **Inter-annual linear trend (slope per year)**: season-filter → reduce each calendar year to one value (`how`) → degree-1 `polyfit` vs year.
- The year is taken from the time coordinate (`.dt.year`), so the slope is in **per-year** units on any calendar — no nanosecond/cftime scaling pitfalls.
- Validates `how` with `ValueError`, consistent with `temporal_aggregate`/`climatology`.

## Tests (TDD, red→green vertical slices)

Over in-memory xarray arrays — no DB, no storage:

- annual series rising 2.0/yr → slope `2.0`; flat series → `0.0`
- season-aware: JJA averaged per year, rising → `2.0`, junk in other months ignored
- spatial `(time,y,x)` → `(y,x)` slope raster
- CMIP6 360-day cftime calendar → correct (`.dt.month` + `.dt.year` both calendar-safe)
- unknown `how` → `ValueError`

40/40 geoprocessing tests green, including the no-Django import guard.

## Scope / follow-ups (deferred)

- SPI/SPEI indices — needs adding `xclim` to `requirements.txt`
- `ClimatologyRecipe` itself + engine `run()` integration test

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)