### PR TITLE
Derived-product contract + declarative inputs (ADR-0008 slice 1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,18 @@ engine does), but may override individual steps via hooks. Recipe families (Clim
 post-processing, Impact-based) register without editing the engine.
 _Avoid_: processor, operator, derivation (Recipe is the spec; Derivation is the act)
 
+**Derived Product Definition**:
+The generic, plugin-agnostic blueprint (ADR-0008) declaring one derived product a feed offers: `recipe_type`, a human
+`label`/`description`, a `config_schema` (operator options), declared `inputs`/`outputs` (as `InputRef`/`OutputRef`),
+and a `trigger_mode` (`event | scheduled | manual`). Pure declaration in `core` — no DB, no engine import — so both
+the feed layer (`sources`) and the engine (`processing`) can read it without a backwards dependency. Returned by
+`DataFeed.get_derived_products()`. The dependency graph and product readiness are computed from this declaration
+**without executing the recipe**. A **product is an edge** in the chain DAG (consumes input collections, emits output
+collections); a **`Collection` is a node**. A product is **not** a `Collection`: one product may emit several output
+`Collection`s. Mirrors `CollectionDefinition`.
+_Avoid_: DerivedCollection (a product is not a collection); conflating the blueprint with the persisted `DerivedProduct`
+config (a `DataFeed` child, ADR-0008 / slice 2)
+
 **Production Unit**:
 The atomic, opaque, hashable coordinate the engine iterates over — one unit produces one output slice. Its
 **semantics are owned by the Recipe**, not the engine (e.g. climatology = `(variable, period, season, quantity,

--- a/georiva/src/georiva/core/derived_products.py
+++ b/georiva/src/georiva/core/derived_products.py
@@ -1,0 +1,115 @@
+"""
+Generic derived-product contract (ADR-0008).
+
+Plugins declare the derived products a feed offers by implementing
+``DataFeed.get_derived_products()`` and returning a list of
+``DerivedProductDefinition``. This is the single source of truth the wizard
+(form + validation), invocation (selector building), tracking (run grouping),
+and chain UI (the planned DAG) all read from.
+
+The contract is **pure declaration** — dataclasses with string enums and no
+database or engine imports. It lives in ``core`` so both the feed layer
+(``sources``) and the engine (``processing``) can import it without a backwards
+dependency (ADR-0005): the engine must not depend on the feed layer, and a
+shared declaration in ``core`` keeps the contract reachable from both.
+
+The DB-backed resolution of a declared ``InputRef`` into the catalog items it
+points at lives in ``processing`` (``resolve_declared_inputs``), not here, so
+``core`` stays free of ``staging``/``processing`` imports.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+TRIGGER_MODES = ("event", "scheduled", "manual")
+CONFIG_FIELD_TYPES = ("str", "int", "float", "bool", "choice")
+TIERS = ("staging", "published")
+
+
+@dataclass(frozen=True)
+class InputRef:
+    """One declared input a product consumes: a collection at a tier."""
+    role: str
+    collection: str
+    tier: str
+    required: bool = True
+
+    def __post_init__(self):
+        if not self.role:
+            raise ValueError("InputRef: 'role' is required and must be non-empty")
+        if not self.collection:
+            raise ValueError("InputRef: 'collection' is required and must be non-empty")
+        if self.tier not in TIERS:
+            raise ValueError(
+                f"InputRef '{self.role}': tier must be one of {TIERS}, got '{self.tier}'"
+            )
+
+
+@dataclass(frozen=True)
+class OutputRef:
+    """One collection a product produces."""
+    role: str
+    collection: str
+
+    def __post_init__(self):
+        if not self.role:
+            raise ValueError("OutputRef: 'role' is required and must be non-empty")
+        if not self.collection:
+            raise ValueError("OutputRef: 'collection' is required and must be non-empty")
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """One operator-configurable option, driving the wizard form + validation."""
+    key: str
+    type: str
+    default: object = None
+    choices: tuple = None
+
+    def __post_init__(self):
+        if self.type not in CONFIG_FIELD_TYPES:
+            raise ValueError(
+                f"ConfigField '{self.key}': type must be one of "
+                f"{CONFIG_FIELD_TYPES}, got '{self.type}'"
+            )
+        if self.type == "choice":
+            if not self.choices:
+                raise ValueError(f"ConfigField '{self.key}': choice type requires 'choices'")
+            if self.default is not None and self.default not in self.choices:
+                raise ValueError(
+                    f"ConfigField '{self.key}': default '{self.default}' is not "
+                    f"among choices {self.choices}"
+                )
+
+
+@dataclass(frozen=True)
+class DerivedProductDefinition:
+    """Blueprint for one derived product a feed can produce (mirrors
+    CollectionDefinition)."""
+    key: str
+    recipe_type: str
+    label: str
+    description: str
+    config_schema: tuple
+    inputs: tuple
+    outputs: tuple
+    trigger_mode: str
+
+    def __post_init__(self):
+        for field in ("key", "recipe_type", "label"):
+            if not getattr(self, field):
+                raise ValueError(
+                    f"DerivedProductDefinition: '{field}' is required and must be non-empty"
+                )
+        if self.trigger_mode not in TRIGGER_MODES:
+            raise ValueError(
+                f"DerivedProductDefinition '{self.key}': trigger_mode must be "
+                f"one of {TRIGGER_MODES}, got '{self.trigger_mode}'"
+            )
+
+    def dependency_edges(self) -> list:
+        """The input collections this product consumes, as
+        ``(collection, tier, required)`` tuples — the product's incoming edges
+        in the chain DAG. Pure: derived from the declaration with no DB access
+        or recipe execution."""
+        return [(ref.collection, ref.tier, ref.required) for ref in self.inputs]

--- a/georiva/src/georiva/core/test_derived_products.py
+++ b/georiva/src/georiva/core/test_derived_products.py
@@ -1,0 +1,142 @@
+"""
+Tests for the generic derived-product contract (ADR-0008, issue #143).
+
+The contract is pure declaration: dataclasses plugins implement to describe the
+derived products a feed offers. These tests assert validation and the
+declaration-derived dependency graph — no DB, no recipe execution. The DB-backed
+resolver (InputRef -> ResolvedInput) is tested in the processing app.
+
+Mirrors the validation style of sources/collection_definitions.py's
+CollectionVariable.
+"""
+from django.test import SimpleTestCase
+
+from georiva.core.derived_products import (
+    ConfigField,
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+
+
+class InputRefTests(SimpleTestCase):
+    def test_staging_and_published_tiers_are_accepted(self):
+        for tier in ("staging", "published"):
+            self.assertEqual(
+                InputRef(role="value", collection="rainfall", tier=tier).tier, tier
+            )
+
+    def test_unknown_tier_is_rejected(self):
+        with self.assertRaises(ValueError):
+            InputRef(role="value", collection="rainfall", tier="archive")
+
+    def test_required_defaults_to_true(self):
+        self.assertTrue(
+            InputRef(role="value", collection="rainfall", tier="staging").required
+        )
+
+    def test_empty_role_or_collection_is_rejected(self):
+        with self.assertRaises(ValueError):
+            InputRef(role="", collection="rainfall", tier="staging")
+        with self.assertRaises(ValueError):
+            InputRef(role="value", collection="", tier="staging")
+
+
+class OutputRefTests(SimpleTestCase):
+    def test_valid_output_exposes_its_fields(self):
+        ref = OutputRef(role="anomaly", collection="rainfall-anomaly")
+        self.assertEqual(ref.collection, "rainfall-anomaly")
+
+    def test_empty_role_or_collection_is_rejected(self):
+        with self.assertRaises(ValueError):
+            OutputRef(role="", collection="rainfall-anomaly")
+        with self.assertRaises(ValueError):
+            OutputRef(role="anomaly", collection="")
+
+
+def _definition(**overrides):
+    """A minimal valid DerivedProductDefinition, overridable per-test."""
+    kwargs = dict(
+        key="anomaly",
+        recipe_type="climatology",
+        label="Rainfall anomaly",
+        description="Anomaly vs a baseline climatology.",
+        config_schema=(),
+        inputs=(InputRef(role="value", collection="rainfall", tier="staging"),),
+        outputs=(OutputRef(role="anomaly", collection="rainfall-anomaly"),),
+        trigger_mode="scheduled",
+    )
+    kwargs.update(overrides)
+    return DerivedProductDefinition(**kwargs)
+
+
+class DerivedProductDefinitionTests(SimpleTestCase):
+    def test_valid_definition_exposes_its_fields(self):
+        definition = _definition()
+
+        self.assertEqual(definition.key, "anomaly")
+        self.assertEqual(definition.recipe_type, "climatology")
+        self.assertEqual(definition.label, "Rainfall anomaly")
+        self.assertEqual(definition.trigger_mode, "scheduled")
+        self.assertEqual(definition.inputs[0].collection, "rainfall")
+        self.assertEqual(definition.outputs[0].collection, "rainfall-anomaly")
+
+    def test_unknown_trigger_mode_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _definition(trigger_mode="hourly")
+
+    def test_event_scheduled_manual_trigger_modes_are_accepted(self):
+        for mode in ("event", "scheduled", "manual"):
+            self.assertEqual(_definition(trigger_mode=mode).trigger_mode, mode)
+
+    def test_empty_required_field_is_rejected(self):
+        for field in ("key", "recipe_type", "label"):
+            with self.subTest(field=field):
+                with self.assertRaises(ValueError):
+                    _definition(**{field: ""})
+
+    def test_dependency_edges_derived_from_declared_inputs(self):
+        # The dependency graph is computable from the declaration alone — no DB,
+        # no recipe execution — so the chain UI and readiness can be built ahead
+        # of any run.
+        definition = _definition(inputs=(
+            InputRef(role="value", collection="rainfall", tier="staging"),
+            InputRef(role="normals", collection="rainfall-normals",
+                     tier="published", required=False),
+        ))
+
+        self.assertEqual(
+            definition.dependency_edges(),
+            [
+                ("rainfall", "staging", True),
+                ("rainfall-normals", "published", False),
+            ],
+        )
+
+
+class ConfigFieldTests(SimpleTestCase):
+    def test_valid_field_types_are_accepted(self):
+        for type_ in ("str", "int", "float", "bool"):
+            self.assertEqual(ConfigField(key="opt", type=type_).type, type_)
+
+    def test_unknown_field_type_is_rejected(self):
+        with self.assertRaises(ValueError):
+            ConfigField(key="opt", type="datetime")
+
+    def test_choice_field_requires_choices(self):
+        with self.assertRaises(ValueError):
+            ConfigField(key="quantity", type="choice")
+
+    def test_choice_default_must_be_among_choices(self):
+        with self.assertRaises(ValueError):
+            ConfigField(
+                key="quantity", type="choice",
+                choices=("anomaly", "value"), default="trend",
+            )
+
+    def test_choice_default_within_choices_is_accepted(self):
+        field = ConfigField(
+            key="quantity", type="choice",
+            choices=("anomaly", "value"), default="anomaly",
+        )
+        self.assertEqual(field.default, "anomaly")

--- a/georiva/src/georiva/processing/recipe.py
+++ b/georiva/src/georiva/processing/recipe.py
@@ -59,6 +59,39 @@ class ResolvedInput:
         return [getattr(a, "checksum", "") for a in self.assets]
 
 
+def resolve_declared_inputs(inputs, *, unit=None) -> "dict[str, ResolvedInput]":
+    """
+    Resolve a product's declared ``InputRef``s into ``ResolvedInput``s by
+    querying the catalog — the StagingItem tier for ``tier="staging"`` inputs,
+    the Published Item tier for ``tier="published"`` — filtered by collection
+    slug (ADR-0008).
+
+    This is the engine-side glue that lets a recipe consume *declared* inputs
+    instead of hardcoding slugs in ``resolve_inputs``: the dependency graph and
+    product readiness become computable from the declaration. An input whose
+    collection has no rows resolves to an absent (``present=False``)
+    ``ResolvedInput`` keyed by its role, which is how readiness reports a blocked
+    product. ``unit`` is accepted for forward compatibility (per-unit time
+    narrowing arrives with product-driven invocation) and is unused here.
+    """
+    from georiva.core.models import Item
+    from georiva.staging.models import StagingItem
+
+    resolved: dict[str, ResolvedInput] = {}
+    for ref in inputs:
+        model = StagingItem if ref.tier == "staging" else Item
+        items = list(
+            model.objects
+            .filter(collection__slug=ref.collection)
+            .prefetch_related("assets")
+        )
+        assets = [a for it in items for a in it.assets.all()]
+        resolved[ref.role] = ResolvedInput(
+            ref.role, required=ref.required, items=items, assets=assets
+        )
+    return resolved
+
+
 @dataclass
 class OutputItem:
     """The Published Item a unit maps to. The recipe owns this mapping."""
@@ -110,9 +143,23 @@ class BaseRecipe(ABC):
     def enumerate_units(self, selector: Any) -> Iterable[ProductionUnit]:
         """Which ProductionUnits does this selector cover?"""
 
-    @abstractmethod
+    def declared_inputs(self, unit: ProductionUnit) -> list:
+        """
+        The ``InputRef``s this recipe consumes for one unit (ADR-0008). Default:
+        none. A declaration-driven recipe returns its product definition's
+        inputs here, so the default ``resolve_inputs`` — and the dependency
+        graph and readiness — work without a bespoke override.
+        """
+        return []
+
     def resolve_inputs(self, unit: ProductionUnit) -> "dict[str, ResolvedInput]":
-        """Resolve the named input selectors for one unit."""
+        """
+        Resolve the named input selectors for one unit. The default consumes the
+        recipe's ``declared_inputs`` (no hardcoded slugs); recipes whose
+        per-unit selection needs more than a collection/tier lookup (e.g.
+        Promotion's per-``staging_item_id`` resolution) override this.
+        """
+        return resolve_declared_inputs(self.declared_inputs(unit), unit=unit)
 
     def readiness(self, unit: ProductionUnit, resolved: "dict[str, ResolvedInput]") -> bool:
         """Default: every required input resolved to at least one item."""

--- a/georiva/src/georiva/processing/tests/test_derived_inputs.py
+++ b/georiva/src/georiva/processing/tests/test_derived_inputs.py
@@ -1,0 +1,135 @@
+"""
+Declaration-driven input resolution (ADR-0008, issue #143).
+
+resolve_declared_inputs turns a product's declared InputRefs into the engine's
+ResolvedInput objects, querying the StagingItem tier or the Published Item tier
+by collection slug. This is the seam that lets resolve_inputs consume declared
+inputs instead of hardcoded slugs — so readiness and the dependency graph are
+computed from the declaration, not from running a recipe.
+
+Mirrors the fixture style of test_multi_input.py (real catalog/staging rows,
+asserting the resolved result).
+"""
+from datetime import datetime, timezone
+
+from django.test import TestCase
+
+from georiva.core.derived_products import InputRef
+from georiva.core.models import Asset, Catalog, Collection, Item, Unit, Variable
+from georiva.processing.recipe import BaseRecipe, resolve_declared_inputs
+from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
+
+_TIME = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+class ResolveDeclaredInputsTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.unit_dim, _ = Unit.objects.get_or_create(
+            symbol="mm", defaults={"name": "millimetre"}
+        )
+
+        # Staging tier: a raw rainfall series.
+        self.staging_col = StagingCollection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        # Published tier: a normals product.
+        self.pub_col = Collection.objects.create(
+            catalog=self.catalog, slug="rainfall-normals", name="Normals"
+        )
+        self.pub_var = Variable.objects.create(
+            collection=self.pub_col, slug="normals", name="Normals",
+            unit=self.unit_dim, value_min=0, value_max=2000,
+        )
+
+    def _add_staging(self):
+        si = StagingItem.objects.create(
+            collection=self.staging_col, datetime=_TIME,
+            bounds=[0, 0, 8, 8], crs="EPSG:4326", width=4, height=4,
+        )
+        StagingAsset.objects.create(
+            item=si, href="chirps/rainfall/r.tif", roles=["source"],
+            format="geotiff", checksum="rain-1",
+        )
+        return si
+
+    def _add_published(self):
+        item = Item.objects.create(
+            collection=self.pub_col, time=_TIME,
+            bounds=[0, 0, 8, 8], crs="EPSG:4326", width=4, height=4,
+        )
+        Asset.objects.create(
+            item=item, variable=self.pub_var, format="cog",
+            href="chirps/normals/n.tif", roles=["data"], checksum="norm-1",
+            width=4, height=4,
+        )
+        return item
+
+    def test_staging_input_resolves_to_staging_items(self):
+        si = self._add_staging()
+
+        resolved = resolve_declared_inputs(
+            [InputRef(role="value", collection="rainfall", tier="staging")]
+        )
+
+        ri = resolved["value"]
+        self.assertTrue(ri.present)
+        self.assertEqual([it.pk for it in ri.items], [si.pk])
+        self.assertEqual(ri.checksums, ["rain-1"])
+
+    def test_published_input_resolves_to_published_items(self):
+        item = self._add_published()
+
+        resolved = resolve_declared_inputs(
+            [InputRef(role="normals", collection="rainfall-normals", tier="published")]
+        )
+
+        ri = resolved["normals"]
+        self.assertTrue(ri.present)
+        self.assertEqual([it.pk for it in ri.items], [item.pk])
+
+    def test_required_flag_is_carried_through(self):
+        resolved = resolve_declared_inputs([
+            InputRef(role="value", collection="rainfall", tier="staging"),
+            InputRef(role="normals", collection="rainfall-normals",
+                     tier="published", required=False),
+        ])
+
+        self.assertTrue(resolved["value"].required)
+        self.assertFalse(resolved["normals"].required)
+
+    def test_empty_collection_resolves_to_absent_input(self):
+        # No rows added: the declared input is keyed but not present, which is
+        # how product readiness detects a blocked (empty-input) product.
+        resolved = resolve_declared_inputs(
+            [InputRef(role="value", collection="rainfall", tier="staging")]
+        )
+
+        self.assertIn("value", resolved)
+        self.assertFalse(resolved["value"].present)
+
+    def test_recipe_declaring_inputs_resolves_them_without_an_override(self):
+        # A declaration-driven recipe sets declared_inputs and inherits the
+        # default resolve_inputs — no hardcoded slugs in a bespoke override.
+        si = self._add_staging()
+
+        class _DeclarativeRecipe(BaseRecipe):
+            type = "declarative_fixture"
+
+            def declared_inputs(self, unit):
+                return [InputRef(role="value", collection="rainfall", tier="staging")]
+
+            def enumerate_units(self, selector):
+                return [{}]
+
+            def outputs(self, unit):
+                return None
+
+            def transform(self, unit, resolved):
+                return []
+
+        resolved = _DeclarativeRecipe().resolve_inputs({})
+
+        self.assertEqual([it.pk for it in resolved["value"].items], [si.pk])

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -16,6 +16,7 @@ from wagtail.admin.panels import FieldPanel
 from .source import BaseDataSource
 
 if TYPE_CHECKING:
+    from georiva.core.derived_products import DerivedProductDefinition
     from georiva.sources.collection_definitions import CollectionDefinition
 
 
@@ -148,7 +149,20 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
         selected definition.
         """
         return []
-    
+
+    def get_derived_products(self) -> list['DerivedProductDefinition']:
+        """
+        Return the derived products this feed offers (ADR-0008).
+
+        An instance method (unlike get_collection_definitions): a product's
+        declared inputs/outputs bind to this feed's actual collections, which is
+        instance state. Override in subclasses to declare every
+        DerivedProductDefinition the plugin produces. The wizard's "Derived
+        Products" step presents these; invocation, tracking, and the chain UI
+        all read from the same declarations.
+        """
+        return []
+
     # =========================================================================
     # Collection link helpers
     # =========================================================================

--- a/georiva/src/georiva/sources/tests/test_derived_products.py
+++ b/georiva/src/georiva/sources/tests/test_derived_products.py
@@ -1,0 +1,19 @@
+"""
+DataFeed's derived-product declaration hook (ADR-0008, issue #143).
+
+A feed declares the derived products it offers via get_derived_products(); the
+base default is none. Plugins override to return DerivedProductDefinitions bound
+to their configured collections.
+"""
+from django.test import TestCase
+
+from georiva.core.models import Catalog
+from georiva.sources.models import DataFeed
+
+
+class GetDerivedProductsTests(TestCase):
+    def test_defaults_to_empty_list(self):
+        catalog = Catalog.objects.create(name="CHIRPS", slug="chirps", file_format="geotiff")
+        feed = DataFeed.objects.create(name="Feed", catalog=catalog)
+
+        self.assertEqual(feed.get_derived_products(), [])


### PR DESCRIPTION
Implements **#143** (ADR-0008 slice 1). Built test-first (red-green, one behavior per cycle).

## What this lands

The generic, plugin-agnostic blueprint plugins implement to *declare* the derived products a feed offers — the foundation the wizard, invocation, tracking, and chain UI all read from. Pure declarative seam: no persistence, no UI.

### `core/derived_products.py` (new)
- `InputRef(role, collection, tier, required=True)` — validates non-empty fields, `tier ∈ {staging, published}`
- `OutputRef(role, collection)` — validates non-empty fields
- `ConfigField(key, type, default, choices)` — `type ∈ {str,int,float,bool,choice}`; a `choice` requires `choices` + an in-range `default`
- `DerivedProductDefinition(...)` — validates required fields + `trigger_mode ∈ {event,scheduled,manual}`; `dependency_edges()` derives the chain-DAG edges **without DB or recipe execution**

Lives in `core` (not `processing`) so both `sources` and `processing` can import it without a backwards dependency — the engine must not depend on the feed layer (ADR-0005).

### `processing/recipe.py`
- `resolve_declared_inputs(inputs, *, unit=None)` — resolves declared `InputRef`s to `ResolvedInput`s by tier + collection slug (staging → `StagingItem`, published → `Item`)
- `BaseRecipe.declared_inputs()` hook + a default `resolve_inputs()` that consumes it; existing recipe overrides (promotion, climatology, multi-input) untouched

### `sources/models.py`
- `DataFeed.get_derived_products()` → `[]` by default. An **instance** method (unlike classmethod `get_collection_definitions`) since products bind to a feed's actual collections.

### `CONTEXT.md`
- Glossary entry for *Derived Product Definition*, recording **product = edge / `Collection` = node**.

## Tests
- `core/test_derived_products.py` — 16 contract validation + `dependency_edges` (`SimpleTestCase`, no DB)
- `processing/tests/test_derived_inputs.py` — 5 DB-seam resolver tests
- `sources/tests/test_derived_products.py` — `get_derived_products` default

Full `core`/`processing`/`sources` suites (91 tests) pass — no regressions.

## Out of scope (later slices)
Persistence (`DerivedProduct` model + wizard, #145), invocation flip (#147), migrating promotion/climatology recipes.

Refs #143