### PR TITLE
feat(sources): declaration-injection + transient-feed product enablement (#161)

### DIFF
--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -37,6 +37,27 @@ def definition_for(product):
     return None
 
 
+def _binding(definition) -> dict:
+    """The product's declared collections, flattened into selector keys (ADR-0008).
+
+    Injected into every selector so a recipe can read its source/baseline/output
+    collection slugs from the declaration instead of reconstructing them — the
+    only way a scheduled/manual product (which has no trigger to learn from) can
+    know which collections it operates on. The engine still treats the selector
+    as opaque; only recipes interpret these keys.
+    """
+    return {
+        "inputs": [
+            {"role": r.role, "collection": r.collection, "tier": r.tier}
+            for r in definition.inputs
+        ],
+        "outputs": [
+            {"role": r.role, "collection": r.collection}
+            for r in definition.outputs
+        ],
+    }
+
+
 def _matches(definition, collection_slug: str, tier: str) -> bool:
     """True if the definition declares an input on this collection at this tier."""
     return any(
@@ -65,8 +86,10 @@ def collection_routes_to_staging(data_feed, collection_slug: str) -> bool:
 def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
     """
     Route an arriving-input ``trigger`` to every enabled DerivedProduct that
-    consumes it. For each match, build ``selector = {**config, **trigger}`` and
-    run the product's recipe, stamping the run with the product origin.
+    consumes it. For each match, build
+    ``selector = {**config, **binding, **trigger}`` (binding = the definition's
+    declared inputs/outputs) and run the product's recipe, stamping the run with
+    the product origin.
     """
     from georiva.processing.engine import run
     from georiva.processing.registry import recipe_registry
@@ -85,7 +108,7 @@ def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
         if recipe is None:
             logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
             continue
-        selector = {**(product.config or {}), **trigger}
+        selector = {**(product.config or {}), **_binding(definition), **trigger}
         results.extend(
             run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
         )
@@ -95,8 +118,9 @@ def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
 def run_product_now(product, *, dispatch: bool = True) -> list:
     """
     Manually trigger a product (ADR-0008) with a *wide* selector built from its
-    config and no event coordinate, so the recipe enumerates all of the
-    product's units — the same path as a backfill. Reuses the engine's run() and
+    config plus its declared binding (inputs/outputs) and no event coordinate, so
+    the recipe enumerates all of the product's units — the same path as a
+    backfill. Reuses the engine's run() and
     the product origin stamping. The caller (the tracking view) gates this on
     product readiness; the engine's per-unit readiness still applies underneath.
     """
@@ -110,7 +134,7 @@ def run_product_now(product, *, dispatch: bool = True) -> list:
     if recipe is None:
         logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
         return []
-    selector = dict(product.config or {})
+    selector = {**(product.config or {}), **_binding(definition)}
     return run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
 
 

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -133,6 +133,23 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
         """
         return []
 
+    def selected_definition_keys(self) -> list[str]:
+        """The collection-definition keys this feed is bound to.
+
+        Read from collection_links once the feed is saved, else from the
+        wizard's transient stash (``_wizard_selected_keys``, set by
+        ``_transient_feed_for_products`` at step 4 before any link exists). An
+        instance ``get_derived_products()`` calls this so it declares the same
+        per-resolution products at the wizard step and at provisioning (ADR-0008).
+        """
+        if self.pk:
+            return [
+                link.definition_key
+                for link in self.collection_links.all()
+                if link.definition_key
+            ]
+        return list(getattr(self, '_wizard_selected_keys', []))
+
     def get_derived_products(self) -> list['DerivedProductDefinition']:
         """
         Return the derived products this feed offers (ADR-0008).

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -87,6 +87,29 @@ class DispatchForInputTests(TestCase):
         self.assertEqual(selector["staging_item_id"], 5)
         self.assertEqual(run.call_args.kwargs["origin"], f"derived_product:{product.pk}")
 
+    def test_selector_carries_declared_inputs_and_outputs(self):
+        # The recipe must be able to read the product's declared collections
+        # from the selector (ADR-0008): a scheduled/manual recipe has no trigger
+        # to learn them from, so the invocation layer injects the declaration.
+        definition = _definition()
+        self._product(definition)
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(), dispatch=False)
+
+        selector = run.call_args.args[1]
+        self.assertEqual(
+            selector["inputs"],
+            [{"role": "source", "collection": "rainfall", "tier": "staging"}],
+        )
+        self.assertEqual(
+            selector["outputs"],
+            [{"role": "served", "collection": "rainfall"}],
+        )
+
     def test_product_on_a_different_collection_is_not_dispatched(self):
         definition = _definition(inputs=(
             InputRef(role="source", collection="temperature", tier="staging"),
@@ -267,6 +290,15 @@ class RunProductNowTests(TestCase):
 
         run.assert_called_once()
         selector = run.call_args.args[1]
-        # Wide selector = the product's config (no event trigger) -> backfill.
-        self.assertEqual(selector, {"baseline": "1991-2020"})
+        # Wide selector = the product's config + declared binding (no event
+        # trigger) -> backfill that can still read its collections.
+        self.assertEqual(selector["baseline"], "1991-2020")
+        self.assertEqual(
+            selector["inputs"],
+            [{"role": "source", "collection": "rainfall", "tier": "staging"}],
+        )
+        self.assertEqual(
+            selector["outputs"],
+            [{"role": "served", "collection": "rainfall"}],
+        )
         self.assertEqual(run.call_args.kwargs["origin"], product_origin(self.product))

--- a/georiva/src/georiva/sources/tests/test_derived_products.py
+++ b/georiva/src/georiva/sources/tests/test_derived_products.py
@@ -15,10 +15,11 @@ from georiva.core.derived_products import (
     InputRef,
     OutputRef,
 )
-from georiva.core.models import Catalog
-from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.core.models import Catalog, Collection
+from georiva.sources.models import DataFeed, DataFeedCollectionLink, DerivedProduct
 from georiva.sources.setup_service import SourceSetupService
 from georiva.sources.views import (
+    _transient_feed_for_products,
     build_product_config_form,
     selected_products_from_session,
 )
@@ -151,6 +152,63 @@ class BuildProductConfigFormTests(TestCase):
 
     def test_definition_without_options_has_no_form(self):
         self.assertIsNone(build_product_config_form(_definition(config_schema=())))
+
+
+class TransientFeedForProductsTests(TestCase):
+    """The wizard's step 4 declares products on an unsaved feed (no
+    collection_links yet), so the selected resolutions are stashed on the
+    transient instance for an instance get_derived_products() to read."""
+
+    def test_stashes_selected_collection_keys_from_the_session(self):
+        session = {
+            "catalog_mode": "create",
+            "new_catalog_slug": "chirps",
+            "new_catalog_name": "CHIRPS",
+            "selected_collection_keys": ["chirps-monthly", "chirps-dekadal"],
+        }
+
+        feed = _transient_feed_for_products(DataFeed, session)
+
+        self.assertIsNone(feed.pk)
+        self.assertEqual(
+            feed._wizard_selected_keys, ["chirps-monthly", "chirps-dekadal"]
+        )
+
+    def test_no_selection_stashes_an_empty_list(self):
+        feed = _transient_feed_for_products(DataFeed, {"catalog_mode": "create"})
+
+        self.assertEqual(feed._wizard_selected_keys, [])
+
+
+class SelectedDefinitionKeysTests(TestCase):
+    """A feed's active definition keys — what an instance get_derived_products()
+    binds its products to — come from collection_links once saved, or the
+    wizard's stash while still transient, and must agree across the two."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+
+    def test_saved_feed_reads_keys_from_collection_links(self):
+        feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        collection = Collection.objects.create(
+            catalog=self.catalog, slug="chirps-monthly", name="CHIRPS Monthly"
+        )
+        DataFeedCollectionLink.objects.create(
+            data_feed=feed, collection=collection, definition_key="chirps-monthly"
+        )
+
+        self.assertEqual(feed.selected_definition_keys(), ["chirps-monthly"])
+
+    def test_transient_feed_reads_keys_from_the_wizard_stash(self):
+        feed = DataFeed(name="Feed", catalog=self.catalog)
+        feed._wizard_selected_keys = ["chirps-monthly"]
+
+        self.assertEqual(feed.selected_definition_keys(), ["chirps-monthly"])
+
+    def test_transient_feed_without_a_stash_has_no_keys(self):
+        self.assertEqual(DataFeed(name="Feed").selected_definition_keys(), [])
 
 
 class SelectedProductsFromSessionTests(TestCase):

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -570,7 +570,12 @@ def selected_products_from_session(data_feed, session_data) -> list:
 def _transient_feed_for_products(model_cls, session_data):
     """An unsaved feed instance (carrying the wizard's chosen catalog) used only
     to ask the plugin which derived products it declares, before the feed is
-    provisioned."""
+    provisioned.
+
+    The feed has no collection_links yet, so the resolutions chosen in step 3 are
+    stashed on the instance as ``_wizard_selected_keys``. An instance
+    get_derived_products() reads links when the feed is saved, else this stash —
+    so the declared product set is identical at step 4 and at provisioning."""
     from georiva.core.models import Catalog
 
     catalog = None
@@ -581,7 +586,9 @@ def _transient_feed_for_products(model_cls, session_data):
         )
     elif session_data.get("catalog_id"):
         catalog = Catalog.objects.filter(pk=session_data["catalog_id"]).first()
-    return model_cls(catalog=catalog) if catalog else model_cls()
+    feed = model_cls(catalog=catalog) if catalog else model_cls()
+    feed._wizard_selected_keys = session_data.get("selected_collection_keys", [])
+    return feed
 
 
 def setup_wizard_select(request):


### PR DESCRIPTION
## What

Core `sources`-layer enablement for ADR-0008's first real plugin consumer (CHIRPS). The derivation engine stays generic; only the invocation layer and the wizard feed helper change.

**1. Declaration-injection into the selector.** `dispatch_for_input` and `run_product_now` now merge each `DerivedProduct`'s declared bindings into the selector:

```python
binding = {
    "inputs":  [{"role", "collection", "tier"} per InputRef],
    "outputs": [{"role", "collection"} per OutputRef],
}
selector = {**(product.config or {}), **binding, **trigger}   # trigger > binding > config
```

A recipe can now read its source/baseline/output collection slugs from the declaration instead of reconstructing them — the only way a scheduled/manual product (no trigger) can learn which collections it operates on. The engine continues to treat the selector as opaque.

**2. Transient-feed product enablement.** `get_derived_products()` is an instance method, but the wizard's step 4 calls it on an unsaved feed (no `collection_links`), while provisioning calls it on the saved feed. Added:
- `DataFeed.selected_definition_keys()` — reads `collection_links` when saved, else the wizard's `_wizard_selected_keys` stash.
- `_transient_feed_for_products` stashes `_wizard_selected_keys` from the wizard session.

So an instance `get_derived_products()` declares the same per-resolution product set at step 4 and at provisioning.

## Tests

Driven out with TDD (one RED→GREEN per behavior):
- selector carries declared `inputs`/`outputs` from `dispatch_for_input` and `run_product_now`
- trigger markers + config coexist with the binding
- `_transient_feed_for_products` stashes selected keys
- `selected_definition_keys()` agrees across transient (stash) and saved (links) feeds

Full `georiva.sources` + `georiva.processing` suite: **132 passing**.

## Note on the issue spec

The issue suggested verifying with a "stub feed subclass." Polymorphic Django model subclasses need DB tables, so instead I shipped `DataFeed.selected_definition_keys()` as a real, reusable method — the exact seam chirps#5 will call — and tested that. Acceptance met with shipped code rather than test-only scaffolding.

## Unblocks

wmo-raf/georiva-source-chirps#5

Closes #161.