### PR TITLE
feat(processing): ClimatologyRecipe — value/anomaly/relative anomaly/trend products

### DIFF
--- a/georiva/src/georiva/processing/management/commands/run_recipe.py
+++ b/georiva/src/georiva/processing/management/commands/run_recipe.py
@@ -4,7 +4,14 @@ Manually invoke a derivation recipe over a selector.
 Usage:
     georiva run_recipe promotion --collection tas-ssp245 --sync
     georiva run_recipe promotion --staging-item-id 12 --staging-item-id 13
+    georiva run_recipe climatology --sync --selector-json '{
+        "source_collection": "tas", "variable": "tas",
+        "periods": [[2011, 2040]], "seasons": ["DJF", "JJA"],
+        "quantities": ["value", "anomaly", "trend"],
+        "baselines": [[1981, 2010]]}'
 """
+import json
+
 from django.core.management.base import BaseCommand, CommandError
 
 from georiva.processing.engine import run
@@ -20,6 +27,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--staging-item-id", dest="staging_item_ids", type=int,
             action="append", default=None,
+        )
+        parser.add_argument(
+            "--selector-json", dest="selector_json", default=None,
+            help="A full selector as a JSON object (for richer recipes like "
+                 "climatology). Merged over --collection/--staging-item-id.",
         )
         parser.add_argument(
             "--sync", action="store_true",
@@ -39,6 +51,11 @@ class Command(BaseCommand):
             selector["collection_slug"] = options["collection_slug"]
         if options.get("staging_item_ids"):
             selector["staging_item_ids"] = options["staging_item_ids"]
+        if options.get("selector_json"):
+            try:
+                selector.update(json.loads(options["selector_json"]))
+            except json.JSONDecodeError as e:
+                raise CommandError(f"Invalid --selector-json: {e}")
 
         results = run(recipe, selector, dispatch=not options["sync"])
 

--- a/georiva/src/georiva/processing/recipes/__init__.py
+++ b/georiva/src/georiva/processing/recipes/__init__.py
@@ -2,4 +2,4 @@
 Built-in recipe families. Importing this package registers them on the engine
 (via the RecipeRegistry decorator). Loaded from ProcessingConfig.ready().
 """
-from . import promotion  # noqa: F401
+from . import climatology, promotion  # noqa: F401

--- a/georiva/src/georiva/processing/recipes/climatology.py
+++ b/georiva/src/georiva/processing/recipes/climatology.py
@@ -1,0 +1,259 @@
+"""
+Climatology & Indices recipe family.
+
+Turns a staging series (one long multi-temporal raster file per
+``variable × experiment``) into Published climatology products across the
+dimensions ``period × season × quantity``, where
+``quantity ∈ {value, anomaly, relative_anomaly, trend}``. Anomaly quantities add
+a ``baseline`` window.
+
+The engine owns the run loop; this recipe only *declares* what to produce:
+
+- ``enumerate_units`` — the cartesian product over the selector's declared
+  dimensions (baseline attached only to the anomaly quantities).
+- ``resolve_inputs`` — a ``value`` selector over the source staging series, plus
+  a required ``baseline`` selector for the anomaly quantities.
+- ``transform`` — slices the series to the period (and baseline) window **by
+  year taken from the file's own time axis** (authoritative + calendar-safe),
+  then computes the quantity via the pure ``geoprocessing`` library.
+- ``outputs`` — maps the categorical coordinates (season, quantity, baseline)
+  onto a Published Collection slug and the period onto the Item time key.
+
+The actual numerical I/O (opening the staging file into an xarray DataArray) is
+isolated in :meth:`read_series` so the declarative pieces and the transform are
+testable with that one seam mocked. The quantity math is covered by the
+``geoprocessing`` unit tests.
+
+See docs/adr/0005-generic-derivation-engine.md and issue #123.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from georiva.geoprocessing import anomaly, climatology, trend
+from georiva.processing.recipe import (
+    BaseRecipe,
+    OutputAsset,
+    OutputItem,
+    ProductionUnit,
+    ResolvedInput,
+)
+from georiva.processing.registry import RecipeRegistry
+
+# Quantities that compare a value window against a baseline window.
+_ANOMALY_QUANTITIES = {"anomaly", "relative_anomaly"}
+
+
+@RecipeRegistry.register
+class ClimatologyRecipe(BaseRecipe):
+    type = "climatology"
+    version = "1"
+
+    # ---- candidate generation ----------------------------------------------
+
+    def enumerate_units(self, selector) -> Iterable[ProductionUnit]:
+        selector = selector or {}
+        source = selector["source_collection"]
+        variable = selector.get("variable")
+        periods = selector["periods"]
+        seasons = selector.get("seasons", ["annual"])
+        quantities = selector.get("quantities", ["value"])
+        baselines = selector.get("baselines", [])
+
+        for period in periods:
+            for season in seasons:
+                for quantity in quantities:
+                    if quantity in _ANOMALY_QUANTITIES:
+                        for baseline in baselines:
+                            yield self._make_unit(
+                                source, variable, period, season, quantity, baseline
+                            )
+                    else:
+                        yield self._make_unit(
+                            source, variable, period, season, quantity, None
+                        )
+
+    @staticmethod
+    def _make_unit(source, variable, period, season, quantity, baseline) -> ProductionUnit:
+        return {
+            "source_collection": source, "variable": variable,
+            "period": period, "season": season,
+            "quantity": quantity, "baseline": baseline,
+        }
+
+    # ---- input resolution ---------------------------------------------------
+
+    def resolve_inputs(self, unit: ProductionUnit) -> "dict[str, ResolvedInput]":
+        items = self._staging_items(unit)
+        assets = [a for si in items for a in si.assets.all()]
+        resolved = {
+            "value": ResolvedInput("value", required=True, items=items, assets=assets),
+        }
+        if unit.get("baseline"):
+            # The baseline window is read from the same source series; it is a
+            # distinct, required selector for the anomaly quantities.
+            resolved["baseline"] = ResolvedInput(
+                "baseline", required=True, items=items, assets=assets
+            )
+        return resolved
+
+    # ---- outputs mapping ----------------------------------------------------
+
+    def outputs(self, unit: ProductionUnit) -> OutputItem:
+        si = self._staging_items(unit)[0]
+        collection = self._published_collection(unit, si.collection.catalog)
+        start = unit["period"][0]
+        return OutputItem(
+            collection=collection,
+            time=datetime(start, 1, 1, tzinfo=timezone.utc),
+            bounds=si.bounds, crs=si.crs, width=si.width, height=si.height,
+            properties={"climatology": {
+                "season": unit["season"], "quantity": unit["quantity"],
+                "period": unit["period"], "baseline": unit.get("baseline"),
+            }},
+        )
+
+    # ---- transform ----------------------------------------------------------
+
+    def transform(self, unit: ProductionUnit, resolved) -> "list[OutputAsset]":
+        season = unit["season"]
+        quantity = unit["quantity"]
+
+        series = self.read_series(resolved["value"].assets)
+        value_window = self._slice_years(series, unit["period"])
+
+        if quantity == "value":
+            result = climatology(value_window, season=season)
+        elif quantity == "trend":
+            result = trend(value_window, season=season)
+        elif quantity in _ANOMALY_QUANTITIES:
+            baseline_series = self.read_series(resolved["baseline"].assets)
+            baseline_window = self._slice_years(baseline_series, unit["baseline"])
+            value = climatology(value_window, season=season)
+            base = climatology(baseline_window, season=season)
+            result = anomaly(value, base, relative=(quantity == "relative_anomaly"))
+        else:
+            raise ValueError(f"unknown quantity: {quantity!r}")
+
+        si = resolved["value"].items[0]
+        out_var = self._output_variable(unit, resolved)
+        # The AssetWriter writes a 2D numpy array; the quantity ops return a
+        # (y, x) DataArray once time is reduced out.
+        import numpy as np
+        array = np.asarray(result, dtype="float32")
+        return [OutputAsset(
+            variable=out_var, roles=["data"], format="cog",
+            array=array, bounds=si.bounds, crs=si.crs,
+            width=si.width, height=si.height,
+        )]
+
+    # ---- I/O seam (mocked in tests) ----------------------------------------
+
+    def read_series(self, assets):
+        """
+        Open the staging asset(s) into an xarray DataArray with a ``time`` dim.
+
+        This is the only real I/O in the recipe and the recipe's single seam:
+        unit tests patch it to return an in-memory array, so the declarative
+        pieces and the transform math stay storage-free. Multiple assets are
+        concatenated along time.
+
+        The byte → xarray step is integration-level (format/engine handling is
+        exercised end-to-end, not in unit tests).
+        """
+        import tempfile
+
+        import xarray as xr
+
+        from georiva.core.storage import BucketType, storage
+
+        if not assets:
+            raise ValueError("ClimatologyRecipe: no source assets to read")
+
+        arrays = []
+        for asset in assets:
+            data = storage.bucket(BucketType.STAGING).read_bytes(asset.href)
+            with tempfile.NamedTemporaryFile(suffix=".nc") as fh:
+                fh.write(data)
+                fh.flush()
+                ds = xr.open_dataset(fh.name)
+            arrays.append(self._pick_variable(ds, asset))
+
+        if len(arrays) == 1:
+            return arrays[0]
+        return xr.concat(arrays, dim="time").sortby("time")
+
+    @staticmethod
+    def _pick_variable(ds, asset):
+        """Select the asset's variable from a Dataset, or the sole data var."""
+        if asset.variable and asset.variable.slug in ds.data_vars:
+            return ds[asset.variable.slug]
+        data_vars = list(ds.data_vars)
+        if len(data_vars) != 1:
+            raise ValueError(
+                f"ClimatologyRecipe: cannot pick a variable from {data_vars} "
+                f"for asset {asset.pk}"
+            )
+        return ds[data_vars[0]]
+
+    # ---- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _slice_years(da, window, time_dim: str = "time"):
+        """Restrict a series to calendar years in ``[start, end]`` (inclusive),
+        using the year from the file's own time axis (authoritative, any calendar)."""
+        start, end = window
+        years = da[time_dim].dt.year
+        return da.sel({time_dim: (years >= start) & (years <= end)})
+
+    @staticmethod
+    def _collection_slug(unit: ProductionUnit) -> str:
+        season = unit["season"] or "annual"
+        parts = [unit["source_collection"], season.lower(), unit["quantity"]]
+        if unit.get("baseline"):
+            b = unit["baseline"]
+            parts.append(f"{b[0]}-{b[1]}")
+        return "_".join(parts)
+
+    def _published_collection(self, unit, catalog):
+        from georiva.core.models import Collection
+
+        slug = self._collection_slug(unit)
+        collection, _ = Collection.objects.get_or_create(
+            catalog=catalog, slug=slug, defaults={"name": slug},
+        )
+        return collection
+
+    @staticmethod
+    def _staging_items(unit) -> list:
+        from georiva.staging.models import StagingItem
+
+        return list(
+            StagingItem.objects
+            .filter(collection__slug=unit["source_collection"])
+            .select_related("collection__catalog")
+            .prefetch_related("assets")
+        )
+
+    def _output_variable(self, unit, resolved):
+        """Mirror the source variable onto the output collection."""
+        from georiva.core.models import Variable
+
+        src = next(
+            (a.variable for a in resolved["value"].assets if a.variable), None
+        )
+        if src is None:
+            raise ValueError(
+                "ClimatologyRecipe: source staging asset has no Variable to mirror"
+            )
+        si = resolved["value"].items[0]
+        collection = self._published_collection(unit, si.collection.catalog)
+        out_var, _ = Variable.objects.get_or_create(
+            collection=collection, slug=src.slug,
+            defaults={
+                "name": src.name, "unit": src.unit,
+                "value_min": src.value_min, "value_max": src.value_max,
+            },
+        )
+        return out_var

--- a/georiva/src/georiva/processing/tests/test_climatology.py
+++ b/georiva/src/georiva/processing/tests/test_climatology.py
@@ -1,0 +1,259 @@
+"""
+ClimatologyRecipe tests — exercised *through* the engine's run()/run_unit()
+seam, with the data-reading I/O (``read_series``) and the AssetWriter mocked.
+The quantity math itself is covered by geoprocessing unit tests; here we assert
+the declarative pieces (enumeration, outputs mapping, input resolution) and that
+running a unit produces the right Published records.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from django.test import TestCase
+
+from georiva.core.models import Catalog, Collection, Item, Unit, Variable
+from georiva.processing.engine import run, run_unit
+from georiva.processing.recipes.climatology import ClimatologyRecipe
+from georiva.staging.models import (
+    DerivationLink,
+    StagingAsset,
+    StagingCollection,
+    StagingItem,
+)
+
+
+def _mock_writer():
+    w = MagicMock()
+    w.bucket.save.side_effect = lambda path, data: path
+    w.write_cog.side_effect = lambda arr, path, *a, **k: path
+    return w
+
+
+def _cube(monthly_by_year, ny=3, nx=2, start="2011-01-01"):
+    """(time, y, x) monthly cube; every pixel at time t equals monthly_by_year[t]."""
+    time = pd.date_range(start, periods=len(monthly_by_year), freq="MS")
+    data = np.broadcast_to(
+        np.asarray(monthly_by_year, dtype="float32")[:, None, None],
+        (len(time), ny, nx),
+    )
+    return xr.DataArray(data, coords={"time": time}, dims=["time", "y", "x"])
+
+
+class _ClimatologyFixture(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CMIP6", slug="cmip6", file_format="netcdf"
+        )
+        self.scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="tas", name="tas"
+        )
+        self.sitem = StagingItem.objects.create(
+            collection=self.scol,
+            start_datetime=datetime(2011, 1, 1, tzinfo=timezone.utc),
+            end_datetime=datetime(2012, 12, 31, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=2, height=3,
+        )
+        # The source variable the recipe mirrors onto its output products.
+        self.unit_c = Unit.objects.create(name="Celsius", symbol="C")
+        self.src_col = Collection.objects.create(
+            catalog=self.catalog, slug="tas-src", name="tas src"
+        )
+        self.src_var = Variable.objects.create(
+            collection=self.src_col, slug="tas", name="tas",
+            unit=self.unit_c, value_min=-50, value_max=50,
+        )
+        self.sasset = StagingAsset.objects.create(
+            item=self.sitem, href="cmip6/tas/series.nc", roles=["source"],
+            format="netcdf", checksum="abc123", variable=self.src_var,
+        )
+
+    def _unit(self, **over):
+        unit = {
+            "source_collection": "tas", "variable": "tas",
+            "period": [2011, 2012], "season": "JJA",
+            "quantity": "value", "baseline": None,
+        }
+        unit.update(over)
+        return unit
+
+    def _run(self, unit, cube):
+        recipe = ClimatologyRecipe()
+        self.writer = _mock_writer()
+        with patch.object(ClimatologyRecipe, "read_series", return_value=cube):
+            return run_unit(recipe, unit, writer=self.writer)
+
+    def _written_array(self):
+        """The (y,x) array the transform handed to the AssetWriter."""
+        return np.asarray(self.writer.write_cog.call_args[0][0])
+
+    def _yearly_jja_cube(self, jja_by_year, junk=999.0):
+        """Contiguous monthly cube over the spanned years; JJA months carry the
+        given per-year value, all other months carry junk (ignored by season)."""
+        years = range(min(jja_by_year), max(jja_by_year) + 1)
+        months = [
+            jja_by_year.get(y, 0.0) if m in (6, 7, 8) else junk
+            for y in years for m in range(1, 13)
+        ]
+        return _cube(months, start=f"{min(jja_by_year)}-01-01")
+
+
+class ValueQuantityTests(_ClimatologyFixture):
+    def test_value_unit_produces_item_asset_and_link(self):
+        # JJA value over 2011-2012; all JJA pixels = 20.0.
+        cube = _cube([20.0] * 24)
+        result = self._run(self._unit(), cube)
+
+        self.assertEqual(result.status, "completed")
+        item = Item.objects.get(pk=result.item_id)
+        self.assertEqual(item.collection.slug, "tas_jja_value")
+        self.assertEqual(item.time, datetime(2011, 1, 1, tzinfo=timezone.utc))
+
+        asset = item.assets.get()
+        self.assertIn("data", asset.roles)
+
+        link = DerivationLink.objects.get(derived_item=item)
+        self.assertEqual(link.source_staging_item, self.sitem)
+        self.assertEqual(link.recipe_id, "climatology")
+
+
+class AnomalyQuantityTests(_ClimatologyFixture):
+    def test_anomaly_uses_baseline_window_and_baseline_slug(self):
+        # JJA value (2011) = 13; JJA baseline (1981) = 10; anomaly = 3.0.
+        cube = self._yearly_jja_cube({1981: 10.0, 2011: 13.0})
+        unit = self._unit(
+            season="JJA", quantity="anomaly",
+            period=[2011, 2011], baseline=[1981, 1981],
+        )
+        result = self._run(unit, cube)
+
+        self.assertEqual(result.status, "completed")
+        item = Item.objects.get(pk=result.item_id)
+        self.assertEqual(item.collection.slug, "tas_jja_anomaly_1981-1981")
+        np.testing.assert_array_almost_equal(
+            self._written_array(), np.full((3, 2), 3.0)
+        )
+
+    def test_relative_anomaly_divides_by_baseline(self):
+        cube = self._yearly_jja_cube({1981: 10.0, 2011: 13.0})
+        unit = self._unit(
+            season="JJA", quantity="relative_anomaly",
+            period=[2011, 2011], baseline=[1981, 1981],
+        )
+        result = self._run(unit, cube)
+
+        self.assertEqual(result.status, "completed")
+        item = Item.objects.get(pk=result.item_id)
+        self.assertEqual(item.collection.slug, "tas_jja_relative_anomaly_1981-1981")
+        np.testing.assert_array_almost_equal(
+            self._written_array(), np.full((3, 2), 0.3)
+        )
+
+
+class TrendQuantityTests(_ClimatologyFixture):
+    def test_trend_computes_per_year_slope_with_no_baseline(self):
+        # JJA rises 10 -> 12 -> 14 over 2011-2013: slope 2.0/year.
+        cube = self._yearly_jja_cube({2011: 10.0, 2012: 12.0, 2013: 14.0})
+        unit = self._unit(season="JJA", quantity="trend", period=[2011, 2013])
+        result = self._run(unit, cube)
+
+        self.assertEqual(result.status, "completed")
+        item = Item.objects.get(pk=result.item_id)
+        self.assertEqual(item.collection.slug, "tas_jja_trend")
+        np.testing.assert_array_almost_equal(
+            self._written_array(), np.full((3, 2), 2.0)
+        )
+
+
+class EnumerateUnitsTests(_ClimatologyFixture):
+    def test_cartesian_product_with_baseline_only_on_anomalies(self):
+        selector = {
+            "source_collection": "tas", "variable": "tas",
+            "periods": [[2011, 2040], [2041, 2070]],
+            "seasons": ["DJF", "JJA"],
+            "quantities": ["value", "anomaly", "trend"],
+            "baselines": [[1981, 2010]],
+        }
+        units = list(ClimatologyRecipe().enumerate_units(selector))
+
+        # 2 periods × 2 seasons × (value + trend + anomaly×1 baseline) = 12.
+        self.assertEqual(len(units), 12)
+
+        anomalies = [u for u in units if u["quantity"] == "anomaly"]
+        self.assertEqual(len(anomalies), 4)  # 2 periods × 2 seasons
+        self.assertTrue(all(u["baseline"] == [1981, 2010] for u in anomalies))
+
+        non_anom = [u for u in units if u["quantity"] in ("value", "trend")]
+        self.assertTrue(all(u["baseline"] is None for u in non_anom))
+
+        self.assertIn(
+            {"source_collection": "tas", "variable": "tas",
+             "period": [2011, 2040], "season": "JJA",
+             "quantity": "value", "baseline": None},
+            units,
+        )
+
+
+class CalendarFromFileContentTests(_ClimatologyFixture):
+    def test_slices_by_year_from_file_axis_not_staging_bounds(self):
+        # Staging index bounds lie (say 2099); the authoritative time is the
+        # file's own 360-day axis spanning 2011-2013.
+        self.sitem.start_datetime = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        self.sitem.end_datetime = datetime(2099, 12, 31, tzinfo=timezone.utc)
+        self.sitem.save()
+
+        time = xr.date_range(
+            "2011-01-01", periods=36, freq="MS",
+            calendar="360_day", use_cftime=True,
+        )
+        months = [
+            {2011: 10.0, 2012: 12.0, 2013: 14.0}[int(t.year)]
+            if t.month in (6, 7, 8) else 999.0
+            for t in time
+        ]
+        data = np.broadcast_to(
+            np.asarray(months, dtype="float32")[:, None, None], (36, 3, 2)
+        )
+        cube = xr.DataArray(data, coords={"time": time}, dims=["time", "y", "x"])
+
+        unit = self._unit(season="JJA", quantity="trend", period=[2011, 2013])
+        result = self._run(unit, cube)
+
+        self.assertEqual(result.status, "completed")
+        np.testing.assert_array_almost_equal(
+            self._written_array(), np.full((3, 2), 2.0)
+        )
+
+
+class RunThroughEngineTests(_ClimatologyFixture):
+    def test_selector_produces_multiple_products_with_lineage(self):
+        cube = self._yearly_jja_cube({2011: 10.0, 2012: 13.0})
+        selector = {
+            "source_collection": "tas", "variable": "tas",
+            "periods": [[2012, 2012]], "seasons": ["JJA", "DJF"],
+            "quantities": ["value", "anomaly"], "baselines": [[2011, 2011]],
+        }
+        with patch.object(ClimatologyRecipe, "read_series", return_value=cube), \
+                patch("georiva.ingestion.asset_writer.AssetWriter") as AW:
+            AW.return_value = _mock_writer()
+            results = run(ClimatologyRecipe(), selector, dispatch=False)
+
+        self.assertEqual(len(results), 4)
+        self.assertTrue(all(r.status == "completed" for r in results))
+
+        slugs = set(
+            Collection.objects.filter(catalog=self.catalog)
+            .values_list("slug", flat=True)
+        )
+        self.assertTrue({
+            "tas_jja_value", "tas_jja_anomaly_2011-2011",
+            "tas_djf_value", "tas_djf_anomaly_2011-2011",
+        } <= slugs)
+
+        self.assertEqual(Item.objects.filter(collection__slug__startswith="tas_").count(), 4)
+        self.assertEqual(DerivationLink.objects.count(), 4)
+        self.assertTrue(
+            all(l.source_staging_item_id == self.sitem.pk
+                for l in DerivationLink.objects.all())
+        )


### PR DESCRIPTION
## Summary

The first real transform recipe for the **Climatology & Indices** family (#123). Turns a staging series (one long multi-temporal raster per `variable × experiment`) into Published climatology products across `period × season × quantity × baseline`, with `quantity ∈ {value, anomaly, relative_anomaly, trend}` (baseline applies only to the anomaly quantities).

Builds on #130 (`value`/`anomaly`/`relative anomaly`) and #131 (`trend`) — the math lives in the pure `geoprocessing` library; this PR is the declarative recipe that drives it through the generic derivation engine.

## Recipe surface

- **`enumerate_units(selector)`** — cartesian product over the selector's declared dimensions (baseline attached only to anomaly quantities).
- **`resolve_inputs`** — a required `value` selector over the source staging series plus, for the anomaly quantities, a required `baseline` selector.
- **`transform`** — slices the series to the period/baseline window **by year taken from the file's own time axis** (authoritative + calendar-safe, incl. CMIP6 360-day), then computes the quantity via `geoprocessing`; converts the `(y,x)` result to a 2D float32 array for the `AssetWriter`.
- **`outputs`** — categorical coords → Published Collection slug `<source>_<season>_<quantity>[_<start>-<end>]`; period → Item time (`Jan 1` of start year, full window in `properties`).
- **`read_series`** — the single mockable I/O seam; the byte → xarray read is integration-level.

## Tests (TDD, red→green through the engine seam)

Exercised *through* `run()`/`run_unit()` with `read_series` + `AssetWriter` mocked; the quantity math itself is covered by the `geoprocessing` unit tests.

1. tracer: `value`/JJA → Item + Asset + `DerivationLink` in `tas_jja_value`
2. `anomaly` → resolves baseline selector, baseline in slug, value `3.0`
3. `relative_anomaly` → `0.3`
4. `trend` → slope `2.0`/yr, no baseline
5. `enumerate_units` → 12-unit cartesian product; baseline only on anomalies
6. **calendar**: slices by the file's 360-day axis, ignoring contradictory staging index bounds
7. **headline**: a selector run via `run()` → 4 distinct Published products, each with a `DerivationLink`

`run_recipe` gains `--selector-json` for manual invocation of richer recipes.

**56 tests green** (7 climatology + 9 engine + 40 geoprocessing). No schema changes.

## Acceptance criteria (#123)

- [x] Running the recipe over a staging series produces multiple Published products keyed by `(period, season, quantity, baseline)`, each a Collection/Item/Asset with a `DerivationLink`
- [x] `value`, `anomaly`, `relative anomaly`, `trend` each compute via `geoprocessing`
- [ ] SPI/SPEI indices — deferred (needs `xclim`)
- [x] Calendar handling (CMIP6 360-day) — time from file content, not staging index bounds
- [x] Tested *through* the engine's `run()` seam with I/O mocked

## Follow-ups (deferred)

- SPI/SPEI (add `xclim` to `requirements.txt`)
- Quantity-specific output-variable units (relative anomaly is dimensionless; trend is per-year) — currently mirrors the source variable
- Asset stats (min/max/mean/std) on derived assets
- Event-driven `candidate_units` (currently delegates to `enumerate_units`)

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)