### PR TITLE
Derived-product tracking view: status, counts, enable/disable (ADR-0008 slice 7)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,14 @@ by it. `NULL` = no product origin (engine-internal or manual run). An engine-int
 no origin, so it never clobbers the original product stamp.
 _Avoid_: a hard `FK(DerivationRun → DerivedProduct)` (would make the engine depend on the feed layer)
 
+**Product status**:
+A `DerivedProduct`'s aggregate run state for the tracking view (ADR-0008), computed by
+`sources.derivation_tracking.product_status` joining its `DerivationRun`s on [[origin]]. Priority
+**`running` > `failed` > `completed` > `idle`** — meaningful because runs are per-unit and overwrite in place, so a
+`FAILED` row means a unit is *currently* stuck (not "failed once"). Carries per-status `counts` and `last_completed_at`.
+The read-side mirror of product-driven invocation; the engine stays unaware.
+_Avoid_: "failed once ever" semantics (a fixed unit's row transitions out of FAILED on re-run)
+
 **Production Unit**:
 The atomic, opaque, hashable coordinate the engine iterates over — one unit produces one output slice. Its
 **semantics are owned by the Recipe**, not the engine (e.g. climatology = `(variable, period, season, quantity,

--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -1,0 +1,55 @@
+"""
+Product run-tracking (ADR-0008).
+
+The read-side counterpart of product-driven invocation: summarise a
+DerivedProduct's DerivationRuns for the tracking view by joining on the opaque
+`origin` key the invocation layer stamped. The engine never groups by product —
+this application-layer aggregate does, keeping the ADR-0005 layering intact.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from georiva.sources.derivation_invocation import product_origin
+
+
+@dataclass
+class ProductStatus:
+    """A product's aggregate run state for the tracking view."""
+    status: str                                  # idle | running | failed | completed
+    total: int = 0
+    counts: dict = field(default_factory=dict)
+    last_completed_at: datetime | None = None
+
+
+def product_status(product) -> ProductStatus:
+    """Aggregate a product's DerivationRuns (joined by origin) into one status."""
+    from georiva.processing.models import DerivationRun
+
+    runs = DerivationRun.objects.filter(origin=product_origin(product))
+    counts = dict(Counter(runs.values_list("status", flat=True)))
+    total = sum(counts.values())
+    if total == 0:
+        return ProductStatus(status="idle")
+
+    completed = runs.filter(status=DerivationRun.Status.COMPLETED)
+    last_completed_at = (
+        completed.order_by("-completed_at")
+        .values_list("completed_at", flat=True)
+        .first()
+    )
+
+    if runs.filter(status=DerivationRun.Status.RUNNING).exists():
+        status = "running"
+    elif runs.filter(status=DerivationRun.Status.FAILED).exists():
+        status = "failed"
+    elif completed.exists():
+        status = "completed"
+    else:
+        status = "idle"
+
+    return ProductStatus(
+        status=status, total=total, counts=counts, last_completed_at=last_completed_at,
+    )

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
@@ -1,0 +1,156 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% trans "Derived Products" %}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .gdp-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1em;
+        }
+
+        .gdp-table th,
+        .gdp-table td {
+            text-align: left;
+            padding: 0.6em 0.8em;
+            border-bottom: 1px solid var(--w-color-border-furniture);
+            vertical-align: middle;
+        }
+
+        .gdp-table th {
+            font-size: 0.75em;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdp-product__label {
+            font-weight: 700;
+        }
+
+        .gdp-product__meta {
+            font-size: 0.8em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdp-badge {
+            display: inline-block;
+            padding: 0.15em 0.6em;
+            border-radius: 999px;
+            font-size: 0.78em;
+            font-weight: 600;
+            border: 1px solid;
+        }
+
+        .gdp-badge--running {
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+            border-color: var(--w-color-info-100);
+        }
+
+        .gdp-badge--completed {
+            background: color-mix(in srgb, var(--w-color-positive-100) 12%, transparent);
+            color: var(--w-color-positive-100);
+            border-color: color-mix(in srgb, var(--w-color-positive-100) 35%, transparent);
+        }
+
+        .gdp-badge--failed {
+            background: var(--w-color-critical-200);
+            color: var(--w-color-white);
+            border-color: var(--w-color-critical-200);
+        }
+
+        .gdp-badge--idle {
+            background: transparent;
+            color: var(--w-color-grey-400);
+            border-color: var(--w-color-border-furniture);
+        }
+
+        .gdp-counts {
+            font-size: 0.8em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdp-disabled {
+            opacity: 0.55;
+        }
+
+        .gdp-empty {
+            margin-top: 1.5em;
+            color: var(--w-color-grey-400);
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Derived Products") icon="cogs" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        {% if messages %}
+            {% for msg in messages %}
+                <div class="help-block help-block--{{ msg.tags }}">{{ msg }}</div>
+            {% endfor %}
+        {% endif %}
+
+        {% if rows %}
+            <table class="gdp-table">
+                <thead>
+                    <tr>
+                        <th>{% trans "Product" %}</th>
+                        <th>{% trans "Feed" %}</th>
+                        <th>{% trans "Status" %}</th>
+                        <th>{% trans "Runs" %}</th>
+                        <th>{% trans "Last completed" %}</th>
+                        <th>{% trans "Enabled" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                        <tr class="{% if not row.product.is_enabled %}gdp-disabled{% endif %}">
+                            <td>
+                                <div class="gdp-product__label">{{ row.label }}</div>
+                                <div class="gdp-product__meta">
+                                    {{ row.product.definition_key }} · {{ row.product.recipe_type }}
+                                </div>
+                            </td>
+                            <td>{{ row.product.data_feed.name }}</td>
+                            <td>
+                                <span class="gdp-badge gdp-badge--{{ row.status.status }}">
+                                    {{ row.status.status }}
+                                </span>
+                            </td>
+                            <td class="gdp-counts">
+                                {% blocktrans with n=row.status.total %}{{ n }} total{% endblocktrans %}
+                                {% if row.status.counts.failed %}
+                                    · {% blocktrans with n=row.status.counts.failed %}{{ n }} failed{% endblocktrans %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if row.status.last_completed_at %}
+                                    {{ row.status.last_completed_at }}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>
+                                <form method="post" action="{% url 'derived_product_tracking' %}">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="action" value="toggle">
+                                    <input type="hidden" name="product_pk" value="{{ row.product.pk }}">
+                                    <button type="submit" class="button button-small button-secondary">
+                                        {% if row.product.is_enabled %}{% trans "Disable" %}{% else %}{% trans "Enable" %}{% endif %}
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p class="gdp-empty">{% trans "No derived products configured yet." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -1,0 +1,131 @@
+"""
+Product run-tracking aggregate (ADR-0008, issue #149).
+
+product_status joins a DerivedProduct to its DerivationRuns by the opaque
+`origin` key and summarises them — the seam the tracking view renders. The UI
+knows about products; the engine still does not (it only stored the origin).
+"""
+from datetime import datetime, timezone
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from georiva.core.models import Catalog
+from georiva.processing.models import DerivationRun
+from georiva.sources.derivation_invocation import product_origin
+from georiva.sources.derivation_tracking import product_status
+from georiva.sources.models import DataFeed, DerivedProduct
+
+User = get_user_model()
+
+
+def _run(origin, status, *, completed_at=None, unit):
+    from georiva.processing.recipe import unit_hash
+    return DerivationRun.objects.create(
+        recipe_type="climatology", recipe_version="1",
+        unit_key=unit, unit_hash=unit_hash(unit),
+        status=status, origin=origin, completed_at=completed_at,
+    )
+
+
+class ProductStatusTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def _origin(self):
+        return product_origin(self.product)
+
+    def test_product_with_no_runs_is_idle(self):
+        status = product_status(self.product)
+
+        self.assertEqual(status.status, "idle")
+        self.assertEqual(status.total, 0)
+
+    def test_a_running_unit_makes_the_product_running(self):
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.RUNNING, unit={"n": 2})
+
+        self.assertEqual(product_status(self.product).status, "running")
+
+    def test_a_failed_unit_with_none_running_makes_the_product_failed(self):
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 2})
+
+        self.assertEqual(product_status(self.product).status, "failed")
+
+    def test_running_takes_precedence_over_failed(self):
+        _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.RUNNING, unit={"n": 2})
+
+        self.assertEqual(product_status(self.product).status, "running")
+
+    def test_only_completed_runs_report_completed_with_last_completed_at(self):
+        earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        latest = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        _run(self._origin(), DerivationRun.Status.COMPLETED, completed_at=earlier, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.COMPLETED, completed_at=latest, unit={"n": 2})
+
+        status = product_status(self.product)
+        self.assertEqual(status.status, "completed")
+        self.assertEqual(status.last_completed_at, latest)
+
+    def test_counts_tally_per_status(self):
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 2})
+        _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 3})
+
+        status = product_status(self.product)
+        self.assertEqual(status.total, 3)
+        self.assertEqual(status.counts.get("completed"), 2)
+        self.assertEqual(status.counts.get("failed"), 1)
+
+    def test_another_products_runs_do_not_bleed_in(self):
+        other = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="normals", recipe_type="climatology",
+        )
+        # The other product is FAILED; ours has only a COMPLETED run.
+        _run(product_origin(other), DerivationRun.Status.FAILED, unit={"n": 9})
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+
+        status = product_status(self.product)
+        self.assertEqual(status.status, "completed")
+        self.assertEqual(status.total, 1)
+
+
+class TrackingViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_track", "t@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def test_tracking_page_lists_product_with_its_status(self):
+        response = self.client.get(reverse("derived_product_tracking"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "anomaly")   # the product is listed
+        self.assertContains(response, "idle")      # no runs yet
+
+    def test_toggle_pauses_a_product_without_deleting_it(self):
+        self.assertTrue(self.product.is_enabled)
+
+        self.client.post(reverse("derived_product_tracking"), {
+            "action": "toggle", "product_pk": self.product.pk,
+        })
+
+        self.product.refresh_from_db()
+        self.assertFalse(self.product.is_enabled)
+        # Config row survives — pausing is not deletion.
+        self.assertTrue(DerivedProduct.objects.filter(pk=self.product.pk).exists())

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1003,3 +1003,55 @@ def wizard_provision(request, model_name):
     except Exception as exc:
         messages.error(request, _("Provisioning failed: %s") % exc)
         return redirect("wizard_step3_collections", model_name=model_name)
+
+
+def derived_product_tracking(request):
+    """
+    Ingestion-style tracking dashboard for derived products (ADR-0008).
+
+    Lists every DerivedProduct with an aggregate run status (idle / running /
+    failed / completed) computed by joining DerivationRuns on the product's
+    origin key, plus an enable/disable toggle that pauses a product without
+    deleting its configuration.
+    """
+    from georiva.sources.derivation_tracking import product_status
+    from georiva.sources.models import DerivedProduct
+
+    if request.method == "POST" and request.POST.get("action") == "toggle":
+        product = get_object_or_404(DerivedProduct, pk=request.POST.get("product_pk"))
+        product.is_enabled = not product.is_enabled
+        product.save(update_fields=["is_enabled"])
+        messages.success(
+            request,
+            _("'%(key)s' %(state)s.") % {
+                "key": product.definition_key,
+                "state": _("enabled") if product.is_enabled else _("disabled"),
+            },
+        )
+        return redirect("derived_product_tracking")
+
+    products = (
+        DerivedProduct.objects
+        .select_related("data_feed", "data_feed__catalog")
+        .order_by("data_feed_id", "id")
+    )
+
+    rows = []
+    for product in products:
+        # Best-effort human label from the feed's declaration (falls back to key).
+        label = product.definition_key
+        for defn in product.data_feed.get_derived_products():
+            if defn.key == product.definition_key:
+                label = defn.label
+                break
+        rows.append({"product": product, "label": label, "status": product_status(product)})
+
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+            {"url": "", "label": _("Derived Products")},
+        ],
+        "rows": rows,
+    }
+    return render(request, "georivasources/derived_product_tracking.html", context)

--- a/georiva/src/georiva/sources/wagtail_hooks.py
+++ b/georiva/src/georiva/sources/wagtail_hooks.py
@@ -22,6 +22,7 @@ from .views import (
     wizard_step3_collections,
     wizard_step4_products,
     wizard_provision,
+    derived_product_tracking,
 )
 from .viewsets import (
     admin_viewsets,
@@ -35,6 +36,7 @@ from .viewsets import (
 def urlconf_georivasources():
     return [
         path('data-feeds/', data_feed_list, name="data_feed_list"),
+        path('data-feeds/derived-products/', derived_product_tracking, name="derived_product_tracking"),
         path('data-feeds/select/', data_feed_add_select, name="data_feed_add_select"),
         path('data-feeds/<int:pk>/', data_feed_detail, name="data_feed_detail"),
         path('data-feeds/<int:pk>/edit/', data_feed_edit, name="data_feed_edit"),
@@ -64,6 +66,16 @@ def register_sources_menu():
         reverse('data_feed_list'),
         icon_name='file-import',
         order=800,
+    )
+
+
+@hooks.register('register_admin_menu_item')
+def register_derived_products_menu():
+    return MenuItem(
+        _("Derived Products"),
+        reverse('derived_product_tracking'),
+        icon_name='cogs',
+        order=810,
     )
 
 


### PR DESCRIPTION
Implements **#149** (ADR-0008 slice 7). Built test-first. Depends on #147 (merged) for the `origin` stamping.

## What this lands

An ingestion-style tracking dashboard for derivation, so operators can monitor it the way they monitor ingestion.

### `sources/derivation_tracking.py` — the aggregate seam (heavily tested)
`product_status(product)` joins a `DerivedProduct` to its `DerivationRun`s by the opaque `origin` key (stamped in #147) and aggregates into one `ProductStatus`: `status`, per-status `counts`, `total`, `last_completed_at`.

**Status priority: `running` > `failed` > `completed` > `idle`.** Meaningful because `DerivationRun` rows are per-unit and overwrite in place on re-run — so a `FAILED` row means a unit is *currently* stuck (not "failed once long ago"), and `RUNNING` means in-flight. Runs are isolated per product by `origin`.

The engine stays unaware of products; this application-layer aggregate does the join (consistent with #147's layering).

### `sources/views.py` + template + menu item — thin view
`derived_product_tracking` lists every product with its feed, a status badge, run counts, and last-completed time, plus an **enable/disable toggle** that pauses a product without deleting its config. Reachable from a new "Derived Products" admin menu item.

## Tests (9 new; 52 sources-wide green)
- `sources/tests/test_derivation_tracking.py` — 7 aggregate tests (idle / running / failed / completed precedence, `last_completed_at`, per-status counts, origin isolation) + 2 thin view tests (page lists product with status; POST toggle flips `is_enabled` without deleting)

## Out of scope (later slices)
Chain diagram (#150), readiness + "Run now" (#151), scheduled beat loop (#148).

Closes #149