### PR TITLE
Product readiness + Run now / backfill trigger (ADR-0008 slice 9)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,6 +106,20 @@ A `DerivedProduct`'s aggregate run state for the tracking view (ADR-0008), compu
 The read-side mirror of product-driven invocation; the engine stays unaware.
 _Avoid_: "failed once ever" semantics (a fixed unit's row transitions out of FAILED on re-run)
 
+**Product readiness**:
+A coarse, product-level gate (ADR-0008) computed by `sources.derivation_tracking.product_readiness` from the declared
+inputs — **no recipe execution**: a product is ready iff every *required* declared input collection exists and is
+non-empty. When blocked, names the first empty required input (`blocked_by` + `reason`, e.g. "normals empty"). Gates the
+tracking view's **Run now** button. Distinct from and **in front of** the engine's per-unit `readiness()` + min-count
+guard, which are unchanged.
+_Avoid_: confusing it with the engine's fine-grained per-unit readiness
+
+**Run now / backfill**:
+The manual overlay (ADR-0008): `sources.derivation_invocation.run_product_now(product)` triggers a product on demand
+with a *wide* selector built from its config and **no** event coordinate, so the recipe enumerates all the product's
+units (the same path as a backfill). Reuses the engine's `run()` and the [[origin]] stamping; gated on [[product-readiness]].
+_Avoid_: a bespoke backfill path (it is just a wide selector through the same `run()`)
+
 **Production Unit**:
 The atomic, opaque, hashable coordinate the engine iterates over — one unit produces one output slice. Its
 **semantics are owned by the Recipe**, not the engine (e.g. climatology = `(variable, period, season, quantity,

--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -29,7 +29,7 @@ def _trigger_tier(trigger: dict) -> str:
     return "staging" if trigger.get("staging_item_id") else "published"
 
 
-def _definition_for(product):
+def definition_for(product):
     """The product's DerivedProductDefinition, looked up on its feed by key."""
     for definition in product.data_feed.get_derived_products():
         if definition.key == product.definition_key:
@@ -61,7 +61,7 @@ def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
 
     results = []
     for product in DerivedProduct.objects.filter(is_enabled=True):
-        definition = _definition_for(product)
+        definition = definition_for(product)
         if definition is None or not _matches(definition, collection_slug, tier):
             continue
         recipe = recipe_registry.get(definition.recipe_type)
@@ -73,3 +73,25 @@ def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
             run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
         )
     return results
+
+
+def run_product_now(product, *, dispatch: bool = True) -> list:
+    """
+    Manually trigger a product (ADR-0008) with a *wide* selector built from its
+    config and no event coordinate, so the recipe enumerates all of the
+    product's units — the same path as a backfill. Reuses the engine's run() and
+    the product origin stamping. The caller (the tracking view) gates this on
+    product readiness; the engine's per-unit readiness still applies underneath.
+    """
+    from georiva.processing.engine import run
+    from georiva.processing.registry import recipe_registry
+
+    definition = definition_for(product)
+    if definition is None:
+        return []
+    recipe = recipe_registry.get(definition.recipe_type)
+    if recipe is None:
+        logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
+        return []
+    selector = dict(product.config or {})
+    return run(recipe, selector, origin=product_origin(product), dispatch=dispatch)

--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -12,7 +12,37 @@ from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from georiva.sources.derivation_invocation import product_origin
+from georiva.sources.derivation_invocation import definition_for, product_origin
+
+
+@dataclass
+class ProductReadiness:
+    """Whether a product can run now (ADR-0008) — a coarse gate computed from the
+    declared inputs, in front of the engine's per-unit readiness."""
+    ready: bool
+    blocked_by: str | None = None     # role of the first empty required input
+    reason: str | None = None         # human reason, e.g. "normals empty"
+
+
+def product_readiness(product) -> ProductReadiness:
+    """
+    A product is ready iff every *required* declared input collection exists and
+    is non-empty — derived from the declaration, no recipe execution. Optional
+    inputs never block. When blocked, names the first empty required input.
+    """
+    from georiva.processing.recipe import resolve_declared_inputs
+
+    definition = definition_for(product)
+    if definition is None:
+        return ProductReadiness(ready=False, reason="no product definition")
+
+    resolved = resolve_declared_inputs(definition.inputs)
+    for ref in definition.inputs:
+        if ref.required and not resolved[ref.role].present:
+            return ProductReadiness(
+                ready=False, blocked_by=ref.role, reason=f"{ref.role} empty",
+            )
+    return ProductReadiness(ready=True)
 
 
 @dataclass

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
@@ -78,6 +78,12 @@
             opacity: 0.55;
         }
 
+        .gdp-blocked {
+            font-size: 0.75em;
+            color: var(--w-color-critical-200);
+            margin-top: 0.25em;
+        }
+
         .gdp-empty {
             margin-top: 1.5em;
             color: var(--w-color-grey-400);
@@ -104,6 +110,7 @@
                         <th>{% trans "Status" %}</th>
                         <th>{% trans "Runs" %}</th>
                         <th>{% trans "Last completed" %}</th>
+                        <th>{% trans "Run" %}</th>
                         <th>{% trans "Enabled" %}</th>
                     </tr>
                 </thead>
@@ -133,6 +140,23 @@
                                     {{ row.status.last_completed_at }}
                                 {% else %}
                                     —
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if row.readiness.ready %}
+                                    <form method="post" action="{% url 'derived_product_tracking' %}">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="action" value="run_now">
+                                        <input type="hidden" name="product_pk" value="{{ row.product.pk }}">
+                                        <button type="submit" class="button button-small">
+                                            {% trans "Run now" %}
+                                        </button>
+                                    </form>
+                                {% else %}
+                                    <button type="button" class="button button-small" disabled>
+                                        {% trans "Run now" %}
+                                    </button>
+                                    <div class="gdp-blocked">{% trans "Blocked" %}: {{ row.readiness.reason }}</div>
                                 {% endif %}
                             </td>
                             <td>

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -19,7 +19,11 @@ from georiva.core.derived_products import (
 )
 from georiva.core.models import Catalog, Collection, Item, Unit, Variable
 from georiva.processing.models import DerivationRun
-from georiva.sources.derivation_invocation import dispatch_for_input, product_origin
+from georiva.sources.derivation_invocation import (
+    dispatch_for_input,
+    product_origin,
+    run_product_now,
+)
 from georiva.sources.models import DataFeed, DerivedProduct
 from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
 
@@ -238,3 +242,31 @@ class StagingArrivalRoutesToProductsTests(TestCase):
             )
 
         dispatch.assert_not_called()
+
+
+class RunProductNowTests(TestCase):
+    """The manual / backfill overlay: run a product on demand with a wide
+    selector (its config), so the recipe enumerates all its units."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="serve-raw",
+            recipe_type="promotion", config={"baseline": "1991-2020"}, is_enabled=True,
+        )
+
+    def test_runs_recipe_with_config_selector_and_product_origin(self):
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[_definition()]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            run_product_now(self.product, dispatch=False)
+
+        run.assert_called_once()
+        selector = run.call_args.args[1]
+        # Wide selector = the product's config (no event trigger) -> backfill.
+        self.assertEqual(selector, {"baseline": "1991-2020"})
+        self.assertEqual(run.call_args.kwargs["origin"], product_origin(self.product))

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -6,18 +6,35 @@ product_status joins a DerivedProduct to its DerivationRuns by the opaque
 knows about products; the engine still does not (it only stored the origin).
 """
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
 from georiva.core.models import Catalog
 from georiva.processing.models import DerivationRun
 from georiva.sources.derivation_invocation import product_origin
 from georiva.sources.derivation_tracking import product_status
 from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
 
 User = get_user_model()
+
+
+def _anomaly_definition():
+    return DerivedProductDefinition(
+        key="anomaly", recipe_type="climatology", label="Rainfall anomaly",
+        description="", config_schema=(),
+        inputs=(InputRef(role="value", collection="rainfall", tier="staging"),),
+        outputs=(OutputRef(role="anomaly", collection="rainfall-anomaly"),),
+        trigger_mode="scheduled",
+    )
 
 
 def _run(origin, status, *, completed_at=None, unit):
@@ -129,3 +146,50 @@ class TrackingViewTests(TestCase):
         self.assertFalse(self.product.is_enabled)
         # Config row survives — pausing is not deletion.
         self.assertTrue(DerivedProduct.objects.filter(pk=self.product.pk).exists())
+
+    def _add_rainfall_staging(self):
+        scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        si = StagingItem.objects.create(
+            collection=scol, datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=4, height=4,
+        )
+        StagingAsset.objects.create(
+            item=si, href="chirps/rainfall/f.tif", roles=["source"],
+            format="geotiff", checksum="r1",
+        )
+
+    def test_blocked_product_shows_its_blocking_reason(self):
+        # The anomaly's required 'value' input (rainfall) is empty -> blocked.
+        with patch.object(DataFeed, "get_derived_products", return_value=[_anomaly_definition()]):
+            response = self.client.get(reverse("derived_product_tracking"))
+
+        self.assertContains(response, "value empty")
+
+    def test_run_now_triggers_a_ready_product(self):
+        self._add_rainfall_staging()  # required input now present -> ready
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[_anomaly_definition()]),
+            patch("georiva.sources.derivation_invocation.run_product_now") as run_now,
+        ):
+            self.client.post(reverse("derived_product_tracking"), {
+                "action": "run_now", "product_pk": self.product.pk,
+            })
+
+        run_now.assert_called_once()
+        self.assertEqual(run_now.call_args.args[0], self.product)
+
+    def test_run_now_refuses_a_blocked_product_and_shows_the_reason(self):
+        # No rainfall staging -> blocked.
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[_anomaly_definition()]),
+            patch("georiva.sources.derivation_invocation.run_product_now") as run_now,
+        ):
+            response = self.client.post(reverse("derived_product_tracking"), {
+                "action": "run_now", "product_pk": self.product.pk,
+            }, follow=True)
+
+        run_now.assert_not_called()
+        self.assertContains(response, "value empty")

--- a/georiva/src/georiva/sources/tests/test_product_readiness.py
+++ b/georiva/src/georiva/sources/tests/test_product_readiness.py
@@ -1,0 +1,100 @@
+"""
+Product readiness (ADR-0008, issue #151).
+
+A coarse, product-level gate computed from the declared inputs — no recipe
+execution: a product is ready iff every *required* declared input collection
+exists and is non-empty. Gates the "Run now" button and names the blocker when
+not ready. The engine's per-unit readiness + min-count guard are unchanged.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from georiva.core.models import Catalog, Collection, Item, Unit, Variable
+from georiva.sources.derivation_tracking import product_readiness
+from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
+
+_TIME = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+def _definition(**overrides):
+    kwargs = dict(
+        key="anomaly",
+        recipe_type="climatology",
+        label="Rainfall anomaly",
+        description="",
+        config_schema=(),
+        inputs=(InputRef(role="value", collection="rainfall", tier="staging"),),
+        outputs=(OutputRef(role="anomaly", collection="rainfall-anomaly"),),
+        trigger_mode="scheduled",
+    )
+    kwargs.update(overrides)
+    return DerivedProductDefinition(**kwargs)
+
+
+class ProductReadinessTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def _add_staging(self, slug="rainfall"):
+        scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug=slug, name=slug
+        )
+        si = StagingItem.objects.create(
+            collection=scol, datetime=_TIME,
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=4, height=4,
+        )
+        StagingAsset.objects.create(
+            item=si, href=f"chirps/{slug}/f.tif", roles=["source"],
+            format="geotiff", checksum=f"{slug}-1",
+        )
+        return si
+
+    def _readiness(self, definition):
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            return product_readiness(self.product)
+
+    def test_ready_when_all_required_inputs_present(self):
+        self._add_staging("rainfall")
+
+        verdict = self._readiness(_definition())
+
+        self.assertTrue(verdict.ready)
+
+    def test_blocked_when_a_required_input_is_empty(self):
+        # The anomaly needs both raw rainfall (present) and normals (absent).
+        self._add_staging("rainfall")
+        definition = _definition(inputs=(
+            InputRef(role="value", collection="rainfall", tier="staging"),
+            InputRef(role="normals", collection="rainfall-normals", tier="published"),
+        ))
+
+        verdict = self._readiness(definition)
+
+        self.assertFalse(verdict.ready)
+        self.assertEqual(verdict.blocked_by, "normals")
+        self.assertIn("normals", verdict.reason)
+
+    def test_an_empty_optional_input_does_not_block(self):
+        self._add_staging("rainfall")
+        definition = _definition(inputs=(
+            InputRef(role="value", collection="rainfall", tier="staging"),
+            InputRef(role="pet", collection="pet", tier="published", required=False),
+        ))
+
+        verdict = self._readiness(definition)
+
+        self.assertTrue(verdict.ready)

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1014,7 +1014,8 @@ def derived_product_tracking(request):
     origin key, plus an enable/disable toggle that pauses a product without
     deleting its configuration.
     """
-    from georiva.sources.derivation_tracking import product_status
+    from georiva.sources.derivation_invocation import run_product_now
+    from georiva.sources.derivation_tracking import product_readiness, product_status
     from georiva.sources.models import DerivedProduct
 
     if request.method == "POST" and request.POST.get("action") == "toggle":
@@ -1028,6 +1029,21 @@ def derived_product_tracking(request):
                 "state": _("enabled") if product.is_enabled else _("disabled"),
             },
         )
+        return redirect("derived_product_tracking")
+
+    if request.method == "POST" and request.POST.get("action") == "run_now":
+        product = get_object_or_404(DerivedProduct, pk=request.POST.get("product_pk"))
+        readiness = product_readiness(product)
+        if readiness.ready:
+            run_product_now(product)
+            messages.success(request, _("Run started for '%s'.") % product.definition_key)
+        else:
+            messages.error(
+                request,
+                _("'%(key)s' blocked: %(reason)s.") % {
+                    "key": product.definition_key, "reason": readiness.reason,
+                },
+            )
         return redirect("derived_product_tracking")
 
     products = (
@@ -1044,7 +1060,12 @@ def derived_product_tracking(request):
             if defn.key == product.definition_key:
                 label = defn.label
                 break
-        rows.append({"product": product, "label": label, "status": product_status(product)})
+        rows.append({
+            "product": product,
+            "label": label,
+            "status": product_status(product),
+            "readiness": product_readiness(product),
+        })
 
     context = {
         "breadcrumbs_items": [


### PR DESCRIPTION
Implements **#151** (ADR-0008 slice 9). Built test-first. Depends on #147 + #149 (merged).

## What this lands

Let operators safely trigger a derivation on demand, and tell them when they can't and why.

### Readiness verdict — `sources/derivation_tracking.py` (pure seam)
`product_readiness(product)` is a coarse, product-level gate computed from the declared `inputs` — **no recipe execution**: a product is ready iff every *required* declared input collection exists and is non-empty (reuses `resolve_declared_inputs` from #143). When blocked, returns `blocked_by` (the empty input's role) + `reason` (e.g. `"normals empty"`). Optional inputs never block. Sits **in front of** the engine's per-unit `readiness()` + min-count guard, which are unchanged.

### Run-now / backfill — `sources/derivation_invocation.py`
`run_product_now(product)` triggers a product on demand with a **wide** selector built from its config and no event coordinate, so the recipe enumerates all the product's units — the same path as a backfill. Reuses the engine's `run()` and the `origin` stamping. (Promoted the shared `_definition_for` → `definition_for`.)

### View — extends the tracking dashboard (#149)
Per product: a **Run now** button enabled only when ready, else the blocking reason. POST `run_now` triggers `run_product_now` when ready and refuses (messaging the reason) otherwise.

## Tests (6 new; 386 green across sources/processing/ingestion — engine untouched)
- `sources/tests/test_product_readiness.py` — ready / blocked-by-X / optional-doesn't-block
- `sources/tests/test_derivation_invocation.py` — `run_product_now` runs with config selector + product origin
- `sources/tests/test_derivation_tracking.py` — blocked reason shown; POST run_now triggers a ready product / refuses a blocked one

## ADR-0008
This is the **last slice**. With it, ADR-0008 is fully implemented end-to-end except the two intentionally-deferred pieces: auto-derived `target_tier` (#146) and the scheduled-product beat loop (#148), plus the chain diagram (#150).

Closes #151