### PR TITLE
feat(ingestion): sweep_staging — reconcile staging bucket against StagingItems

### DIFF
--- a/georiva/src/georiva/ingestion/management/commands/sweep_staging.py
+++ b/georiva/src/georiva/ingestion/management/commands/sweep_staging.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Reconcile the STAGING bucket against StagingItems: register any staged "
+        "object that has no StagingItem (event missed, consumer down, or DB reset "
+        "with the bucket intact), without re-downloading."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--async",
+            action="store_true",
+            dest="async_mode",
+            default=False,
+            help="Queue files via Celery instead of registering synchronously.",
+        )
+
+    def handle(self, *args, **options):
+        from georiva.ingestion.tasks import sweep_staging
+
+        self.stdout.write("Running sweep_staging...")
+        count = sweep_staging(sync=not options["async_mode"])
+        self.stdout.write(self.style.SUCCESS(
+            f"Sweep complete: {count} new staging file(s) registered."
+        ))

--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -238,6 +238,47 @@ def sweep_unprocessed(sync: bool = False):
     )
 
 
+@app.task(name="georiva.ingestion.tasks.sweep_staging", queue="georiva-default")
+def sweep_staging(sync: bool = False):
+    """
+    Reconcile the STAGING bucket against StagingItems — the staging-tier mirror
+    of sweep_unprocessed.
+
+    The staging path is event-driven (MinIO PUT → Redis → register_staging_file),
+    so an object that landed while the consumer was down, or that survives a DB
+    reset with the bucket intact, has no StagingItem. This scans the bucket and
+    registers exactly those objects (no re-download), firing derivation for each.
+
+    An object is "known" if a StagingAsset already references its key as href.
+    Returns the number of files dispatched for registration.
+    """
+    from georiva.staging.models import StagingAsset
+
+    dispatch = process_staging_file.run if sync else process_staging_file.delay
+
+    bucket = storage.bucket(BucketType.STAGING)
+    known = set(StagingAsset.objects.values_list("href", flat=True))
+
+    dispatched = 0
+    for f in bucket.list_files(recursive=True):
+        key = f["path"]
+        name = Path(key).name
+        if name.startswith(".") or name == ".keep":
+            continue
+        if key in known:
+            continue
+        try:
+            validate_path(key)
+        except ValueError:
+            logger.debug("sweep_staging: skipping non-conforming path: %s", key)
+            continue
+        dispatch(bucket=BucketType.STAGING, key=key)
+        dispatched += 1
+
+    logger.info("sweep_staging: dispatched %d new staging file(s)", dispatched)
+    return dispatched
+
+
 @app.task(name="georiva.ingestion.tasks.cleanup_archives", queue="georiva-default")
 def cleanup_archives(max_age_days: int = 5):
     from georiva.core.storage import storage, BucketType

--- a/georiva/src/georiva/ingestion/tests/test_sweep_staging.py
+++ b/georiva/src/georiva/ingestion/tests/test_sweep_staging.py
@@ -1,0 +1,59 @@
+"""
+Tests for sweep_staging — the staging-tier reconcile.
+
+The staging path is event-driven (MinIO PUT → Redis → register_staging_file), so
+an object that lands while the consumer is down, or survives a DB reset, has no
+StagingItem. sweep_staging scans the bucket and registers exactly those, without
+re-downloading. Mirror of sweep_unprocessed for the staging tier.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from georiva.core.models import Catalog
+from georiva.core.storage import BucketType
+from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
+
+
+class SweepStagingTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="chirps-monthly", name="m"
+        )
+
+    def _already_registered(self, key):
+        item = StagingItem.objects.create(collection=self.scol)
+        StagingAsset.objects.create(item=item, href=key, roles=["source"])
+
+    def _run_with_bucket(self, keys):
+        with patch("georiva.ingestion.tasks.storage") as mock_storage, \
+                patch("georiva.ingestion.tasks.process_staging_file") as mock_task:
+            mock_storage.bucket.return_value.list_files.return_value = [
+                {"path": k} for k in keys
+            ]
+            from georiva.ingestion.tasks import sweep_staging
+            count = sweep_staging(sync=True)
+        return count, mock_task
+
+    def test_registers_only_objects_without_a_staging_item(self):
+        self._already_registered("chirps/chirps-monthly/a.tif")
+        count, mock_task = self._run_with_bucket([
+            "chirps/chirps-monthly/a.tif",   # already registered → skip
+            "chirps/chirps-monthly/b.tif",   # new → register
+        ])
+
+        self.assertEqual(count, 1)
+        mock_task.run.assert_called_once_with(
+            bucket=BucketType.STAGING, key="chirps/chirps-monthly/b.tif"
+        )
+
+    def test_skips_hidden_files(self):
+        count, mock_task = self._run_with_bucket([
+            "chirps/chirps-monthly/.keep",
+        ])
+
+        self.assertEqual(count, 0)
+        mock_task.run.assert_not_called()


### PR DESCRIPTION
Adds `sweep_staging` — the staging-tier mirror of `sweep_unprocessed`.

## Why
The staging path is purely event-driven (MinIO PUT → Redis staging-events → `register_staging_file`). If an object lands while the consumer is down, or the bucket survives a DB reset, there is **no built-in way to reconcile it** — `sweep_unprocessed` only scans the `INCOMING`/`SOURCES` buckets, not `STAGING`. So a re-run of a feed just logs everything as "skipped (already exists)" and rebuilds nothing.

## What
- `sweep_staging(sync=False)` task: lists the `STAGING` bucket, skips hidden + non-conforming paths, skips objects already registered (known by `StagingAsset.href`), and dispatches `process_staging_file` for the rest (registers + fires derivation) — no re-download.
- `georiva sweep_staging [--async]` management command, mirroring `sweep_unprocessed`.

## Tests
`ingestion/tests/test_sweep_staging.py` — registers only unregistered objects; skips hidden files. Full ingestion suite green (270).

🤖 Generated with [Claude Code](https://claude.com/claude-code)