### PR TITLE
feat(processing): climatology output metadata + derived-asset stats

### DIFF
--- a/georiva/src/georiva/processing/recipes/climatology.py
+++ b/georiva/src/georiva/processing/recipes/climatology.py
@@ -146,7 +146,22 @@ class ClimatologyRecipe(BaseRecipe):
             variable=out_var, roles=["data"], format="cog",
             array=array, bounds=si.bounds, crs=si.crs,
             width=si.width, height=si.height,
+            stats=self._array_stats(array),
         )]
+
+    @staticmethod
+    def _array_stats(array) -> dict:
+        """NaN-aware min/max/mean/std for the derived raster (empty if all-NaN)."""
+        import numpy as np
+
+        if not np.isfinite(array).any():
+            return {}
+        return {
+            "min": float(np.nanmin(array)),
+            "max": float(np.nanmax(array)),
+            "mean": float(np.nanmean(array)),
+            "std": float(np.nanstd(array)),
+        }
 
     # ---- I/O seam (mocked in tests) ----------------------------------------
 
@@ -237,7 +252,13 @@ class ClimatologyRecipe(BaseRecipe):
         )
 
     def _output_variable(self, unit, resolved):
-        """Mirror the source variable onto the output collection."""
+        """
+        Derive the output Variable from the source, adjusting metadata to the
+        quantity: ``value`` mirrors the source; ``anomaly``/``trend`` keep the
+        source unit but use a symmetric range around zero; ``relative_anomaly``
+        is dimensionless on [-1, 1]. The recipe creates these in the per-quantity
+        output collection (one Variable per collection).
+        """
         from georiva.core.models import Variable
 
         src = next(
@@ -249,11 +270,35 @@ class ClimatologyRecipe(BaseRecipe):
             )
         si = resolved["value"].items[0]
         collection = self._published_collection(unit, si.collection.catalog)
+        spec = self._variable_spec(src, unit["quantity"])
         out_var, _ = Variable.objects.get_or_create(
-            collection=collection, slug=src.slug,
-            defaults={
-                "name": src.name, "unit": src.unit,
-                "value_min": src.value_min, "value_max": src.value_max,
-            },
+            collection=collection, slug=src.slug, defaults=spec,
         )
         return out_var
+
+    def _variable_spec(self, src, quantity: str) -> dict:
+        """Quantity-specific (name, unit, value_min, value_max) for the output."""
+        span = (src.value_max - src.value_min) / 2.0
+        if quantity == "value":
+            return {"name": src.name, "unit": src.unit,
+                    "value_min": src.value_min, "value_max": src.value_max}
+        if quantity == "anomaly":
+            return {"name": f"{src.name} anomaly", "unit": src.unit,
+                    "value_min": -span, "value_max": span}
+        if quantity == "relative_anomaly":
+            return {"name": f"{src.name} relative anomaly",
+                    "unit": self._dimensionless_unit(),
+                    "value_min": -1.0, "value_max": 1.0}
+        if quantity == "trend":
+            return {"name": f"{src.name} trend (per year)", "unit": src.unit,
+                    "value_min": -span, "value_max": span}
+        raise ValueError(f"unknown quantity: {quantity!r}")
+
+    @staticmethod
+    def _dimensionless_unit():
+        from georiva.core.models import Unit
+
+        unit, _ = Unit.objects.get_or_create(
+            symbol="dimensionless", defaults={"name": "Dimensionless"},
+        )
+        return unit

--- a/georiva/src/georiva/processing/tests/test_climatology.py
+++ b/georiva/src/georiva/processing/tests/test_climatology.py
@@ -62,7 +62,7 @@ class _ClimatologyFixture(TestCase):
         )
         self.src_var = Variable.objects.create(
             collection=self.src_col, slug="tas", name="tas",
-            unit=self.unit_c, value_min=-50, value_max=50,
+            unit=self.unit_c, value_min=0, value_max=50,
         )
         self.sasset = StagingAsset.objects.create(
             item=self.sitem, href="cmip6/tas/series.nc", roles=["source"],
@@ -116,6 +116,62 @@ class ValueQuantityTests(_ClimatologyFixture):
         link = DerivationLink.objects.get(derived_item=item)
         self.assertEqual(link.source_staging_item, self.sitem)
         self.assertEqual(link.recipe_id, "climatology")
+
+
+class AssetStatsTests(_ClimatologyFixture):
+    def test_derived_asset_carries_stats_from_result(self):
+        cube = _cube([20.0] * 24)  # JJA climatology = 20.0 everywhere
+        result = self._run(self._unit(), cube)
+
+        asset = Item.objects.get(pk=result.item_id).assets.get()
+        self.assertAlmostEqual(asset.stats_min, 20.0)
+        self.assertAlmostEqual(asset.stats_max, 20.0)
+        self.assertAlmostEqual(asset.stats_mean, 20.0)
+        self.assertAlmostEqual(asset.stats_std, 0.0)
+
+
+class OutputVariableMetadataTests(_ClimatologyFixture):
+    def _out_variable(self, unit, cube):
+        result = self._run(unit, cube)
+        self.assertEqual(result.status, "completed")
+        return Item.objects.get(pk=result.item_id).assets.get().variable
+
+    def test_value_variable_mirrors_source(self):
+        var = self._out_variable(self._unit(), _cube([20.0] * 24))
+        self.assertEqual(var.unit, self.unit_c)
+        self.assertAlmostEqual(var.value_min, 0.0)
+        self.assertAlmostEqual(var.value_max, 50.0)
+
+    def test_anomaly_variable_has_symmetric_range_and_mirrors_unit(self):
+        cube = self._yearly_jja_cube({1981: 10.0, 2011: 13.0})
+        unit = self._unit(
+            season="JJA", quantity="anomaly",
+            period=[2011, 2011], baseline=[1981, 1981],
+        )
+        var = self._out_variable(unit, cube)
+        self.assertEqual(var.unit, self.unit_c)  # an anomaly keeps source units
+        self.assertAlmostEqual(var.value_min, -25.0)  # span = (50-0)/2
+        self.assertAlmostEqual(var.value_max, 25.0)
+        self.assertIn("anomaly", var.name.lower())
+
+    def test_relative_anomaly_variable_is_dimensionless(self):
+        cube = self._yearly_jja_cube({1981: 10.0, 2011: 13.0})
+        unit = self._unit(
+            season="JJA", quantity="relative_anomaly",
+            period=[2011, 2011], baseline=[1981, 1981],
+        )
+        var = self._out_variable(unit, cube)
+        self.assertNotEqual(var.unit, self.unit_c)
+        self.assertEqual(var.unit.symbol, "dimensionless")
+        self.assertAlmostEqual(var.value_min, -1.0)
+        self.assertAlmostEqual(var.value_max, 1.0)
+
+    def test_trend_variable_names_per_year_and_keeps_unit(self):
+        cube = self._yearly_jja_cube({2011: 10.0, 2012: 12.0, 2013: 14.0})
+        unit = self._unit(season="JJA", quantity="trend", period=[2011, 2013])
+        var = self._out_variable(unit, cube)
+        self.assertEqual(var.unit, self.unit_c)
+        self.assertIn("per year", var.name.lower())
 
 
 class AnomalyQuantityTests(_ClimatologyFixture):


### PR DESCRIPTION
## Summary

Two refinements to the `ClimatologyRecipe` (#123), following the recipe itself (#132). No schema changes.

### 1. Quantity-specific output-variable metadata

The output Variable no longer blindly mirrors the source — its metadata now depends on the quantity:

| quantity | unit | value range | name |
|---|---|---|---|
| `value` | source | source | source |
| `anomaly` | source | symmetric ±span | "… anomaly" |
| `relative_anomaly` | **dimensionless** | [-1, 1] | "… relative anomaly" |
| `trend` | source | symmetric ±span | "… (per year)" |

`span` = half the source value range. Per the agreed approach, `trend` keeps the source unit and documents per-year in the name rather than fabricating an offset-unit per-year pint symbol; `relative_anomaly` uses a `get_or_create` dimensionless Unit.

### 2. Derived-asset stats

Derived assets now carry NaN-aware `min`/`max`/`mean`/`std` computed from the result raster (empty when all-NaN), so palettes/legends and the catalog have real ranges.

## Tests (TDD, through the engine seam)

5 new cycles, all exercised through `run_unit()` with I/O mocked:

- a produced Asset carries stats from the result
- `value` variable mirrors the source
- `anomaly` variable: symmetric range around 0, source unit, "anomaly" in name
- `relative_anomaly` variable: dimensionless unit, [-1, 1]
- `trend` variable: source unit, "per year" in name

**61 tests green** (processing + geoprocessing).

## Deferred

- **Event-driven `candidate_units`** → #125 (invocation surface): an event carries no selector, so it needs persisted recipe config.
- **SPI/SPEI** → needs `xclim` in `requirements.txt`.

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)