### PR TITLE
Product-driven invocation + selector config + origin stamping (ADR-0008 slice 5)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,22 @@ JSON validated against the definition's `config_schema`, `is_enabled` (pause wit
 output `Collection`s.
 _Avoid_: DerivedCollection; treating it as the blueprint (that is the Derived Product Definition)
 
+**Product-driven invocation**:
+The application-layer flip (ADR-0008) where an arriving input is routed to the enabled `DerivedProduct`s that *declare*
+it as an input — not fanned out to every recipe. `sources.derivation_invocation.dispatch_for_input(trigger)` matches the
+trigger's `(collection_slug, tier)` against each enabled product's declared `InputRef`s, builds
+`selector = {**config, **trigger}`, and calls the engine's generic `run(recipe, selector)`. It is the **only** place that
+joins `DerivedProduct` to the engine, so the engine never imports the feed layer (ADR-0005); the feed layer depending on
+the engine is the allowed direction. Event-driven products fall out of this for free.
+_Avoid_: recipe-driven dispatch (the pre-ADR-0008 fan-out); putting product routing in `processing`
+
+**Origin** (`DerivationRun.origin`):
+An opaque, nullable, indexed grouping key the invocation layer stamps on each `DerivationRun` with the product identity
+(`derived_product:{pk}`). The engine stores and indexes it but never interprets it; the tracking UI joins product → runs
+by it. `NULL` = no product origin (engine-internal or manual run). An engine-internal re-run (sweep/invalidation) passes
+no origin, so it never clobbers the original product stamp.
+_Avoid_: a hard `FK(DerivationRun → DerivedProduct)` (would make the engine depend on the feed layer)
+
 **Production Unit**:
 The atomic, opaque, hashable coordinate the engine iterates over — one unit produces one output slice. Its
 **semantics are owned by the Recipe**, not the engine (e.g. climatology = `(variable, period, season, quantity,

--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -92,11 +92,12 @@ def process_staging_file(self, bucket: str, key: str):
 
     item = register_staging_file(bucket=bucket, key=key)
     if item is not None:
-        from georiva.processing.invocation import (
-            dispatch_for_trigger,
-            staging_item_trigger,
-        )
-        dispatch_for_trigger(staging_item_trigger(item))
+        # Product-driven invocation (ADR-0008): route the arriving input to the
+        # enabled DerivedProducts that consume it, not to every recipe.
+        from georiva.processing.invocation import staging_item_trigger
+        from georiva.sources.derivation_invocation import dispatch_for_input
+
+        dispatch_for_input(staging_item_trigger(item))
 
 
 @app.task(name="georiva.ingestion.tasks.sweep_unprocessed", queue="georiva-default")

--- a/georiva/src/georiva/processing/engine.py
+++ b/georiva/src/georiva/processing/engine.py
@@ -161,12 +161,15 @@ def _is_current(out_item, recipe: BaseRecipe, input_hash: str) -> bool:
     return d.get("input_hash") == input_hash and d.get("version") == recipe.version
 
 
-def run_unit(recipe: BaseRecipe, unit: ProductionUnit, *, writer=None, worker_id="") -> UnitResult:
+def run_unit(recipe: BaseRecipe, unit: ProductionUnit, *, writer=None, worker_id="", origin=None) -> UnitResult:
     """
     Execute one ProductionUnit end to end, under the DerivationRun lock.
 
     Idempotent: an unchanged unit is a no-op; changed inputs (or recipe
     version) recompute and overwrite the Published Item in place.
+
+    ``origin`` is an opaque grouping key passed straight to the DerivationRun
+    (ADR-0008); the engine never interprets it.
     """
     from django.db import transaction
 
@@ -179,6 +182,7 @@ def run_unit(recipe: BaseRecipe, unit: ProductionUnit, *, writer=None, worker_id
         unit_key=unit,
         unit_hash=uhash,
         worker_id=worker_id,
+        origin=origin,
     )
     if run is None:
         logger.info("Unit already locked: %s %s", recipe.type, uhash[:8])
@@ -235,7 +239,7 @@ def _emit_event(recipe, unit, item, input_hash):
         logger.warning("Derivation event publish failed: %s", e)
 
 
-def run(recipe: BaseRecipe, selector, *, dispatch: bool = True, worker_id="") -> list:
+def run(recipe: BaseRecipe, selector, *, dispatch: bool = True, worker_id="", origin=None) -> list:
     """
     Enumerate candidate units for a selector and run each.
 
@@ -252,7 +256,7 @@ def run(recipe: BaseRecipe, selector, *, dispatch: bool = True, worker_id="") ->
     if dispatch:
         from .tasks import run_unit_task
         for unit in units:
-            run_unit_task.delay(recipe_type=recipe.type, unit=unit)
+            run_unit_task.delay(recipe_type=recipe.type, unit=unit, origin=origin)
         return [UnitResult(status="dispatched") for _ in units]
 
-    return [run_unit(recipe, unit, worker_id=worker_id) for unit in units]
+    return [run_unit(recipe, unit, worker_id=worker_id, origin=origin) for unit in units]

--- a/georiva/src/georiva/processing/models.py
+++ b/georiva/src/georiva/processing/models.py
@@ -87,12 +87,17 @@ class DerivationRun(TimeStampedModel):
         return dj_timezone.now() - self.locked_at > self.LOCK_TIMEOUT
 
     @classmethod
-    def acquire(cls, *, recipe_type, recipe_version, unit_key, unit_hash, worker_id="") -> "DerivationRun | None":
+    def acquire(cls, *, recipe_type, recipe_version, unit_key, unit_hash, worker_id="", origin=None) -> "DerivationRun | None":
         """
         Atomically take the lock for (recipe_type, unit_hash).
 
         Returns the locked, RUNNING DerivationRun on success, or None if another
         worker already holds a live lock on this unit.
+
+        ``origin`` is an opaque grouping key (ADR-0008) supplied by the
+        invocation layer. It is set when the run is first created and, on a
+        re-acquire, updated only when a non-None ``origin`` is given — so an
+        engine-internal re-run (origin=None) never clobbers a product's stamp.
         """
         now = dj_timezone.now()
         run, _ = cls.objects.get_or_create(
@@ -102,21 +107,14 @@ class DerivationRun(TimeStampedModel):
                 "recipe_version": recipe_version,
                 "unit_key": unit_key,
                 "status": cls.Status.PENDING,
+                "origin": origin,
             },
         )
 
         stale_cutoff = now - cls.LOCK_TIMEOUT
 
         # Lockable when pending/failed/idempotent-noop/not-ready, or a stale run.
-        claimed = cls.objects.filter(
-            pk=run.pk,
-        ).filter(
-            models.Q(status__in=[
-                cls.Status.PENDING, cls.Status.FAILED,
-                cls.Status.SKIPPED, cls.Status.NOT_READY, cls.Status.COMPLETED,
-            ])
-            | models.Q(status=cls.Status.RUNNING, locked_at__lt=stale_cutoff)
-        ).update(
+        claim_values = dict(
             status=cls.Status.RUNNING,
             recipe_version=recipe_version,
             unit_key=unit_key,
@@ -125,6 +123,20 @@ class DerivationRun(TimeStampedModel):
             started_at=now,
             error="",
         )
+        # Only (re)stamp origin when the caller supplies one — an engine-internal
+        # re-run (origin=None) must not erase the product origin set originally.
+        if origin is not None:
+            claim_values["origin"] = origin
+
+        claimed = cls.objects.filter(
+            pk=run.pk,
+        ).filter(
+            models.Q(status__in=[
+                cls.Status.PENDING, cls.Status.FAILED,
+                cls.Status.SKIPPED, cls.Status.NOT_READY, cls.Status.COMPLETED,
+            ])
+            | models.Q(status=cls.Status.RUNNING, locked_at__lt=stale_cutoff)
+        ).update(**claim_values)
 
         if not claimed:
             return None

--- a/georiva/src/georiva/processing/tasks.py
+++ b/georiva/src/georiva/processing/tasks.py
@@ -40,7 +40,7 @@ def setup_periodic_tasks(sender, **kwargs):
     acks_late=True,
     queue="georiva-processing",
 )
-def run_unit_task(self, recipe_type: str, unit: dict):
+def run_unit_task(self, recipe_type: str, unit: dict, origin: str = None):
     """Run a single ProductionUnit for a recipe (one DerivationRun)."""
     from georiva.processing.engine import run_unit
     from georiva.processing.registry import recipe_registry
@@ -51,7 +51,7 @@ def run_unit_task(self, recipe_type: str, unit: dict):
         return
 
     worker_id = self.request.id or ""
-    result = run_unit(recipe, unit, worker_id=worker_id)
+    result = run_unit(recipe, unit, worker_id=worker_id, origin=origin)
 
     # Completion chaining: a produced Published item is itself a derivation
     # input, so stream a downstream trigger to its consumers (internal

--- a/georiva/src/georiva/processing/tests/test_invocation.py
+++ b/georiva/src/georiva/processing/tests/test_invocation.py
@@ -217,52 +217,6 @@ class PromotionCandidateUnitsTests(_StagingFixture):
         self.assertEqual(units, [])
 
 
-class StagingConsumerHookTests(_StagingFixture):
-    """A registered StagingItem auto-triggers derivation for the units it
-    feeds — the staging-consumer event hook."""
-
-    def test_process_staging_file_dispatches_for_new_item(self):
-        from georiva.core.storage import BucketType
-        from georiva.ingestion.tasks import process_staging_file
-
-        with (
-            patch(
-                "georiva.ingestion.staging_consumer.register_staging_file",
-                return_value=self.sitem,
-            ),
-            patch(
-                "georiva.processing.invocation.dispatch_for_trigger"
-            ) as dispatch,
-        ):
-            process_staging_file.apply(
-                kwargs={"bucket": BucketType.STAGING, "key": "cmip6/tas/f.tif"}
-            )
-
-        dispatch.assert_called_once()
-        trigger = dispatch.call_args.args[0]
-        self.assertEqual(trigger["staging_item_id"], self.sitem.pk)
-        self.assertEqual(trigger["collection_slug"], "tas")
-
-    def test_no_dispatch_when_registration_skipped(self):
-        from georiva.core.storage import BucketType
-        from georiva.ingestion.tasks import process_staging_file
-
-        with (
-            patch(
-                "georiva.ingestion.staging_consumer.register_staging_file",
-                return_value=None,
-            ),
-            patch(
-                "georiva.processing.invocation.dispatch_for_trigger"
-            ) as dispatch,
-        ):
-            process_staging_file.apply(
-                kwargs={"bucket": BucketType.STAGING, "key": "bad/path.tif"}
-            )
-
-        dispatch.assert_not_called()
-
-
 class CompletionChainingTests(_RegistryIsolationMixin, TestCase):
     """When a unit completes producing a Published item, that item is itself an
     input — the streaming task chains a downstream trigger so internal

--- a/georiva/src/georiva/processing/tests/test_origin_stamping.py
+++ b/georiva/src/georiva/processing/tests/test_origin_stamping.py
@@ -1,0 +1,82 @@
+"""
+Origin threading through the engine (ADR-0008, issue #147).
+
+The invocation layer stamps each DerivationRun with an opaque `origin` (the
+product identity) by passing it through run/run_unit to DerivationRun.acquire.
+The engine never interprets it — these tests assert it is stored, threaded, and
+not clobbered by engine-internal re-runs. The product-driven dispatcher that
+*builds* the origin lives in the sources layer (tested separately).
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from georiva.processing.engine import run, run_unit
+from georiva.processing.models import DerivationRun
+from georiva.processing.recipe import BaseRecipe, OutputItem, ResolvedInput
+
+
+class _NotReadyRecipe(BaseRecipe):
+    """A recipe whose required input is absent, so run_unit acquires the run
+    (stamping origin) then stops at the readiness gate — no Item is produced."""
+
+    type = "origin_fake"
+    version = "1"
+
+    def enumerate_units(self, selector):
+        return [{"k": 1}]
+
+    def resolve_inputs(self, unit):
+        return {"src": ResolvedInput("src", required=True, items=[], assets=[])}
+
+    def outputs(self, unit):
+        from datetime import datetime, timezone
+        return OutputItem(collection=None, time=datetime(2020, 1, 1, tzinfo=timezone.utc))
+
+    def transform(self, unit, resolved):
+        return []
+
+
+class _TwoUnitRecipe(BaseRecipe):
+    type = "two_unit_fake"
+    version = "1"
+
+    def enumerate_units(self, selector):
+        return [{"n": 1}, {"n": 2}]
+
+    def resolve_inputs(self, unit):
+        return {}
+
+    def outputs(self, unit):
+        return OutputItem(collection=None, time=None)
+
+    def transform(self, unit, resolved):
+        return []
+
+
+class RunOriginThreadingTests(TestCase):
+    def test_run_threads_origin_to_each_dispatched_unit_task(self):
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            run(_TwoUnitRecipe(), {}, dispatch=True, origin="derived_product:9")
+
+        self.assertEqual(task.delay.call_count, 2)
+        origins = {c.kwargs["origin"] for c in task.delay.call_args_list}
+        self.assertEqual(origins, {"derived_product:9"})
+
+
+class RunUnitOriginTests(TestCase):
+    def test_run_unit_stamps_origin_on_the_derivation_run(self):
+        run_unit(_NotReadyRecipe(), {"k": 1}, origin="derived_product:7")
+
+        runrec = DerivationRun.objects.get(recipe_type="origin_fake")
+        self.assertEqual(runrec.origin, "derived_product:7")
+
+    def test_re_running_without_origin_keeps_the_existing_stamp(self):
+        recipe = _NotReadyRecipe()
+        run_unit(recipe, {"k": 1}, origin="derived_product:7")
+
+        # An engine-internal re-dispatch (sweep / invalidation) carries no origin.
+        run_unit(recipe, {"k": 1})
+
+        runrec = DerivationRun.objects.get(recipe_type="origin_fake")
+        self.assertEqual(runrec.origin, "derived_product:7")

--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -1,0 +1,75 @@
+"""
+Product-driven derivation invocation (ADR-0008).
+
+The application-layer flip of derivation from *recipe-driven* to
+*DerivedProduct-driven*: an arriving input finds the enabled DerivedProducts
+whose declared inputs match its collection/tier, builds a selector from each
+product's config, and calls the engine's generic run(recipe, selector), stamping
+the run with the product origin.
+
+This is the ONLY place that joins the feed layer (DerivedProduct) to the engine,
+so the engine itself never imports DerivedProduct (ADR-0005). The feed layer
+depending on the engine is the allowed direction.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def product_origin(product) -> str:
+    """The opaque DerivationRun.origin key for a product — the stable identity
+    the tracking UI groups runs by (ADR-0008)."""
+    return f"derived_product:{product.pk}"
+
+
+def _trigger_tier(trigger: dict) -> str:
+    """The tier of the arriving input: staging items vs published items."""
+    return "staging" if trigger.get("staging_item_id") else "published"
+
+
+def _definition_for(product):
+    """The product's DerivedProductDefinition, looked up on its feed by key."""
+    for definition in product.data_feed.get_derived_products():
+        if definition.key == product.definition_key:
+            return definition
+    return None
+
+
+def _matches(definition, collection_slug: str, tier: str) -> bool:
+    """True if the definition declares an input on this collection at this tier."""
+    return any(
+        ref.collection == collection_slug and ref.tier == tier
+        for ref in definition.inputs
+    )
+
+
+def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
+    """
+    Route an arriving-input ``trigger`` to every enabled DerivedProduct that
+    consumes it. For each match, build ``selector = {**config, **trigger}`` and
+    run the product's recipe, stamping the run with the product origin.
+    """
+    from georiva.processing.engine import run
+    from georiva.processing.registry import recipe_registry
+
+    from georiva.sources.models import DerivedProduct
+
+    collection_slug = trigger.get("collection_slug")
+    tier = _trigger_tier(trigger)
+
+    results = []
+    for product in DerivedProduct.objects.filter(is_enabled=True):
+        definition = _definition_for(product)
+        if definition is None or not _matches(definition, collection_slug, tier):
+            continue
+        recipe = recipe_registry.get(definition.recipe_type)
+        if recipe is None:
+            logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
+            continue
+        selector = {**(product.config or {}), **trigger}
+        results.extend(
+            run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
+        )
+    return results

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -1,0 +1,240 @@
+"""
+Product-driven invocation (ADR-0008, issue #147).
+
+An arriving input finds the enabled DerivedProducts whose declared inputs match
+its collection/tier, builds a selector from each product's config, and calls the
+engine's run(recipe, selector) — stamping the run with the product origin. This
+application-layer dispatcher is the only place that knows about DerivedProduct;
+the engine stays generic.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from georiva.core.models import Catalog, Collection, Item, Unit, Variable
+from georiva.processing.models import DerivationRun
+from georiva.sources.derivation_invocation import dispatch_for_input, product_origin
+from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
+
+
+def _mock_writer():
+    w = MagicMock()
+    w.bucket.save.side_effect = lambda path, data: path
+    w.write_cog.side_effect = lambda arr, path, *a, **k: path
+    return w
+
+
+def _definition(**overrides):
+    kwargs = dict(
+        key="serve-raw",
+        recipe_type="promotion",
+        label="Serve raw",
+        description="",
+        config_schema=(),
+        inputs=(InputRef(role="source", collection="rainfall", tier="staging"),),
+        outputs=(OutputRef(role="served", collection="rainfall"),),
+        trigger_mode="event",
+    )
+    kwargs.update(overrides)
+    return DerivedProductDefinition(**kwargs)
+
+
+def _staging_trigger(collection_slug="rainfall", staging_item_id=5):
+    return {"staging_item_id": staging_item_id, "collection_slug": collection_slug}
+
+
+class DispatchForInputTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+
+    def _product(self, definition, **overrides):
+        return DerivedProduct.objects.create(
+            data_feed=self.feed,
+            definition_key=definition.key,
+            recipe_type=definition.recipe_type,
+            config=overrides.get("config", {}),
+            is_enabled=overrides.get("is_enabled", True),
+        )
+
+    def test_matching_enabled_product_runs_with_selector_and_origin(self):
+        definition = _definition()
+        product = self._product(definition, config={"baseline": "1991-2020"})
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(), dispatch=False)
+
+        run.assert_called_once()
+        selector = run.call_args.args[1]
+        # Selector carries the product's config merged with the event coordinates.
+        self.assertEqual(selector["baseline"], "1991-2020")
+        self.assertEqual(selector["staging_item_id"], 5)
+        self.assertEqual(run.call_args.kwargs["origin"], f"derived_product:{product.pk}")
+
+    def test_product_on_a_different_collection_is_not_dispatched(self):
+        definition = _definition(inputs=(
+            InputRef(role="source", collection="temperature", tier="staging"),
+        ))
+        self._product(definition)
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(collection_slug="rainfall"), dispatch=False)
+
+        run.assert_not_called()
+
+    def test_disabled_product_is_not_dispatched(self):
+        definition = _definition()
+        self._product(definition, is_enabled=False)
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(), dispatch=False)
+
+        run.assert_not_called()
+
+    def test_product_consuming_a_different_tier_is_not_dispatched(self):
+        # The product wants rainfall at the published tier; a staging arrival
+        # must not trigger it.
+        definition = _definition(inputs=(
+            InputRef(role="source", collection="rainfall", tier="published"),
+        ))
+        self._product(definition)
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(), dispatch=False)
+
+        run.assert_not_called()
+
+
+class EndToEndPromotionTests(TestCase):
+    """The mechanism end to end on a core recipe: a staging arrival routed
+    through an enabled promotion product produces a Published item, and the run
+    carries the product origin."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.pub_col = Collection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        self.unit_dim, _ = Unit.objects.get_or_create(
+            symbol="mm", defaults={"name": "millimetre"}
+        )
+        self.variable = Variable.objects.create(
+            collection=self.pub_col, slug="precip", name="Precipitation",
+            unit=self.unit_dim, value_min=0, value_max=2000,
+        )
+        self.scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        self.sitem = StagingItem.objects.create(
+            collection=self.scol, datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=10, height=10,
+        )
+        StagingAsset.objects.create(
+            item=self.sitem, href="chirps/rainfall/f.tif", roles=["source"],
+            format="geotiff", checksum="abc123", variable=self.variable,
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.definition = _definition()
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key=self.definition.key,
+            recipe_type="promotion", config={}, is_enabled=True,
+        )
+
+    def test_staging_arrival_promotes_and_stamps_product_origin(self):
+        trigger = {"staging_item_id": self.sitem.pk, "collection_slug": "rainfall"}
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[self.definition]),
+            patch("georiva.core.storage.storage") as st,
+            patch("georiva.ingestion.asset_writer.AssetWriter", return_value=_mock_writer()),
+        ):
+            st.bucket.return_value.read_bytes.return_value = b"GEOTIFFBYTES"
+            dispatch_for_input(trigger, dispatch=False)
+
+        item = Item.objects.get(collection=self.pub_col)
+        self.assertEqual(item.time, datetime(2020, 1, 1, tzinfo=timezone.utc))
+
+        run_rec = DerivationRun.objects.get(recipe_type="promotion")
+        self.assertEqual(run_rec.status, DerivationRun.Status.COMPLETED)
+        self.assertEqual(run_rec.origin, product_origin(self.product))
+
+
+class StagingArrivalRoutesToProductsTests(TestCase):
+    """The staging-arrival entry point is product-driven: registering a staging
+    file dispatches the input to its consuming products."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        self.sitem = StagingItem.objects.create(
+            collection=self.scol, datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=10, height=10,
+        )
+
+    def test_process_staging_file_dispatches_input_to_products(self):
+        from georiva.core.storage import BucketType
+        from georiva.ingestion.tasks import process_staging_file
+
+        with (
+            patch(
+                "georiva.ingestion.staging_consumer.register_staging_file",
+                return_value=self.sitem,
+            ),
+            patch(
+                "georiva.sources.derivation_invocation.dispatch_for_input"
+            ) as dispatch,
+        ):
+            process_staging_file.apply(
+                kwargs={"bucket": BucketType.STAGING, "key": "chirps/rainfall/f.tif"}
+            )
+
+        dispatch.assert_called_once()
+        trigger = dispatch.call_args.args[0]
+        self.assertEqual(trigger["staging_item_id"], self.sitem.pk)
+        self.assertEqual(trigger["collection_slug"], "rainfall")
+
+    def test_no_dispatch_when_registration_is_skipped(self):
+        from georiva.core.storage import BucketType
+        from georiva.ingestion.tasks import process_staging_file
+
+        with (
+            patch(
+                "georiva.ingestion.staging_consumer.register_staging_file",
+                return_value=None,
+            ),
+            patch(
+                "georiva.sources.derivation_invocation.dispatch_for_input"
+            ) as dispatch,
+        ):
+            process_staging_file.apply(
+                kwargs={"bucket": BucketType.STAGING, "key": "bad/path.tif"}
+            )
+
+        dispatch.assert_not_called()


### PR DESCRIPTION
Implements **#147** (ADR-0008 slice 5). Built test-first. Depends on #143, #145, #144 (all merged).

## What this lands

Flip derivation invocation from **recipe-driven** to **`DerivedProduct`-driven**: a configured product (not a constant in a recipe) decides what runs and with what options.

### `sources/derivation_invocation.py` (new — application layer)
`dispatch_for_input(trigger)` finds the **enabled** `DerivedProduct`s whose declared `InputRef`s match the trigger's `(collection_slug, tier)`, builds `selector = {**product.config, **trigger}`, and calls the engine's generic `run(recipe, selector, origin=product_origin(product))`. This is the **only** place that joins `DerivedProduct` to the engine — the engine never imports the feed layer (ADR-0005); the feed depending on the engine is the allowed direction. Event-driven products fall out of this for free.

### `processing` — opaque origin threading (stays generic)
`origin` threads through `run` → `run_unit` → `DerivationRun.acquire` and across Celery via `run_unit_task`. `acquire` only **(re)stamps** origin when one is supplied, so an engine-internal re-run (sweep/invalidation, `origin=None`) never clobbers a product's stamp. The `processing/engine.py` + `processing/models.py` layering guard (from #144) stays green.

### Call-site flip
`ingestion.process_staging_file` routes staging arrivals through `dispatch_for_input` instead of the recipe-driven fan-out.

### End-to-end demo (core recipe)
A real `run_unit` through the promotion recipe: a staging arrival + an enabled promotion product produces a Published item whose `DerivationRun.origin` = the product identity.

## Tests (12 new; 370 green across processing/sources/ingestion)
- `processing/tests/test_origin_stamping.py` — origin stamped via `run_unit`; no-clobber on re-run; `run()` threads origin to the unit task
- `sources/tests/test_derivation_invocation.py` — matching enabled product → `run(selector-from-config, origin)`; non-matching collection/tier and disabled products dispatch nothing; end-to-end promotion; `process_staging_file` routes through the dispatcher (+ skip when registration returns nothing)
- Relocated the obsolete recipe-driven staging-consumer hook tests to the sources layer

### Scope
Flipped the **staging-arrival** event path (the core of the slice). Engine-internal re-dispatch (completion chaining, backfill sweep, forward invalidation) stays recipe/run-based — flipping those would force a `processing → sources` backwards dependency. Climatology is already selector-driven, so no core recipe had embedded constants to strip here; plugin recipe migration (CHIRPS) is out of scope per #138.

## Out of scope (later slices)
Scheduled-product beat loop (#148), tracking view (#149), chain diagram (#150), readiness + Run-now (#151).

Closes #147