### PR TITLE
feat(sources): wizard opt-out for derived products (#165)

### DIFF
--- a/georiva/src/georiva/core/derived_products.py
+++ b/georiva/src/georiva/core/derived_products.py
@@ -112,6 +112,7 @@ class DerivedProductDefinition:
     inputs: tuple
     outputs: tuple
     trigger_mode: str
+    default_enabled: bool = True
 
     def __post_init__(self):
         for field in ("key", "recipe_type", "label"):

--- a/georiva/src/georiva/core/test_derived_products.py
+++ b/georiva/src/georiva/core/test_derived_products.py
@@ -95,6 +95,15 @@ class DerivedProductDefinitionTests(SimpleTestCase):
                 with self.assertRaises(ValueError):
                     _definition(**{field: ""})
 
+    def test_default_enabled_defaults_to_true(self):
+        # An operator sees each product pre-ticked in the wizard unless the
+        # plugin declares otherwise, so existing declarations keep provisioning
+        # everything without change.
+        self.assertTrue(_definition().default_enabled)
+
+    def test_default_enabled_can_be_declared_false(self):
+        self.assertFalse(_definition(default_enabled=False).default_enabled)
+
     def test_dependency_edges_derived_from_declared_inputs(self):
         # The dependency graph is computable from the declaration alone — no DB,
         # no recipe execution — so the chain UI and readiness can be built ahead

--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -127,6 +127,12 @@ def run_product_now(product, *, dispatch: bool = True) -> list:
     from georiva.processing.engine import run
     from georiva.processing.registry import recipe_registry
 
+    # A disabled product is inert on every path — the event and scheduled paths
+    # filter on is_enabled upstream, and this manual/backfill overlay is the one
+    # entry they don't pre-filter, so it must gate here too.
+    if not product.is_enabled:
+        return []
+
     definition = definition_for(product)
     if definition is None:
         return []

--- a/georiva/src/georiva/sources/setup_service.py
+++ b/georiva/src/georiva/sources/setup_service.py
@@ -106,34 +106,42 @@ class SourceSetupService:
     
     def provision_derived_products(self, data_feed, selected_products: list) -> list:
         """
-        Provision DerivedProduct rows for a feed from selected definitions plus
-        operator config (ADR-0008).
+        Provision DerivedProduct rows for a feed from its declared definitions
+        plus operator config and per-product enablement (ADR-0008).
 
-        ``selected_products`` is a list of ``(DerivedProductDefinition, config)``
-        pairs. Each config is validated/coerced against the definition's
-        config_schema *before* any write, so an invalid option rejects the whole
-        batch atomically (nothing is half-provisioned). Idempotent: re-running
-        upserts on (data_feed, definition_key), so a wizard revisit edits rather
-        than duplicates.
+        ``selected_products`` is a list of ``(DerivedProductDefinition, config,
+        enabled)`` triples — one per *declared* definition, whether the operator
+        ticked it or not. Each config is validated/coerced against the
+        definition's config_schema *before* any write, so an invalid option
+        rejects the whole batch atomically (nothing is half-provisioned).
+
+        Idempotent: re-running upserts on (data_feed, definition_key), so a
+        wizard revisit edits config rather than duplicating. ``is_enabled`` is
+        set via ``create_defaults`` — only on row creation — so a re-run never
+        clobbers an enable/disable toggle an operator changed after setup.
         """
         from georiva.sources.models import DerivedProduct
 
         with transaction.atomic():
             products = []
-            for definition, config in selected_products:
+            for definition, config, enabled in selected_products:
                 cleaned = definition.validate_config(config or {})
+                # ``defaults`` drives the update path (config edits on a wizard
+                # re-run); ``create_defaults`` drives the create path and is a
+                # superset that also seeds is_enabled — so is_enabled is written
+                # once at creation and a re-run never flips an operator's toggle.
+                shared = {"recipe_type": definition.recipe_type, "config": cleaned}
                 product, _created = DerivedProduct.objects.update_or_create(
                     data_feed=data_feed,
                     definition_key=definition.key,
-                    defaults={
-                        "recipe_type": definition.recipe_type,
-                        "config": cleaned,
-                    },
+                    defaults=shared,
+                    create_defaults={**shared, "is_enabled": bool(enabled)},
                 )
                 products.append(product)
                 logger.info(
-                    "DerivedProduct %s: feed=%s product=%s",
-                    "created" if _created else "updated", data_feed.pk, definition.key,
+                    "DerivedProduct %s: feed=%s product=%s enabled=%s",
+                    "created" if _created else "updated",
+                    data_feed.pk, definition.key, product.is_enabled,
                 )
             return products
 

--- a/georiva/src/georiva/sources/templates/georivasources/wizard_step4_products.html
+++ b/georiva/src/georiva/sources/templates/georivasources/wizard_step4_products.html
@@ -63,10 +63,28 @@
             background: var(--w-color-grey-50);
         }
 
+        .gprod-card__toggle {
+            display: flex;
+            align-items: center;
+            gap: 0.55em;
+            margin: 0 0 0.2em;
+            cursor: pointer;
+        }
+
+        .gprod-card__enable {
+            width: 1.05em;
+            height: 1.05em;
+            flex: 0 0 auto;
+        }
+
         .gprod-card__name {
             font-weight: 700;
             font-size: 1em;
-            margin: 0 0 0.2em;
+            margin: 0;
+        }
+
+        .gprod-card--disabled {
+            opacity: 0.6;
         }
 
         .gprod-card__desc {
@@ -121,9 +139,14 @@
 
             {% for entry in product_entries %}
                 {% with defn=entry.definition form=entry.config_form %}
-                    <div class="gprod-card" id="gprod-{{ defn.key }}">
+                    <div class="gprod-card{% if not entry.checked %} gprod-card--disabled{% endif %}" id="gprod-{{ defn.key }}">
                         <div class="gprod-card__header">
-                            <p class="gprod-card__name">{{ defn.label }}</p>
+                            <label class="gprod-card__toggle">
+                                <input type="checkbox" class="gprod-card__enable"
+                                       name="products" value="{{ defn.key }}"
+                                       {% if entry.checked %}checked{% endif %}>
+                                <span class="gprod-card__name">{{ defn.label }}</span>
+                            </label>
                             {% if defn.description %}
                                 <p class="gprod-card__desc">{{ defn.description }}</p>
                             {% endif %}
@@ -169,4 +192,28 @@
             </div>
         </form>
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const cards = document.querySelectorAll('.gprod-card');
+            cards.forEach(function (card) {
+                const checkbox = card.querySelector('.gprod-card__enable');
+                const config = card.querySelector('.gprod-config-section');
+                if (!checkbox) {
+                    return;
+                }
+                const sync = function () {
+                    card.classList.toggle('gprod-card--disabled', !checkbox.checked);
+                    if (config) {
+                        config.hidden = !checkbox.checked;
+                    }
+                };
+                checkbox.addEventListener('change', sync);
+                sync();
+            });
+        });
+    </script>
 {% endblock %}

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -302,3 +302,19 @@ class RunProductNowTests(TestCase):
             [{"role": "served", "collection": "rainfall"}],
         )
         self.assertEqual(run.call_args.kwargs["origin"], product_origin(self.product))
+
+    def test_disabled_product_dispatches_nothing(self):
+        # A disabled product is inert on every path: event and scheduled already
+        # filter on is_enabled, and the manual/backfill overlay must refuse it
+        # too, so an unticked product fires no run when data arrives or on demand.
+        self.product.is_enabled = False
+        self.product.save(update_fields=["is_enabled"])
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[_definition()]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            result = run_product_now(self.product, dispatch=False)
+
+        run.assert_not_called()
+        self.assertEqual(result, [])

--- a/georiva/src/georiva/sources/tests/test_derived_products.py
+++ b/georiva/src/georiva/sources/tests/test_derived_products.py
@@ -92,7 +92,7 @@ class ProvisionDerivedProductsTests(TestCase):
     def test_creates_a_row_per_selected_definition(self):
         self.service.provision_derived_products(
             self.feed,
-            [(_definition(), {"quantity": "anomaly", "min_years": "25"})],
+            [(_definition(), {"quantity": "anomaly", "min_years": "25"}, True)],
         )
 
         product = DerivedProduct.objects.get(data_feed=self.feed, definition_key="anomaly")
@@ -100,6 +100,17 @@ class ProvisionDerivedProductsTests(TestCase):
         # Config is validated/coerced through the definition's config_schema.
         self.assertEqual(product.config, {"quantity": "anomaly", "min_years": 25})
         self.assertTrue(product.is_enabled)
+
+    def test_unticked_definition_provisions_a_disabled_row(self):
+        # Every declared product gets a row; an operator's opt-out is recorded as
+        # is_enabled=False, not as a missing row — so it stays visible and
+        # re-enablable later.
+        self.service.provision_derived_products(
+            self.feed, [(_definition(), {}, False)]
+        )
+
+        product = DerivedProduct.objects.get(data_feed=self.feed, definition_key="anomaly")
+        self.assertFalse(product.is_enabled)
 
     def test_invalid_config_rejects_the_batch_without_writing_any_rows(self):
         good = _definition(key="promotion", recipe_type="promotion", config_schema=())
@@ -109,8 +120,8 @@ class ProvisionDerivedProductsTests(TestCase):
             self.service.provision_derived_products(
                 self.feed,
                 [
-                    (good, {}),
-                    (bad, {"quantity": "not-a-choice"}),
+                    (good, {}, True),
+                    (bad, {"quantity": "not-a-choice"}, True),
                 ],
             )
 
@@ -119,15 +130,63 @@ class ProvisionDerivedProductsTests(TestCase):
 
     def test_reprovisioning_updates_in_place_rather_than_duplicating(self):
         self.service.provision_derived_products(
-            self.feed, [(_definition(), {"min_years": "30"})]
+            self.feed, [(_definition(), {"min_years": "30"}, True)]
         )
         self.service.provision_derived_products(
-            self.feed, [(_definition(), {"min_years": "50"})]
+            self.feed, [(_definition(), {"min_years": "50"}, True)]
         )
 
         products = DerivedProduct.objects.filter(data_feed=self.feed, definition_key="anomaly")
         self.assertEqual(products.count(), 1)
         self.assertEqual(products.get().config["min_years"], 50)
+
+    def test_creates_a_row_for_every_declared_definition_ticked_or_not(self):
+        # Provisioning is "a row per declared definition", not "rows for what's
+        # ticked" — the opt-out lives in is_enabled, not in row presence.
+        anomaly = _definition(key="anomaly")
+        promotion = _definition(key="promotion", recipe_type="promotion", config_schema=())
+
+        self.service.provision_derived_products(
+            self.feed,
+            [(anomaly, {}, True), (promotion, {}, False)],
+        )
+
+        rows = DerivedProduct.objects.filter(data_feed=self.feed).order_by("definition_key")
+        self.assertEqual(
+            [(r.definition_key, r.is_enabled) for r in rows],
+            [("anomaly", True), ("promotion", False)],
+        )
+
+    def test_reprovisioning_never_flips_an_existing_is_enabled(self):
+        # is_enabled is a create-time default: once a row exists, re-running the
+        # wizard edits config but must not clobber a toggle the operator changed
+        # after setup.
+        self.service.provision_derived_products(
+            self.feed, [(_definition(), {"min_years": "30"}, True)]
+        )
+        # Operator later disables it out-of-band.
+        product = DerivedProduct.objects.get(data_feed=self.feed, definition_key="anomaly")
+        product.is_enabled = False
+        product.save(update_fields=["is_enabled"])
+
+        # Wizard re-run arrives with enabled=True again.
+        self.service.provision_derived_products(
+            self.feed, [(_definition(), {"min_years": "50"}, True)]
+        )
+
+        product.refresh_from_db()
+        self.assertFalse(product.is_enabled)      # toggle preserved
+        self.assertEqual(product.config["min_years"], 50)   # config still updated
+
+    def test_unticked_product_provisions_with_schema_defaults(self):
+        # An unticked product is validated with an empty config, so it lands with
+        # its declared schema defaults filled in — ready to run if enabled later.
+        self.service.provision_derived_products(
+            self.feed, [(_definition(), {}, False)]
+        )
+
+        product = DerivedProduct.objects.get(data_feed=self.feed, definition_key="anomaly")
+        self.assertEqual(product.config, {"quantity": "anomaly", "min_years": 30})
 
 
 class BuildProductConfigFormTests(TestCase):
@@ -212,30 +271,69 @@ class SelectedDefinitionKeysTests(TestCase):
 
 
 class SelectedProductsFromSessionTests(TestCase):
+    """The wizard hands provisioning a triple for *every* declared definition —
+    enablement from the operator's tick selection, config from the step-4 form —
+    so provisioning always writes a full row set with the opt-out in is_enabled."""
+
     def setUp(self):
         self.catalog = Catalog.objects.create(
             name="CHIRPS", slug="chirps", file_format="geotiff"
         )
         self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
 
-    def test_pairs_each_stored_config_with_its_declared_definition(self):
+    def test_yields_a_triple_for_every_declared_definition(self):
+        anomaly = _definition(key="anomaly")
+        promotion = _definition(key="promotion")
+        session = {
+            "derived_products_config": {"anomaly": {"min_years": 25}},
+            "selected_product_keys": ["anomaly"],
+        }
+
+        with patch.object(DataFeed, "get_derived_products",
+                          return_value=[anomaly, promotion]):
+            triples = selected_products_from_session(self.feed, session)
+
+        # A triple per declared definition; enabled reflects the tick selection,
+        # config comes from the step-4 form (or {} for an unticked product).
+        self.assertEqual(
+            triples,
+            [(anomaly, {"min_years": 25}, True), (promotion, {}, False)],
+        )
+
+    def test_empty_selection_disables_every_product(self):
+        # Unticking all is a real choice — an empty list is honoured, not
+        # treated as "no selection made".
         defn = _definition()
-        session = {"derived_products_config": {"anomaly": {"min_years": 25}}}
+        session = {"selected_product_keys": []}
 
         with patch.object(DataFeed, "get_derived_products", return_value=[defn]):
-            pairs = selected_products_from_session(self.feed, session)
+            triples = selected_products_from_session(self.feed, session)
 
-        self.assertEqual(pairs, [(defn, {"min_years": 25})])
+        self.assertEqual(triples, [(defn, {}, False)])
+
+    def test_absent_selection_falls_back_to_default_enabled(self):
+        # No selection stored (e.g. a stale/short-circuit path) → the plugin's
+        # declared default_enabled decides, so nothing regresses to disabled.
+        on = _definition(key="on", default_enabled=True)
+        off = _definition(key="off", default_enabled=False)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[on, off]):
+            triples = selected_products_from_session(self.feed, {})
+
+        self.assertEqual(triples, [(on, {}, True), (off, {}, False)])
 
     def test_ignores_config_for_undeclared_products(self):
         defn = _definition()
-        session = {"derived_products_config": {"ghost": {}}}
+        session = {
+            "derived_products_config": {"anomaly": {}, "ghost": {"x": 1}},
+            "selected_product_keys": ["anomaly", "ghost"],
+        }
 
         with patch.object(DataFeed, "get_derived_products", return_value=[defn]):
-            pairs = selected_products_from_session(self.feed, session)
+            triples = selected_products_from_session(self.feed, session)
 
-        self.assertEqual(pairs, [])
+        self.assertEqual(triples, [(defn, {}, True)])
 
-    def test_no_products_section_yields_nothing(self):
+    def test_no_declared_products_yields_nothing(self):
         with patch.object(DataFeed, "get_derived_products", return_value=[]):
             self.assertEqual(selected_products_from_session(self.feed, {}), [])

--- a/georiva/src/georiva/sources/tests/test_wizard_products.py
+++ b/georiva/src/georiva/sources/tests/test_wizard_products.py
@@ -1,0 +1,235 @@
+"""
+Admin HTTP-seam tests for the wizard's Derived Products step (issue #165).
+
+Operators opt individual derived products in/out via a checkbox per product.
+The step pre-ticks from each definition's ``default_enabled`` (or the prior
+session selection on a back-navigation), validates config only for ticked
+products, and carries the selection through to provisioning — which writes a
+row for *every* declared definition with the opt-out in ``is_enabled``.
+
+The wizard resolves an operator-chosen source type to a concrete DataFeed
+subclass; core ships none (they come from plugins), so these tests drive the
+base DataFeed as the model, patching model resolution and the feed's declared
+products.
+"""
+import re
+
+from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch
+
+from georiva.core.derived_products import (
+    ConfigField,
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from django.contrib.auth import get_user_model
+
+from georiva.core.models import Catalog
+from georiva.sources.models import DataFeed, DerivedProduct
+
+User = get_user_model()
+
+MODEL_NAME = "datafeed"
+SESSION_KEY = f"georiva_setup_wizard_{MODEL_NAME}"
+
+
+def _definition(**overrides):
+    kwargs = dict(
+        key="anomaly",
+        recipe_type="climatology",
+        label="Rainfall anomaly",
+        description="Anomaly vs a baseline.",
+        config_schema=(
+            ConfigField(key="quantity", type="choice",
+                        choices=("anomaly", "value"), default="anomaly"),
+            ConfigField(key="min_years", type="int", default=30),
+        ),
+        inputs=(InputRef(role="value", collection="rainfall", tier="staging"),),
+        outputs=(OutputRef(role="anomaly", collection="rainfall-anomaly"),),
+        trigger_mode="scheduled",
+    )
+    kwargs.update(overrides)
+    return DerivedProductDefinition(**kwargs)
+
+
+def _checkbox_is_checked(html, key):
+    """Whether the enable checkbox for ``key`` is rendered ``checked``."""
+    match = re.search(
+        rf'<input[^>]*name="products"[^>]*value="{key}"[^>]*>', html
+    )
+    assert match, f"no enable checkbox rendered for product '{key}'"
+    return "checked" in match.group(0)
+
+
+class WizardStepBase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser("wiz", "w@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+
+    def _set_session(self, **extra):
+        session = self.client.session
+        session[SESSION_KEY] = {"selected_collection_keys": ["chirps-monthly"], **extra}
+        session.save()
+
+    def _step4_url(self):
+        return reverse("wizard_step4_products", kwargs={"model_name": MODEL_NAME})
+
+
+class Step4EnableCheckboxTests(WizardStepBase):
+    def test_get_pre_ticks_from_default_enabled(self):
+        self._set_session()
+        on = _definition(key="on", default_enabled=True)
+        off = _definition(key="off", default_enabled=False)
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[on, off]),
+        ):
+            response = self.client.get(self._step4_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertTrue(_checkbox_is_checked(html, "on"))
+        self.assertFalse(_checkbox_is_checked(html, "off"))
+
+    def test_get_pre_ticks_from_the_prior_session_selection(self):
+        # A back-navigation restores the operator's earlier ticks, overriding the
+        # declared defaults: 'on' was unticked and 'off' was ticked last time.
+        self._set_session(selected_product_keys=["off"])
+        on = _definition(key="on", default_enabled=True)
+        off = _definition(key="off", default_enabled=False)
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[on, off]),
+        ):
+            response = self.client.get(self._step4_url())
+
+        html = response.content.decode()
+        self.assertFalse(_checkbox_is_checked(html, "on"))
+        self.assertTrue(_checkbox_is_checked(html, "off"))
+
+
+class Step4PostTests(WizardStepBase):
+    def test_post_records_the_selection_and_only_validates_ticked_products(self):
+        self._set_session()
+        ticked = _definition(key="ticked", config_schema=(
+            ConfigField(key="min_years", type="int", default=30),
+        ))
+        optout = _definition(key="optout", config_schema=(
+            ConfigField(key="quantity", type="choice",
+                        choices=("anomaly", "value"), default="anomaly"),
+        ))
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[ticked, optout]),
+        ):
+            response = self.client.post(self._step4_url(), {
+                "products": ["ticked"],          # optout is unticked
+                "ticked-min_years": "40",
+                # An out-of-choices value that WOULD fail validation if optout
+                # were validated — it must be ignored because optout is unticked.
+                "optout-quantity": "trend",
+            })
+
+        # No validation error -> straight through to provisioning.
+        self.assertRedirects(
+            response,
+            reverse("wizard_provision", kwargs={"model_name": MODEL_NAME}),
+            fetch_redirect_response=False,
+        )
+        session = self.client.session[SESSION_KEY]
+        self.assertEqual(session["selected_product_keys"], ["ticked"])
+        self.assertEqual(session["derived_products_config"]["ticked"], {"min_years": 40})
+        # Unticked product carries no config -> provisions with schema defaults.
+        self.assertEqual(session["derived_products_config"]["optout"], {})
+
+    def test_post_reports_a_bad_config_on_a_ticked_product(self):
+        self._set_session()
+        ticked = _definition(key="ticked", config_schema=(
+            ConfigField(key="quantity", type="choice",
+                        choices=("anomaly", "value"), default="anomaly"),
+        ))
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[ticked]),
+        ):
+            response = self.client.post(self._step4_url(), {
+                "products": ["ticked"],
+                "ticked-quantity": "trend",   # not among choices
+            })
+
+        # Re-renders the step (no redirect) because a ticked product is invalid.
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("selected_product_keys", self.client.session.get(SESSION_KEY, {}))
+
+
+class WizardProvisionSeamTests(WizardStepBase):
+    """The end of the seam: a completed wizard session provisions a row for every
+    declared definition, with the opt-out landing as is_enabled=False and staying
+    visible (disabled) in the tracking dashboard."""
+
+    def _complete_session(self, **extra):
+        session = self.client.session
+        session[SESSION_KEY] = {
+            "selected_collection_keys": ["chirps-monthly"],
+            "catalog_mode": "select",
+            "catalog_id": self.catalog.pk,
+            "new_feed_name": "CHIRPS Feed",
+            "new_feed_interval": 360,
+            **extra,
+        }
+        session.save()
+
+    def test_provision_creates_a_row_per_definition_with_selected_enablement(self):
+        anomaly = _definition(key="anomaly", config_schema=())
+        promotion = _definition(key="promotion", recipe_type="promotion", config_schema=())
+        self._complete_session(
+            selected_product_keys=["anomaly"],   # promotion unticked
+            derived_products_config={"anomaly": {}, "promotion": {}},
+        )
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[anomaly, promotion]),
+        ):
+            response = self.client.get(
+                reverse("wizard_provision", kwargs={"model_name": MODEL_NAME})
+            )
+
+        self.assertEqual(response.status_code, 302)
+        rows = {p.definition_key: p for p in DerivedProduct.objects.all()}
+        self.assertEqual(set(rows), {"anomaly", "promotion"})
+        self.assertTrue(rows["anomaly"].is_enabled)
+        self.assertFalse(rows["promotion"].is_enabled)
+
+    def test_disabled_product_appears_in_the_tracking_dashboard(self):
+        anomaly = _definition(key="anomaly", config_schema=())
+        promotion = _definition(key="promotion", recipe_type="promotion", config_schema=())
+        self._complete_session(
+            selected_product_keys=["anomaly"],
+            derived_products_config={"anomaly": {}, "promotion": {}},
+        )
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=[anomaly, promotion]),
+        ):
+            self.client.get(
+                reverse("wizard_provision", kwargs={"model_name": MODEL_NAME})
+            )
+            response = self.client.get(reverse("derived_product_tracking"))
+
+        # The opted-out product is inert but still listed (disabled), ready to be
+        # enabled later with one toggle.
+        self.assertContains(response, "promotion")
+        self.assertFalse(
+            DerivedProduct.objects.get(definition_key="promotion").is_enabled
+        )

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -553,18 +553,28 @@ def build_product_config_form(definition):
 
 def selected_products_from_session(data_feed, session_data) -> list:
     """
-    Map the wizard's stored per-product config back onto the feed's declared
-    DerivedProductDefinitions, as ``(definition, config)`` pairs ready for
-    SourceSetupService.provision_derived_products. Config stored for a product
-    the feed no longer declares (a stale session) is skipped.
+    Map the wizard session onto the feed's declared DerivedProductDefinitions as
+    ``(definition, config, enabled)`` triples ready for
+    SourceSetupService.provision_derived_products.
+
+    A triple is produced for *every* declared definition — provisioning always
+    writes a full row set, with an operator's opt-out carried as ``enabled``
+    rather than a missing row. ``enabled`` comes from the step-4 tick selection
+    (``selected_product_keys``); if no selection was stored (a short-circuit or
+    stale path) each product falls back to its declared ``default_enabled``. An
+    empty selection list is honoured as "all unticked", not "no selection".
+    Config stored for a product the feed no longer declares is ignored.
     """
     products_config = session_data.get("derived_products_config", {})
-    by_key = {d.key: d for d in data_feed.get_derived_products()}
-    return [
-        (by_key[key], config)
-        for key, config in products_config.items()
-        if key in by_key
-    ]
+    selected_keys = session_data.get("selected_product_keys")
+    triples = []
+    for defn in data_feed.get_derived_products():
+        if selected_keys is None:
+            enabled = defn.default_enabled
+        else:
+            enabled = defn.key in selected_keys
+        triples.append((defn, products_config.get(defn.key, {}), enabled))
+    return triples
 
 
 def _transient_feed_for_products(model_cls, session_data):
@@ -883,6 +893,10 @@ def wizard_step4_products(request, model_name):
 
     verbose_name = model_cls._meta.verbose_name
     saved = session_data.get("derived_products_config", {})
+    # Prior tick selection, if the operator has visited this step before (a
+    # back-navigation); None means "not chosen yet" -> fall back to default_enabled.
+    session_selected = session_data.get("selected_product_keys")
+    posted_selected = set(request.POST.getlist("products")) if request.method == "POST" else None
 
     entries = []
     for defn in definitions:
@@ -893,14 +907,26 @@ def wizard_step4_products(request, model_name):
             form = form_cls(request.POST, prefix=defn.key)
         else:
             form = form_cls(initial=saved.get(defn.key, {}), prefix=defn.key)
-        entries.append({"definition": defn, "config_form": form})
+
+        if posted_selected is not None:
+            checked = defn.key in posted_selected
+        elif session_selected is not None:
+            checked = defn.key in session_selected
+        else:
+            checked = defn.default_enabled
+
+        entries.append({"definition": defn, "config_form": form, "checked": checked})
 
     if request.method == "POST":
         errors = []
         products_config = {}
         for entry in entries:
             defn, form = entry["definition"], entry["config_form"]
-            if form is None:
+            # Config is validated only for ticked products; an unticked product
+            # (or a ticked one with no options) provisions with schema defaults
+            # (empty config), so a bad value on a product the operator opted out
+            # of never blocks the wizard.
+            if not entry["checked"] or form is None:
                 products_config[defn.key] = {}
             elif form.is_valid():
                 products_config[defn.key] = {
@@ -911,6 +937,9 @@ def wizard_step4_products(request, model_name):
 
         if not errors:
             session_data["derived_products_config"] = products_config
+            session_data["selected_product_keys"] = [
+                e["definition"].key for e in entries if e["checked"]
+            ]
             request.session[_wizard_session_key(model_name)] = session_data
             return redirect("wizard_provision", model_name=model_name)
 


### PR DESCRIPTION
## What this does

Slice 1 of #164. Operators can now **opt individual derived products in/out** in the wizard's Derived Products step, instead of every declared product being provisioned unconditionally.

Demo: run the CHIRPS wizard, untick anomaly, provision → anomaly appears **disabled** in tracking and dispatches nothing when data arrives, but is one toggle away from being enabled later.

Closes #165.

## Changes by seam

| Seam | Change |
|------|--------|
| **Contract** (`core/derived_products.py`) | `default_enabled: bool = True` on `DerivedProductDefinition` — defaulted, so existing plugin declarations stay valid unchanged. |
| **Wizard step 4** (`sources/views.py` + template) | Enable checkbox per product, pre-ticked from the session selection (survives back/forward navigation) or `default_enabled`. Config validated **only for ticked** products; the selection is carried in the session as `selected_product_keys`. JS greys out and hides the config section for unticked products. |
| **Provisioning** (`sources/setup_service.py`) | `provision_derived_products` now takes `(definition, config, enabled)` **triples** and writes a row for **every** declared definition. `is_enabled` is seeded via `create_defaults`, so a wizard re-run edits config but **never flips** a toggle an operator changed later. |
| **Session mapping** (`sources/views.py`) | `selected_products_from_session` yields a triple per declared definition — `enabled` from the tick selection, falling back to `default_enabled`; an empty selection is honoured as "all unticked". |
| **Invocation** (`sources/derivation_invocation.py`) | `run_product_now` refuses a disabled product, closing the one dispatch path (manual/backfill) that wasn't already `is_enabled`-filtered. Event + scheduled paths already filter, so an unticked product is fully inert. |

## Acceptance criteria (#165)

- [x] `DerivedProductDefinition` has `default_enabled: bool = True`; the wizard pre-ticks from it; existing declarations remain valid
- [x] Wizard step renders an enable checkbox per product; selection carried in the session and survives back/forward navigation
- [x] Provisioning creates a `DerivedProduct` row for every declared definition; `is_enabled` from selection, applied only on row creation (re-run updates config, never flips the toggle)
- [x] Unticked products trigger no event/scheduled/manual dispatch, and appear as disabled rows in the tracking dashboard
- [x] Config forms validated only for ticked products; unticked provision with defaults
- [x] Tested at the admin HTTP seam (wizard POST → provisioned rows) and service seam; contract test covers the new field

## Testing

Built test-first (TDD) across 10 red→green slices. All **143** `georiva.core` + `georiva.sources` tests pass.

New/updated coverage:
- `core/test_derived_products.py` — `default_enabled` default + settable
- `sources/tests/test_derived_products.py` — provision-every-definition, create-time-only `is_enabled`, unticked→schema defaults, triple session mapping
- `sources/tests/test_derivation_invocation.py` — disabled product dispatches nothing on the manual path
- `sources/tests/test_wizard_products.py` (new) — admin HTTP seam: checkbox pre-tick from default/session, config validated only for ticked, provision → rows, disabled row in tracking dashboard

## Notes

- **No migration**: `default_enabled` lives on the pure dataclass; `DerivedProduct.is_enabled` already existed.
- **Django `create_defaults` gotcha**: on the create path Django uses *only* `create_defaults` (not `defaults`), so it's a superset (`{recipe_type, config, is_enabled}`) — this is what makes `is_enabled` create-time-only.
- **Out of scope** (later #164 slices): the tracking-dashboard toggle still flips `is_enabled` raw rather than routing through a service; no dependency-chain gating yet.
