### PR TITLE
feat(sources): chain diagram (planned DAG) + lineage drill-down (#150)

### DIFF
--- a/georiva/src/georiva/sources/derivation_chain.py
+++ b/georiva/src/georiva/sources/derivation_chain.py
@@ -1,0 +1,93 @@
+"""
+Chain diagram — the planned DAG (ADR-0008).
+
+Builds the pipeline topology a feed declares: collections are nodes, products
+are edges (one hyperedge per product, carrying its declared input/output
+collections), overlaid with each product's run status and readiness. Built from
+the declarations + the configured DerivedProducts — no recipe execution — so
+configured-but-unrun (blocked) edges appear alongside the ones that have run.
+
+The read-side topology view; the engine stays unaware (ADR-0005).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from georiva.sources.derivation_invocation import definition_for
+
+
+@dataclass
+class ChainNode:
+    """A collection in the pipeline."""
+    collection: str
+
+
+@dataclass
+class ChainEdge:
+    """A product: a hyperedge from its input collections to its output ones."""
+    product_id: int
+    label: str
+    recipe_type: str
+    trigger_mode: str
+    inputs: list = field(default_factory=list)
+    outputs: list = field(default_factory=list)
+    status: str = "idle"
+    ready: bool = True
+    reason: str | None = None
+
+
+@dataclass
+class ChainGraph:
+    nodes: list = field(default_factory=list)
+    edges: list = field(default_factory=list)
+
+
+def build_chain_graph(data_feed) -> ChainGraph:
+    """Turn a feed's enabled products + their declarations into a planned DAG."""
+    from georiva.sources.derivation_tracking import product_readiness, product_status
+    from georiva.sources.models import DerivedProduct
+
+    edges = []
+    node_slugs = []
+    for product in DerivedProduct.objects.filter(data_feed=data_feed, is_enabled=True):
+        definition = definition_for(product)
+        if definition is None:
+            continue
+        inputs = [ref.collection for ref in definition.inputs]
+        outputs = [ref.collection for ref in definition.outputs]
+        for slug in inputs + outputs:
+            if slug not in node_slugs:
+                node_slugs.append(slug)
+        readiness = product_readiness(product)
+        edges.append(ChainEdge(
+            product_id=product.pk,
+            label=definition.label,
+            recipe_type=definition.recipe_type,
+            trigger_mode=definition.trigger_mode,
+            inputs=inputs,
+            outputs=outputs,
+            status=product_status(product).status,
+            ready=readiness.ready,
+            reason=readiness.reason,
+        ))
+
+    return ChainGraph(nodes=[ChainNode(slug) for slug in node_slugs], edges=edges)
+
+
+def item_lineage(item) -> list:
+    """The input items a produced item was derived from (ADR-0008) — the
+    item-level provenance drill-down, read from DerivationLink. Returns the
+    source StagingItems/Items recorded for ``item``."""
+    from georiva.staging.models import DerivationLink
+
+    links = (
+        DerivationLink.objects
+        .filter(derived_item=item)
+        .select_related("source_staging_item", "source_published_item")
+    )
+    sources = []
+    for link in links:
+        src = link.source_staging_item or link.source_published_item
+        if src is not None:
+            sources.append(src)
+    return sources

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
@@ -251,6 +251,15 @@
                 {% trans "Edit Details" %}
             </a>
 
+            <a href="{% url 'derived_product_chain' feed_pk=feed.pk %}" class="button bicolor button--icon">
+                <span class="icon-wrapper">
+                    <svg class="icon icon-site icon" aria-hidden="true">
+                        <use href="#icon-site"></use>
+                    </svg>
+                </span>
+                {% trans "View Chain" %}
+            </a>
+
             {% if feed.delete_url %}
                 <a href="{{ feed.delete_url }}" class="button no">
                     {% trans "Delete" %}

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_chain.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_chain.html
@@ -1,0 +1,115 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% trans "Derivation Chain" %} — {{ feed.name }}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .gchain-intro {
+            margin: 1em 0 1.5em;
+            color: var(--w-color-text-label);
+            font-size: 0.9em;
+        }
+
+        .gchain-edge {
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 8px;
+            padding: 0.85em 1.1em;
+            margin-bottom: 1em;
+        }
+
+        .gchain-edge--blocked {
+            border-color: var(--w-color-critical-200);
+        }
+
+        .gchain-flow {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.5em;
+            font-size: 0.9em;
+        }
+
+        .gchain-node {
+            display: inline-block;
+            padding: 0.2em 0.6em;
+            border-radius: 4px;
+            background: var(--w-color-grey-50);
+            border: 1px solid var(--w-color-border-furniture);
+            font-weight: 600;
+        }
+
+        .gchain-arrow {
+            color: var(--w-color-grey-400);
+            user-select: none;
+        }
+
+        .gchain-product {
+            display: inline-block;
+            padding: 0.2em 0.6em;
+            border-radius: 999px;
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+            font-weight: 600;
+        }
+
+        .gchain-meta {
+            margin-top: 0.5em;
+            font-size: 0.8em;
+            color: var(--w-color-grey-400);
+            display: flex;
+            gap: 1em;
+            flex-wrap: wrap;
+        }
+
+        .gchain-reason {
+            color: var(--w-color-critical-200);
+        }
+
+        .gchain-empty {
+            margin-top: 1.5em;
+            color: var(--w-color-grey-400);
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=feed.name subtitle=_("Derivation chain") icon="site" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        <p class="gchain-intro">
+            {% trans "How this feed's products interconnect — collections are nodes, products are edges. Configured-but-unrun (blocked) edges show why." %}
+        </p>
+
+        {% if graph.edges %}
+            {% for edge in graph.edges %}
+                <div class="gchain-edge {% if not edge.ready %}gchain-edge--blocked{% endif %}">
+                    <div class="gchain-flow">
+                        {% for slug in edge.inputs %}
+                            <span class="gchain-node">{{ slug }}</span>
+                        {% endfor %}
+                        <span class="gchain-arrow">→</span>
+                        <span class="gchain-product">{{ edge.label }}</span>
+                        <span class="gchain-arrow">→</span>
+                        {% for slug in edge.outputs %}
+                            <span class="gchain-node">{{ slug }}</span>
+                        {% endfor %}
+                    </div>
+                    <div class="gchain-meta">
+                        <span>{% trans "Recipe" %}: {{ edge.recipe_type }}</span>
+                        <span>{% trans "Trigger" %}: {{ edge.trigger_mode }}</span>
+                        <span>{% trans "Status" %}: {{ edge.status }}</span>
+                        {% if edge.ready %}
+                            <span>{% trans "Ready" %}</span>
+                        {% else %}
+                            <span class="gchain-reason">{% trans "Blocked" %}: {{ edge.reason }}</span>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p class="gchain-empty">{% trans "This feed declares no derived products." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/templates/georivasources/item_lineage.html
+++ b/georiva/src/georiva/sources/templates/georivasources/item_lineage.html
@@ -1,0 +1,63 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% trans "Item lineage" %} — {{ item }}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .glin-intro {
+            margin: 1em 0 1.5em;
+            color: var(--w-color-text-label);
+            font-size: 0.9em;
+        }
+
+        .glin-source {
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 8px;
+            padding: 0.85em 1.1em;
+            margin-bottom: 0.75em;
+        }
+
+        .glin-collection {
+            display: inline-block;
+            padding: 0.2em 0.6em;
+            border-radius: 4px;
+            background: var(--w-color-grey-50);
+            border: 1px solid var(--w-color-border-furniture);
+            font-weight: 600;
+        }
+
+        .glin-when {
+            margin-left: 0.75em;
+            font-size: 0.85em;
+            color: var(--w-color-grey-400);
+        }
+
+        .glin-empty {
+            margin-top: 1.5em;
+            color: var(--w-color-grey-400);
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=item subtitle=_("Item lineage") icon="site" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        <p class="glin-intro">
+            {% trans "The input items this produced item was derived from, read from the recorded derivation links." %}
+        </p>
+
+        {% if sources %}
+            {% for source in sources %}
+                <div class="glin-source">
+                    <span class="glin-collection">{{ source.collection.slug }}</span>
+                    <span class="glin-when">{{ source }}</span>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p class="glin-empty">{% trans "No recorded inputs for this item." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/tests/test_derivation_chain.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_chain.py
@@ -1,0 +1,215 @@
+"""
+Chain diagram — the planned DAG (ADR-0008, issue #150).
+
+build_chain_graph turns a feed's declarations + configured products into nodes
+(collections) and edges (products), overlaid with each product's status and
+readiness — the seam the server-rendered chain view draws. Declaration-driven,
+no recipe execution, so configured-but-unrun (blocked) edges appear too.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from georiva.core.models import Catalog
+from georiva.sources.derivation_chain import build_chain_graph, item_lineage
+from georiva.sources.models import DataFeed, DerivedProduct
+
+
+def _definition(key="anomaly", inputs=None, outputs=None, **overrides):
+    kwargs = dict(
+        key=key,
+        recipe_type="climatology",
+        label="Rainfall anomaly",
+        description="",
+        config_schema=(),
+        inputs=inputs or (InputRef(role="value", collection="rainfall", tier="staging"),),
+        outputs=outputs or (OutputRef(role="anomaly", collection="rainfall-anomaly"),),
+        trigger_mode="scheduled",
+    )
+    kwargs.update(overrides)
+    return DerivedProductDefinition(**kwargs)
+
+
+class BuildChainGraphTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+
+    def _product(self, definition, **overrides):
+        return DerivedProduct.objects.create(
+            data_feed=self.feed,
+            definition_key=definition.key,
+            recipe_type=definition.recipe_type,
+            is_enabled=overrides.get("is_enabled", True),
+        )
+
+    def test_one_product_is_one_edge_between_its_collections(self):
+        definition = _definition()
+        self._product(definition)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        self.assertEqual({n.collection for n in graph.nodes}, {"rainfall", "rainfall-anomaly"})
+        self.assertEqual(len(graph.edges), 1)
+        edge = graph.edges[0]
+        self.assertEqual(edge.inputs, ["rainfall"])
+        self.assertEqual(edge.outputs, ["rainfall-anomaly"])
+        self.assertEqual(edge.recipe_type, "climatology")
+        self.assertEqual(edge.trigger_mode, "scheduled")
+        self.assertEqual(edge.label, "Rainfall anomaly")
+
+    def test_multi_input_product_edge_carries_all_inputs(self):
+        # {raw, normals} -> anomaly
+        definition = _definition(inputs=(
+            InputRef(role="value", collection="rainfall", tier="staging"),
+            InputRef(role="normals", collection="rainfall-normals", tier="published"),
+        ))
+        self._product(definition)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        edge = graph.edges[0]
+        self.assertEqual(edge.inputs, ["rainfall", "rainfall-normals"])
+        self.assertEqual(
+            {n.collection for n in graph.nodes},
+            {"rainfall", "rainfall-normals", "rainfall-anomaly"},
+        )
+
+    def test_edge_is_overlaid_with_status_and_blocked_readiness(self):
+        # No runs and the required 'rainfall' input collection is empty:
+        # a configured-but-unrun (blocked) edge with its reason.
+        definition = _definition()
+        self._product(definition)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        edge = graph.edges[0]
+        self.assertEqual(edge.status, "idle")     # no DerivationRuns yet
+        self.assertFalse(edge.ready)              # required input empty
+        self.assertIn("value", edge.reason)       # blocking reason named
+
+    def test_disabled_product_is_not_an_edge(self):
+        definition = _definition()
+        self._product(definition, is_enabled=False)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        self.assertEqual(graph.edges, [])
+        self.assertEqual(graph.nodes, [])
+
+
+class ItemLineageTests(TestCase):
+    def test_lineage_returns_the_source_items_of_a_produced_item(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Collection, Item
+        from georiva.staging.models import (
+            DerivationLink,
+            StagingCollection,
+            StagingItem,
+        )
+
+        t = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        catalog = Catalog.objects.create(name="C", slug="c", file_format="geotiff")
+
+        # The produced (derived) item.
+        out_col = Collection.objects.create(catalog=catalog, slug="anomaly", name="Anomaly")
+        derived = Item.objects.create(collection=out_col, time=t)
+
+        # A staging input and a published input.
+        scol = StagingCollection.objects.create(catalog=catalog, slug="rainfall", name="Rainfall")
+        staging_src = StagingItem.objects.create(collection=scol, datetime=t)
+        pub_col = Collection.objects.create(catalog=catalog, slug="normals", name="Normals")
+        published_src = Item.objects.create(collection=pub_col, time=t)
+
+        DerivationLink.objects.create(
+            derived_item=derived, source_staging_item=staging_src,
+            recipe_id="climatology", recipe_version="1", input_hash="h",
+        )
+        DerivationLink.objects.create(
+            derived_item=derived, source_published_item=published_src,
+            recipe_id="climatology", recipe_version="1", input_hash="h",
+        )
+
+        sources = item_lineage(derived)
+
+        self.assertEqual(len(sources), 2)
+        self.assertIn(staging_src, sources)
+        self.assertIn(published_src, sources)
+
+
+class ChainViewTests(TestCase):
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        self.user = User.objects.create_superuser("admin_chain", "c@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+        DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def test_chain_page_renders_nodes_and_edge_labels(self):
+        from django.urls import reverse
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[_definition()]):
+            response = self.client.get(
+                reverse("derived_product_chain", kwargs={"feed_pk": self.feed.pk})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "rainfall")           # an input node
+        self.assertContains(response, "rainfall-anomaly")   # an output node
+        self.assertContains(response, "Rainfall anomaly")   # the product edge label
+
+
+class ItemLineageViewTests(TestCase):
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        self.user = User.objects.create_superuser("admin_lin", "l@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_lineage_page_lists_a_produced_items_inputs(self):
+        from datetime import datetime, timezone
+
+        from django.urls import reverse
+
+        from georiva.core.models import Collection, Item
+        from georiva.staging.models import (
+            DerivationLink,
+            StagingCollection,
+            StagingItem,
+        )
+
+        t = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        catalog = Catalog.objects.create(name="C", slug="c", file_format="geotiff")
+        out_col = Collection.objects.create(catalog=catalog, slug="anomaly", name="Anomaly")
+        derived = Item.objects.create(collection=out_col, time=t)
+        scol = StagingCollection.objects.create(catalog=catalog, slug="rainfall", name="Rainfall")
+        staging_src = StagingItem.objects.create(collection=scol, datetime=t)
+        DerivationLink.objects.create(
+            derived_item=derived, source_staging_item=staging_src,
+            recipe_id="climatology", recipe_version="1", input_hash="h",
+        )
+
+        response = self.client.get(
+            reverse("item_lineage", kwargs={"item_pk": derived.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "rainfall")  # the input collection

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1076,3 +1076,52 @@ def derived_product_tracking(request):
         "rows": rows,
     }
     return render(request, "georivasources/derived_product_tracking.html", context)
+
+
+def derived_product_chain(request, feed_pk):
+    """
+    Server-rendered chain diagram (ADR-0008): the planned DAG of a feed's
+    pipeline — collections are nodes, products are edges labeled with
+    recipe / status / readiness / trigger, including configured-but-unrun
+    (blocked) edges with their reason. No interactive graph library.
+    """
+    from georiva.sources.derivation_chain import build_chain_graph
+
+    feed = get_object_or_404(DataFeed, pk=feed_pk)
+    graph = build_chain_graph(feed)
+
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+            {"url": reverse("data_feed_detail", kwargs={"pk": feed.pk}), "label": feed.name},
+            {"url": "", "label": _("Chain")},
+        ],
+        "feed": feed,
+        "graph": graph,
+    }
+    return render(request, "georivasources/derived_product_chain.html", context)
+
+
+def item_lineage(request, item_pk):
+    """
+    Item-level provenance drill-down (ADR-0008): the input items a produced
+    item was derived from, read from DerivationLink. The read-side lineage view
+    for one produced Item.
+    """
+    from georiva.core.models import Item
+    from georiva.sources.derivation_chain import item_lineage as lineage_sources
+
+    item = get_object_or_404(Item, pk=item_pk)
+    sources = lineage_sources(item)
+
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+            {"url": "", "label": _("Lineage")},
+        ],
+        "item": item,
+        "sources": sources,
+    }
+    return render(request, "georivasources/item_lineage.html", context)

--- a/georiva/src/georiva/sources/wagtail_hooks.py
+++ b/georiva/src/georiva/sources/wagtail_hooks.py
@@ -23,6 +23,8 @@ from .views import (
     wizard_step4_products,
     wizard_provision,
     derived_product_tracking,
+    derived_product_chain,
+    item_lineage,
 )
 from .viewsets import (
     admin_viewsets,
@@ -37,6 +39,8 @@ def urlconf_georivasources():
     return [
         path('data-feeds/', data_feed_list, name="data_feed_list"),
         path('data-feeds/derived-products/', derived_product_tracking, name="derived_product_tracking"),
+        path('data-feeds/<int:feed_pk>/chain/', derived_product_chain, name="derived_product_chain"),
+        path('items/<int:item_pk>/lineage/', item_lineage, name="item_lineage"),
         path('data-feeds/select/', data_feed_add_select, name="data_feed_add_select"),
         path('data-feeds/<int:pk>/', data_feed_detail, name="data_feed_detail"),
         path('data-feeds/<int:pk>/edit/', data_feed_edit, name="data_feed_edit"),


### PR DESCRIPTION
## What

Implements ADR-0008 slice 8 (#150): show operators the pipeline topology as a server-rendered chain diagram, plus item-level provenance drill-down.

## How

- **`build_chain_graph`** (`derivation_chain.py`) — turns `(declarations + configured DerivedProducts)` into a planned DAG: collections are nodes, products are edges carrying declared inputs/outputs, overlaid with each product's `origin`-grouped run status and readiness. Declaration-driven, no recipe execution — so configured-but-unrun (blocked) edges appear with their blocking reason alongside ones that have run. Tested as a pure seam.
- **Chain view + template** — server-rendered (no interactive graph library, per the issue), edges labeled with recipe / status / readiness / trigger-mode; blocked edges visually distinguished and annotated with the reason. Reachable via a new "View Chain" button on the feed detail page.
- **`item_lineage`** — maps a produced `Item` to the exact source items recorded in `DerivationLink`, rendered by the lineage view.

## Acceptance criteria (#150)

- [x] Planned-DAG builder, tested as a pure seam
- [x] Server-rendered chain view with recipe/status/readiness/trigger labels
- [x] Configured-but-unrun (blocked) edges shown with a blocking reason
- [x] Item → lineage drill-down via `DerivationLink`
- [x] Admin views tested thinly

## Notes

The lineage page is reachable by direct URL and covered by tests; it isn't linked from a UI surface yet (no item-list view exists in the sources admin to anchor a link). Can be wired from the visualization/item views in a follow-up.

## Testing

`georiva.sources` — 76/76 pass.

Closes #150