### PR TITLE
feat(processing): full invocation surface + backfill sweep (#125)

### DIFF
--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -85,11 +85,18 @@ def process_staging_file(self, bucket: str, key: str):
     Register a raw file landed in the STAGING bucket as one StagingItem.
 
     Store-only path: this does NOT materialize any served layers — it holds
-    the file as a raw input for later derivation.
+    the file as a raw input for later derivation, then fires the staging event
+    so derivation recipes that consume this input are triggered.
     """
     from georiva.ingestion.staging_consumer import register_staging_file
 
-    register_staging_file(bucket=bucket, key=key)
+    item = register_staging_file(bucket=bucket, key=key)
+    if item is not None:
+        from georiva.processing.invocation import (
+            dispatch_for_trigger,
+            staging_item_trigger,
+        )
+        dispatch_for_trigger(staging_item_trigger(item))
 
 
 @app.task(name="georiva.ingestion.tasks.sweep_unprocessed", queue="georiva-default")

--- a/georiva/src/georiva/processing/engine.py
+++ b/georiva/src/georiva/processing/engine.py
@@ -241,9 +241,13 @@ def run(recipe: BaseRecipe, selector, *, dispatch: bool = True, worker_id="") ->
 
     ``dispatch=True`` fans out one Celery task per unit on the processing queue;
     ``dispatch=False`` runs inline (used by tests and small synchronous runs).
-    Backfill and streaming both call this — they differ only in selector width.
+    Backfill and streaming both call this — they differ only in selector width:
+    a wide range selector enumerates many units; a narrow arriving-input trigger
+    maps to just the units that input feeds. Both go through
+    ``candidate_units`` (whose default is ``enumerate_units``), so this one
+    primitive serves event-driven, scheduled/backfill, and manual invocation.
     """
-    units = list(recipe.enumerate_units(selector))
+    units = list(recipe.candidate_units(selector))
 
     if dispatch:
         from .tasks import run_unit_task

--- a/georiva/src/georiva/processing/invocation.py
+++ b/georiva/src/georiva/processing/invocation.py
@@ -1,0 +1,156 @@
+"""
+Invocation surface for the derivation engine.
+
+Event-driven, scheduled/backfill, and the periodic sweep are all thin callers of
+the one ``run(recipe, selector)`` primitive — they differ only in how wide a
+selector (or how narrow a trigger) they build. This module holds the event-side
+helpers:
+
+- ``dispatch_for_trigger`` — an arriving input fans out to every registered
+  recipe; each recipe's ``candidate_units(trigger)`` decides whether (and which)
+  units it feeds, so irrelevant recipes contribute nothing.
+- ``invalidate_downstream`` — walk ``DerivationLink`` forward from a changed
+  input through its derived items (transitively, through internal
+  intermediates) and re-dispatch each one.
+
+See issue #125 and docs/adr/0005-generic-derivation-engine.md.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def staging_item_trigger(staging_item) -> dict:
+    """The arriving-input trigger for a newly registered StagingItem."""
+    return {
+        "staging_item_id": staging_item.pk,
+        "collection_slug": staging_item.collection.slug,
+    }
+
+
+def published_item_trigger(item) -> dict:
+    """The arriving-input trigger for a Published item produced by a derivation
+    (an intermediate that may itself feed a further derivation)."""
+    return {
+        "published_item_id": item.pk,
+        "collection_slug": item.collection.slug,
+    }
+
+
+def _dispatch_unit(recipe_type: str, unit: dict, *, dispatch: bool = True) -> None:
+    """Re-run one known ProductionUnit via the same per-unit primitive ``run``
+    fans out to — no enumeration/orchestration is duplicated."""
+    if dispatch:
+        from .tasks import run_unit_task
+        run_unit_task.delay(recipe_type=recipe_type, unit=unit)
+    else:
+        from .engine import run_unit
+        from .registry import recipe_registry
+        recipe = recipe_registry.get(recipe_type)
+        if recipe is not None:
+            run_unit(recipe, unit)
+
+
+def current_input_hash(recipe, unit: dict) -> str:
+    """The input_hash a unit would have *now*, from its inputs' current
+    checksums — compared against the recorded hash to detect staleness."""
+    from .recipe import compute_input_hash
+
+    return compute_input_hash(recipe.resolve_inputs(unit), recipe.version)
+
+
+def sweep_stale_units(*, dispatch: bool = True) -> int:
+    """
+    The write-side mirror of ``sweep_unprocessed``: find already-computed units
+    whose inputs have since changed (recorded ``input_hash`` ≠ current) and
+    recompute them — without any event. Returns the number re-dispatched.
+    """
+    from .models import DerivationRun
+
+    terminal = [DerivationRun.Status.COMPLETED, DerivationRun.Status.SKIPPED]
+    stale = 0
+    for run_rec in DerivationRun.objects.filter(status__in=terminal):
+        recipe = _recipe_for(run_rec.recipe_type)
+        if recipe is None:
+            continue
+        try:
+            current = current_input_hash(recipe, run_rec.unit_key)
+        except Exception as e:  # a recipe that can't resolve is skipped, not fatal
+            logger.warning("Sweep: cannot hash %s: %s", run_rec, e)
+            continue
+        if current != run_rec.input_hash:
+            _dispatch_unit(run_rec.recipe_type, run_rec.unit_key, dispatch=dispatch)
+            stale += 1
+            # Recomputing this unit will change its output, so anything derived
+            # from it is stale too — propagate forward in this same pass (the
+            # intermediate hasn't recomputed yet, so a hash check wouldn't catch
+            # it). Walks transitively through internal intermediates.
+            if run_rec.produced_item_id:
+                invalidate_downstream(run_rec.produced_item, dispatch=dispatch)
+    if stale:
+        logger.info("Sweep: re-dispatched %d stale unit(s)", stale)
+    return stale
+
+
+def _recipe_for(recipe_type: str):
+    from .registry import recipe_registry
+
+    return recipe_registry.get(recipe_type)
+
+
+def invalidate_downstream(changed_item, *, dispatch: bool = True) -> int:
+    """
+    Walk ``DerivationLink`` forward from a changed input and recompute every
+    item derived from it — transitively, through internal intermediates.
+
+    ``changed_item`` is a StagingItem or a Published Item. Each derived item is
+    re-run via its recorded ``DerivationRun`` (recipe_type + unit_key). Returns
+    the number of downstream units re-dispatched.
+    """
+    from georiva.staging.models import DerivationLink, StagingItem
+
+    from .models import DerivationRun
+
+    count = 0
+    seen: set[tuple[str, int]] = set()
+    frontier = [changed_item]
+    while frontier:
+        node = frontier.pop()
+        if isinstance(node, StagingItem):
+            links = DerivationLink.objects.filter(source_staging_item=node)
+        else:  # a Published item that is itself an input to further derivations
+            links = DerivationLink.objects.filter(source_published_item=node)
+
+        for link in links.select_related("derived_item__collection"):
+            derived = link.derived_item
+            key = ("item", derived.pk)
+            if key in seen:
+                continue
+            seen.add(key)
+            for run_rec in DerivationRun.objects.filter(produced_item=derived):
+                _dispatch_unit(run_rec.recipe_type, run_rec.unit_key, dispatch=dispatch)
+                count += 1
+            frontier.append(derived)  # continue forward through intermediates
+    return count
+
+
+def dispatch_for_trigger(trigger: dict, *, dispatch: bool = True) -> list:
+    """
+    Run every registered recipe against an arriving-input ``trigger``.
+
+    Each recipe's ``candidate_units(trigger)`` maps the input back to the units
+    it feeds (or ``[]`` if the recipe does not consume this input), so a single
+    arriving input auto-triggers exactly the right units across all recipes.
+    """
+    from .engine import run
+    from .registry import recipe_registry
+
+    results = []
+    for recipe_type in recipe_registry.all_types():
+        recipe = recipe_registry.get(recipe_type)
+        if recipe is None:
+            continue
+        results.extend(run(recipe, trigger, dispatch=dispatch))
+    return results

--- a/georiva/src/georiva/processing/recipes/climatology.py
+++ b/georiva/src/georiva/processing/recipes/climatology.py
@@ -52,6 +52,18 @@ class ClimatologyRecipe(BaseRecipe):
 
     # ---- candidate generation ----------------------------------------------
 
+    def candidate_units(self, trigger) -> Iterable[ProductionUnit]:
+        """
+        Climatology is scheduled/manual, not event-driven: the product space
+        (period × season × quantity × baseline) is not derivable from a bare
+        arriving input. So a trigger lacking the explicit period config yields
+        nothing — this recipe is invoked over an explicit selector instead.
+        """
+        trigger = trigger or {}
+        if not (trigger.get("source_collection") and trigger.get("periods")):
+            return []
+        return self.enumerate_units(trigger)
+
     def enumerate_units(self, selector) -> Iterable[ProductionUnit]:
         selector = selector or {}
         source = selector["source_collection"]

--- a/georiva/src/georiva/processing/recipes/promotion.py
+++ b/georiva/src/georiva/processing/recipes/promotion.py
@@ -43,6 +43,24 @@ class PromotionRecipe(BaseRecipe):
         for sid in qs.values_list("pk", flat=True):
             yield {"staging_item_id": sid}
 
+    def candidate_units(self, trigger) -> Iterable[ProductionUnit]:
+        """
+        Map an arriving input back to the unit(s) it feeds.
+
+        An event trigger carries a single ``staging_item_id`` → its 1:1
+        promotion unit. Anything else is treated as a (possibly wide) selector
+        and enumerated normally, so scheduled/backfill/manual stay unchanged.
+        """
+        trigger = trigger or {}
+        if "staging_item_id" in trigger:
+            return [{"staging_item_id": trigger["staging_item_id"]}]
+        if "published_item_id" in trigger:
+            # Promotion consumes Staging inputs only — ignore Published-item
+            # (completion-chaining) triggers rather than mis-reading their
+            # collection_slug as a staging filter.
+            return []
+        return self.enumerate_units(trigger)
+
     def resolve_inputs(self, unit: ProductionUnit) -> "dict[str, ResolvedInput]":
         from georiva.staging.models import StagingItem
 

--- a/georiva/src/georiva/processing/tasks.py
+++ b/georiva/src/georiva/processing/tasks.py
@@ -12,6 +12,27 @@ from georiva.config.celery import app
 logger = logging.getLogger(__name__)
 
 
+@app.on_after_finalize.connect
+def setup_periodic_tasks(sender, **kwargs):
+    """Register the periodic backfill sweep (mirror of sweep_unprocessed)."""
+    try:
+        from django_celery_beat.models import IntervalSchedule, PeriodicTask
+
+        schedule_5min, _ = IntervalSchedule.objects.get_or_create(
+            every=5, period=IntervalSchedule.MINUTES,
+        )
+        PeriodicTask.objects.update_or_create(
+            name="georiva.processing.sweep_derivations",
+            defaults={
+                "task": "georiva.processing.tasks.sweep_derivations",
+                "interval": schedule_5min,
+                "enabled": True,
+            },
+        )
+    except Exception as e:  # DB may be unavailable at import/finalize time
+        logger.debug("Skipped derivation sweep schedule setup: %s", e)
+
+
 @app.task(
     name="georiva.processing.tasks.run_unit_task",
     bind=True,
@@ -30,7 +51,37 @@ def run_unit_task(self, recipe_type: str, unit: dict):
         return
 
     worker_id = self.request.id or ""
-    run_unit(recipe, unit, worker_id=worker_id)
+    result = run_unit(recipe, unit, worker_id=worker_id)
+
+    # Completion chaining: a produced Published item is itself a derivation
+    # input, so stream a downstream trigger to its consumers (internal
+    # intermediates → their dependent products).
+    if result.status == "completed" and result.item_id:
+        from georiva.core.models import Item
+        from georiva.processing.invocation import (
+            dispatch_for_trigger,
+            published_item_trigger,
+        )
+
+        item = Item.objects.filter(pk=result.item_id).select_related("collection").first()
+        if item is not None:
+            dispatch_for_trigger(published_item_trigger(item))
+
+
+@app.task(
+    name="georiva.processing.tasks.sweep_derivations",
+    queue="georiva-default",
+)
+def sweep_derivations():
+    """
+    Periodic backfill sweep — the write-side mirror of ``sweep_unprocessed``.
+
+    Recomputes units whose inputs changed since they were last derived
+    (recorded ``input_hash`` ≠ current), without depending on an event.
+    """
+    from georiva.processing.invocation import sweep_stale_units
+
+    return sweep_stale_units()
 
 
 @app.task(

--- a/georiva/src/georiva/processing/tests/test_invocation.py
+++ b/georiva/src/georiva/processing/tests/test_invocation.py
@@ -1,0 +1,563 @@
+"""
+Invocation surface — event-driven, scheduled/backfill, and the periodic
+backfill sweep all funnel through the one ``run(recipe, selector)`` primitive.
+Tests drive each path and assert the right units are (re)computed, with the
+per-unit compute (``run_unit_task``) mocked.
+
+See issue #125 and docs/adr/0005-generic-derivation-engine.md.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from georiva.processing.engine import run
+from georiva.processing.recipe import BaseRecipe, OutputItem
+from georiva.processing.registry import RecipeRegistry
+
+
+class _TriggerRecipe(BaseRecipe):
+    """
+    A recipe whose ``candidate_units`` maps a narrow trigger to just the units
+    it feeds, while ``enumerate_units`` would return a *wide* set. Proves that
+    ``run()`` enumerates via ``candidate_units`` (so streaming stays narrow).
+    """
+
+    type = "trigger_fake"
+    version = "1"
+
+    def enumerate_units(self, selector):
+        # Deliberately wide — run() must NOT use this for a trigger.
+        return [{"n": i} for i in range(5)]
+
+    def candidate_units(self, trigger):
+        if trigger.get("relevant"):
+            return [{"n": 1}, {"n": 2}]
+        return []
+
+    def resolve_inputs(self, unit):
+        return {}
+
+    def outputs(self, unit):
+        return OutputItem(collection=None, time=None)
+
+    def transform(self, unit, resolved):
+        return []
+
+
+class RunUsesCandidateUnitsTests(TestCase):
+    def test_run_dispatches_candidate_units_not_enumerate(self):
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            run(_TriggerRecipe(), {"relevant": True}, dispatch=True)
+
+        # candidate_units → 2 units (not enumerate_units' 5).
+        self.assertEqual(task.delay.call_count, 2)
+        dispatched = {c.kwargs["unit"]["n"] for c in task.delay.call_args_list}
+        self.assertEqual(dispatched, {1, 2})
+
+    def test_irrelevant_trigger_dispatches_nothing(self):
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            run(_TriggerRecipe(), {"relevant": False}, dispatch=True)
+
+        self.assertEqual(task.delay.call_count, 0)
+
+
+class _RangeRecipe(BaseRecipe):
+    """A recipe that expands a wide range selector into one unit per year —
+    the scheduled/backfill shape. Uses the *default* ``candidate_units`` (which
+    delegates to ``enumerate_units``), so streaming and backfill share one path."""
+
+    type = "range_fake"
+    version = "1"
+
+    def enumerate_units(self, selector):
+        start, end = selector["years"]
+        return [{"year": y} for y in range(start, end + 1)]
+
+    def resolve_inputs(self, unit):
+        return {}
+
+    def outputs(self, unit):
+        return OutputItem(collection=None, time=None)
+
+    def transform(self, unit, resolved):
+        return []
+
+
+class ScheduledBackfillTests(TestCase):
+    def test_run_over_range_fans_out_one_task_per_unit(self):
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            run(_RangeRecipe(), {"years": [2011, 2013]}, dispatch=True)
+
+        # One per-unit task per year in the range (2011, 2012, 2013).
+        self.assertEqual(task.delay.call_count, 3)
+        years = {c.kwargs["unit"]["year"] for c in task.delay.call_args_list}
+        self.assertEqual(years, {2011, 2012, 2013})
+
+
+class _RegistryIsolationMixin:
+    """Register fake recipes for the duration of a test, then restore."""
+
+    fake_recipes: list = []
+
+    def setUp(self):
+        super().setUp()
+        self._saved = dict(RecipeRegistry._recipes)
+        RecipeRegistry._recipes.clear()
+        for cls in self.fake_recipes:
+            RecipeRegistry._recipes[cls.type] = cls
+
+    def tearDown(self):
+        RecipeRegistry._recipes.clear()
+        RecipeRegistry._recipes.update(self._saved)
+        super().tearDown()
+
+
+class _RelevantRecipe(_TriggerRecipe):
+    type = "fake_relevant"
+
+    def candidate_units(self, trigger):
+        return [{"n": 1}] if trigger.get("kind") == "match" else []
+
+
+class _OtherRecipe(_TriggerRecipe):
+    type = "fake_other"
+
+    def candidate_units(self, trigger):
+        return []
+
+
+class DispatchForTriggerTests(_RegistryIsolationMixin, TestCase):
+    fake_recipes = [_RelevantRecipe, _OtherRecipe]
+
+    def test_only_recipes_that_claim_the_trigger_dispatch(self):
+        from georiva.processing.invocation import dispatch_for_trigger
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            dispatch_for_trigger({"kind": "match"})
+
+        dispatched = [c.kwargs["recipe_type"] for c in task.delay.call_args_list]
+        self.assertEqual(dispatched, ["fake_relevant"])
+
+    def test_trigger_no_recipe_claims_dispatches_nothing(self):
+        from georiva.processing.invocation import dispatch_for_trigger
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            dispatch_for_trigger({"kind": "nomatch"})
+
+        self.assertEqual(task.delay.call_count, 0)
+
+
+class _StagingFixture(TestCase):
+    def setUp(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Catalog
+        from georiva.staging.models import (
+            StagingAsset,
+            StagingCollection,
+            StagingItem,
+        )
+
+        self.catalog = Catalog.objects.create(
+            name="CMIP6", slug="cmip6", file_format="geotiff"
+        )
+        self.scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="tas", name="tas"
+        )
+        self.sitem = StagingItem.objects.create(
+            collection=self.scol,
+            datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=10, height=10,
+        )
+        StagingAsset.objects.create(
+            item=self.sitem, href="cmip6/tas/f.tif", roles=["source"],
+            format="geotiff", checksum="abc123",
+        )
+
+
+class PromotionCandidateUnitsTests(_StagingFixture):
+    """Promotion is the naturally event-driven recipe: an arriving staging
+    item maps 1:1 to its promotion unit; a wide selector still enumerates."""
+
+    def test_staging_trigger_maps_to_single_unit(self):
+        from datetime import datetime, timezone
+
+        from georiva.processing.recipes.promotion import PromotionRecipe
+        from georiva.staging.models import StagingItem
+
+        # A second staging item that must NOT be triggered by the first's event.
+        StagingItem.objects.create(
+            collection=self.scol,
+            datetime=datetime(2020, 1, 2, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=10, height=10,
+        )
+
+        units = list(
+            PromotionRecipe().candidate_units({"staging_item_id": self.sitem.pk})
+        )
+        self.assertEqual(units, [{"staging_item_id": self.sitem.pk}])
+
+    def test_selector_without_trigger_still_enumerates(self):
+        from georiva.processing.recipes.promotion import PromotionRecipe
+
+        units = list(
+            PromotionRecipe().candidate_units({"collection_slug": "tas"})
+        )
+        self.assertIn({"staging_item_id": self.sitem.pk}, units)
+
+    def test_ignores_published_item_trigger(self):
+        # Promotion consumes Staging inputs only. A completion-chaining trigger
+        # for a Published item (carrying a collection_slug) must NOT make it
+        # fire for same-named staging items.
+        from georiva.processing.recipes.promotion import PromotionRecipe
+
+        units = list(PromotionRecipe().candidate_units(
+            {"published_item_id": 99, "collection_slug": "tas"}
+        ))
+        self.assertEqual(units, [])
+
+
+class StagingConsumerHookTests(_StagingFixture):
+    """A registered StagingItem auto-triggers derivation for the units it
+    feeds — the staging-consumer event hook."""
+
+    def test_process_staging_file_dispatches_for_new_item(self):
+        from georiva.core.storage import BucketType
+        from georiva.ingestion.tasks import process_staging_file
+
+        with (
+            patch(
+                "georiva.ingestion.staging_consumer.register_staging_file",
+                return_value=self.sitem,
+            ),
+            patch(
+                "georiva.processing.invocation.dispatch_for_trigger"
+            ) as dispatch,
+        ):
+            process_staging_file.apply(
+                kwargs={"bucket": BucketType.STAGING, "key": "cmip6/tas/f.tif"}
+            )
+
+        dispatch.assert_called_once()
+        trigger = dispatch.call_args.args[0]
+        self.assertEqual(trigger["staging_item_id"], self.sitem.pk)
+        self.assertEqual(trigger["collection_slug"], "tas")
+
+    def test_no_dispatch_when_registration_skipped(self):
+        from georiva.core.storage import BucketType
+        from georiva.ingestion.tasks import process_staging_file
+
+        with (
+            patch(
+                "georiva.ingestion.staging_consumer.register_staging_file",
+                return_value=None,
+            ),
+            patch(
+                "georiva.processing.invocation.dispatch_for_trigger"
+            ) as dispatch,
+        ):
+            process_staging_file.apply(
+                kwargs={"bucket": BucketType.STAGING, "key": "bad/path.tif"}
+            )
+
+        dispatch.assert_not_called()
+
+
+class CompletionChainingTests(_RegistryIsolationMixin, TestCase):
+    """When a unit completes producing a Published item, that item is itself an
+    input — the streaming task chains a downstream trigger so internal
+    intermediates flow to their consumers."""
+
+    fake_recipes = [_RelevantRecipe]
+
+    def _published_item(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Catalog, Collection, Item
+
+        catalog = Catalog.objects.create(
+            name="C", slug="c", file_format="geotiff"
+        )
+        col = Collection.objects.create(catalog=catalog, slug="anom", name="anom")
+        return Item.objects.create(
+            collection=col, time=datetime(2020, 1, 1, tzinfo=timezone.utc)
+        )
+
+    def test_completed_unit_chains_downstream_trigger(self):
+        from georiva.processing.engine import UnitResult
+        from georiva.processing.tasks import run_unit_task
+
+        item = self._published_item()
+
+        with (
+            patch(
+                "georiva.processing.engine.run_unit",
+                return_value=UnitResult(status="completed", item_id=item.pk),
+            ),
+            patch(
+                "georiva.processing.invocation.dispatch_for_trigger"
+            ) as dispatch,
+        ):
+            run_unit_task.apply(
+                kwargs={"recipe_type": "fake_relevant", "unit": {"n": 1}}
+            )
+
+        dispatch.assert_called_once()
+        trigger = dispatch.call_args.args[0]
+        self.assertEqual(trigger["published_item_id"], item.pk)
+        self.assertEqual(trigger["collection_slug"], "anom")
+
+    def test_not_ready_unit_does_not_chain(self):
+        from georiva.processing.engine import UnitResult
+        from georiva.processing.tasks import run_unit_task
+
+        with (
+            patch(
+                "georiva.processing.engine.run_unit",
+                return_value=UnitResult(status="not_ready"),
+            ),
+            patch(
+                "georiva.processing.invocation.dispatch_for_trigger"
+            ) as dispatch,
+        ):
+            run_unit_task.apply(
+                kwargs={"recipe_type": "fake_relevant", "unit": {"n": 1}}
+            )
+
+        dispatch.assert_not_called()
+
+
+class _Asset:
+    """A minimal asset-like object carrying just a checksum (for hashing)."""
+
+    def __init__(self, checksum):
+        self.checksum = checksum
+
+
+class _SweepRecipe(BaseRecipe):
+    """A recipe whose single input's checksum the test controls, to drive the
+    sweep's recorded-vs-current input_hash comparison."""
+
+    type = "sweep_fake"
+    version = "1"
+    checksum = "v1"
+
+    def enumerate_units(self, selector):
+        return []
+
+    def candidate_units(self, trigger):
+        return []
+
+    def resolve_inputs(self, unit):
+        from georiva.processing.recipe import ResolvedInput
+
+        return {
+            "src": ResolvedInput(
+                "src", required=True, items=[], assets=[_Asset(self.checksum)]
+            )
+        }
+
+    def outputs(self, unit):
+        return OutputItem(collection=None, time=None)
+
+    def transform(self, unit, resolved):
+        return []
+
+
+class SweepStalenessTests(_RegistryIsolationMixin, TestCase):
+    fake_recipes = [_SweepRecipe]
+
+    def _completed_run(self, recorded_hash):
+        from georiva.processing.models import DerivationRun
+        from georiva.processing.recipe import unit_hash
+
+        unit = {"n": 1}
+        return DerivationRun.objects.create(
+            recipe_type="sweep_fake", recipe_version="1",
+            unit_key=unit, unit_hash=unit_hash(unit),
+            input_hash=recorded_hash, status=DerivationRun.Status.COMPLETED,
+        )
+
+    def _current_hash(self):
+        from georiva.processing.recipe import compute_input_hash
+
+        recipe = _SweepRecipe()
+        return compute_input_hash(recipe.resolve_inputs({"n": 1}), recipe.version)
+
+    def test_stale_unit_is_recomputed_without_an_event(self):
+        from georiva.processing.tasks import sweep_derivations
+
+        # Recorded hash differs from current → the input changed.
+        self._completed_run(recorded_hash="STALE")
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            sweep_derivations.apply()
+
+        task.delay.assert_called_once()
+        self.assertEqual(task.delay.call_args.kwargs["recipe_type"], "sweep_fake")
+        self.assertEqual(task.delay.call_args.kwargs["unit"], {"n": 1})
+
+    def test_current_unit_is_not_recomputed(self):
+        from georiva.processing.tasks import sweep_derivations
+
+        # Recorded hash equals current → nothing to do.
+        self._completed_run(recorded_hash=self._current_hash())
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            sweep_derivations.apply()
+
+        task.delay.assert_not_called()
+
+    def test_sweep_propagates_through_intermediates(self):
+        """A stale unit's recompute also invalidates items derived from its
+        output — in one pass, before the intermediate has recomputed."""
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Catalog, Collection, Item
+        from georiva.processing.models import DerivationRun
+        from georiva.processing.recipe import unit_hash
+        from georiva.processing.tasks import sweep_derivations
+        from georiva.staging.models import DerivationLink
+
+        t = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        catalog = Catalog.objects.create(name="C2", slug="c2", file_format="geotiff")
+
+        # B is the stale unit's product (sweep_fake, recorded ≠ current).
+        bcol = Collection.objects.create(catalog=catalog, slug="b2", name="b2")
+        b = Item.objects.create(collection=bcol, time=t)
+        b_unit = {"n": 1}
+        DerivationRun.objects.create(
+            recipe_type="sweep_fake", recipe_version="1",
+            unit_key=b_unit, unit_hash=unit_hash(b_unit),
+            input_hash="STALE", status=DerivationRun.Status.COMPLETED,
+            produced_item=b,
+        )
+
+        # C is derived from B (a further product). Its own input (B) hasn't
+        # changed yet, so only the forward walk reaches it.
+        ccol = Collection.objects.create(catalog=catalog, slug="c2c", name="c2c")
+        c = Item.objects.create(collection=ccol, time=t)
+        c_unit = {"id": "C"}
+        DerivationRun.objects.create(
+            recipe_type="recipe_c", recipe_version="1",
+            unit_key=c_unit, unit_hash=unit_hash(c_unit),
+            input_hash="hc", status=DerivationRun.Status.COMPLETED,
+            produced_item=c,
+        )
+        DerivationLink.objects.create(
+            derived_item=c, source_published_item=b,
+            recipe_id="recipe_c", recipe_version="1", input_hash="hc",
+        )
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            sweep_derivations.apply()
+
+        dispatched = {
+            (call.kwargs["recipe_type"], tuple(sorted(call.kwargs["unit"].items())))
+            for call in task.delay.call_args_list
+        }
+        self.assertIn(("sweep_fake", (("n", 1),)), dispatched)   # the stale unit
+        self.assertIn(("recipe_c", (("id", "C"),)), dispatched)  # propagated downstream
+
+
+class ForwardInvalidationTests(TestCase):
+    """A changed input invalidates its derived items transitively — walking
+    DerivationLink forward through internal intermediates (A → B → C)."""
+
+    def setUp(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Catalog, Collection, Item
+        from georiva.processing.models import DerivationRun
+        from georiva.processing.recipe import unit_hash
+        from georiva.staging.models import (
+            DerivationLink,
+            StagingCollection,
+            StagingItem,
+        )
+
+        t = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        catalog = Catalog.objects.create(name="C", slug="c", file_format="geotiff")
+
+        # A: staging input.
+        scol = StagingCollection.objects.create(catalog=catalog, slug="a", name="a")
+        self.A = StagingItem.objects.create(collection=scol, datetime=t)
+
+        # B: internal intermediate derived from A.
+        bcol = Collection.objects.create(
+            catalog=catalog, slug="b", name="b",
+            visibility=Collection.Visibility.INTERNAL,
+        )
+        self.B = Item.objects.create(collection=bcol, time=t)
+        DerivationRun.objects.create(
+            recipe_type="recipe_b", recipe_version="1",
+            unit_key={"id": "B"}, unit_hash=unit_hash({"id": "B"}),
+            status=DerivationRun.Status.COMPLETED, produced_item=self.B,
+        )
+        DerivationLink.objects.create(
+            derived_item=self.B, source_staging_item=self.A,
+            recipe_id="recipe_b", recipe_version="1", input_hash="hb",
+        )
+
+        # C: product derived from B.
+        ccol = Collection.objects.create(catalog=catalog, slug="cc", name="cc")
+        self.C = Item.objects.create(collection=ccol, time=t)
+        DerivationRun.objects.create(
+            recipe_type="recipe_c", recipe_version="1",
+            unit_key={"id": "C"}, unit_hash=unit_hash({"id": "C"}),
+            status=DerivationRun.Status.COMPLETED, produced_item=self.C,
+        )
+        DerivationLink.objects.create(
+            derived_item=self.C, source_published_item=self.B,
+            recipe_id="recipe_c", recipe_version="1", input_hash="hc",
+        )
+
+    def test_changed_input_recomputes_downstream_transitively(self):
+        from georiva.processing.invocation import invalidate_downstream
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            invalidate_downstream(self.A)
+
+        dispatched = {
+            (c.kwargs["recipe_type"], c.kwargs["unit"]["id"])
+            for c in task.delay.call_args_list
+        }
+        self.assertEqual(dispatched, {("recipe_b", "B"), ("recipe_c", "C")})
+
+    def test_invalidating_intermediate_recomputes_only_below_it(self):
+        from georiva.processing.invocation import invalidate_downstream
+
+        # Changing B (not A) should recompute C only.
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            invalidate_downstream(self.B)
+
+        dispatched = {
+            (c.kwargs["recipe_type"], c.kwargs["unit"]["id"])
+            for c in task.delay.call_args_list
+        }
+        self.assertEqual(dispatched, {("recipe_c", "C")})
+
+
+class ClimatologyCandidateUnitsTests(TestCase):
+    """Climatology is scheduled/manual, not event-driven: it needs period
+    config an arriving input can't supply, so it ignores bare event triggers
+    (and never crashes when fanned out across recipes for an input event)."""
+
+    def test_ignores_event_trigger(self):
+        from georiva.processing.recipes.climatology import ClimatologyRecipe
+
+        units = list(
+            ClimatologyRecipe().candidate_units({"staging_item_id": 5})
+        )
+        self.assertEqual(units, [])
+
+    def test_full_selector_still_enumerates(self):
+        from georiva.processing.recipes.climatology import ClimatologyRecipe
+
+        selector = {
+            "source_collection": "tas", "variable": "tas",
+            "periods": [[2011, 2040]], "seasons": ["annual"],
+            "quantities": ["value"],
+        }
+        units = list(ClimatologyRecipe().candidate_units(selector))
+        self.assertEqual(len(units), 1)


### PR DESCRIPTION
Closes #125.

Completes the engine's "streaming and backfill are one primitive" goal: event-driven, scheduled/backfill, and the periodic sweep are all thin callers of the one `run(recipe, selector)` primitive.

## The unifying change
`run(recipe, selector)` now enumerates via **`candidate_units(selector)`** instead of `enumerate_units`. The base `candidate_units` delegates to `enumerate_units`, so a wide range selector still enumerates many units (backfill) while a narrow arriving-input trigger maps to just the units it feeds (streaming) — one primitive, selector width the only difference (ADR-0005). Backward-compatible: all prior engine/multi-input/climatology tests pass.

## New surface (`processing/invocation.py` + tasks + beat)
- **`dispatch_for_trigger(trigger)`** — fans an arriving input to every registered recipe; each recipe's `candidate_units` claims only what it consumes. Hooked into `process_staging_file` (new StagingItem) and `run_unit_task`'s post-completion path (a produced intermediate streams to its consumers).
- **`sweep_derivations`** task (periodic, beat-registered; mirror of `sweep_unprocessed`) — recomputes units whose recorded `input_hash` ≠ current input checksums, **without an event**.
- **`invalidate_downstream(item)`** — walks `DerivationLink` forward transitively (through internal intermediates), re-dispatching each downstream unit. The sweep calls it so a stale A→B also recomputes C in one pass.
- Recipe `candidate_units` overrides: `PromotionRecipe` (staging trigger → 1:1, ignores Published-item triggers), `ClimatologyRecipe` (scheduled-only, ignores bare event triggers). Scheduled/backfill over a range stays on the existing `run_recipe` management command.

## Tests → acceptance criteria
| Acceptance criterion | Test(s) |
|---|---|
| Arriving input triggers exactly its units (and no others) | `RunUsesCandidateUnitsTests`, `DispatchForTriggerTests`, `StagingConsumerHookTests`, `Promotion`/`ClimatologyCandidateUnitsTests` (incl. the published-trigger over-fire guard) |
| Scheduled/backfill over a date range fans out per-unit tasks | `ScheduledBackfillTests` |
| Sweep recomputes a stale unit without an event (no-op when current) | `SweepStalenessTests` |
| Forward invalidation transitive through internal intermediates | `ForwardInvalidationTests`, `SweepStalenessTests.test_sweep_propagates_through_intermediates` |
| All paths funnel through the one primitive (no duplicated orchestration) | structural — event/scheduled go through `run()`; sweep/invalidation re-dispatch known units via the same `run_unit_task` that `run()` fans out to (no re-enumeration) |

All compute (`run_unit_task`) is mocked in the tests.

## Notes
- The sweep and forward-invalidation re-dispatch *known* units (from `DerivationRun`/`DerivationLink`) via the same per-unit `run_unit_task` that `run()` fans out to — they skip re-enumeration rather than duplicating orchestration.
- `candidate_units(input)`, deferred from #124, lands here as the event→unit mapping the streaming path needs.
- **Full suite: 411/411 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)