### PR TITLE
feat(sources): product dependency chain module + dependency-aware wizard (#166)

### DIFF
--- a/georiva/src/georiva/core/derived_products.py
+++ b/georiva/src/georiva/core/derived_products.py
@@ -113,6 +113,11 @@ class DerivedProductDefinition:
     outputs: tuple
     trigger_mode: str
     default_enabled: bool = True
+    # Explicit product-level dependencies the tier-aware data-flow rule can't
+    # infer (a product needing another's side effect, not its output collection).
+    # The chain module unions these with the inferred edges; unknown targets are
+    # caught there, where the full definition set is available.
+    depends_on: tuple = ()
 
     def __post_init__(self):
         for field in ("key", "recipe_type", "label"):
@@ -125,6 +130,16 @@ class DerivedProductDefinition:
                 f"DerivedProductDefinition '{self.key}': trigger_mode must be "
                 f"one of {TRIGGER_MODES}, got '{self.trigger_mode}'"
             )
+        for dep in self.depends_on:
+            if not dep:
+                raise ValueError(
+                    f"DerivedProductDefinition '{self.key}': depends_on entries "
+                    f"must be non-empty"
+                )
+            if dep == self.key:
+                raise ValueError(
+                    f"DerivedProductDefinition '{self.key}': cannot depend on itself"
+                )
 
     def validate_config(self, config: dict) -> dict:
         """

--- a/georiva/src/georiva/core/product_chain.py
+++ b/georiva/src/georiva/core/product_chain.py
@@ -1,0 +1,168 @@
+"""
+Pure product-dependency chain (ADR-0008/0009).
+
+The product-level DAG over a feed's declared derived products: product P depends
+on product Q iff a **required** input of P at **published** tier names a
+collection among Q's outputs, unioned with P's explicit ``depends_on``. Tier
+awareness is essential — a staging-tier input is fed by the loader, not by
+another product, so a tier-blind rule would fabricate edges (e.g. anomaly ->
+promotion in CHIRPS).
+
+Everything here is pure over a ``Sequence[DerivedProductDefinition]``: no DB, no
+recipe execution, so the module is importable from both the feed layer
+(``sources``) and the engine (``processing``) without a backwards dependency
+(ADR-0005). The DB-backed resolution of declared inputs into catalog items lives
+in ``processing``; this module is graph math only.
+"""
+from __future__ import annotations
+
+
+class ChainError(ValueError):
+    """A derived-product chain declaration is invalid (bad structure)."""
+
+
+class ChainCycleError(ChainError):
+    """The declared products form a dependency cycle."""
+
+
+def _raw_dependencies(defs) -> dict:
+    """Dependency map *including* any self-edge — used for cycle detection so a
+    product that (nonsensically) consumes its own output at required published
+    tier surfaces as a self-loop rather than being silently dropped."""
+    outputs_to_producers: dict[str, set[str]] = {}
+    for defn in defs:
+        for ref in defn.outputs:
+            outputs_to_producers.setdefault(ref.collection, set()).add(defn.key)
+
+    deps: dict[str, set[str]] = {}
+    for defn in defs:
+        result: set[str] = set()
+        for ref in defn.inputs:
+            if not ref.required or ref.tier != "published":
+                continue
+            result |= outputs_to_producers.get(ref.collection, set())
+        result |= set(defn.depends_on)
+        deps[defn.key] = result
+    return deps
+
+
+def product_dependencies(defs) -> dict:
+    """
+    Map each product key to the set of product keys it depends on.
+
+    An edge P -> Q exists iff a *required*, *published*-tier input of P names a
+    collection among Q's outputs, or Q is listed in P's ``depends_on``. A
+    product never lists itself (a self-edge is dropped here; it is caught as a
+    cycle by ``validate_chain``).
+    """
+    deps = _raw_dependencies(defs)
+    for key, upstream in deps.items():
+        upstream.discard(key)
+    return deps
+
+
+def product_dependents(defs) -> dict:
+    """Map each product key to the set of keys that depend on it — the inverse
+    of ``product_dependencies``, the cascade direction for disable."""
+    deps = product_dependencies(defs)
+    dependents: dict[str, set[str]] = {key: set() for key in deps}
+    for key, upstream in deps.items():
+        for target in upstream:
+            dependents.setdefault(target, set()).add(key)
+    return dependents
+
+
+def _closure(adjacency: dict, key) -> set:
+    """Transitive reachable set from ``key`` over ``adjacency``, excluding
+    ``key`` itself."""
+    seen: set[str] = set()
+    stack = list(adjacency.get(key, set()))
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(adjacency.get(node, set()))
+    seen.discard(key)
+    return seen
+
+
+def dependencies_closure(defs, key) -> set:
+    """Every product ``key`` transitively depends on — the set that must be
+    enabled for ``key`` to be enabled (auto-tick / structural gate)."""
+    return _closure(product_dependencies(defs), key)
+
+
+def dependents_closure(defs, key) -> set:
+    """Every product that transitively depends on ``key`` — the set disabling
+    ``key`` cascades to (the confirmation set)."""
+    return _closure(product_dependents(defs), key)
+
+
+def validate_chain(defs) -> None:
+    """
+    Raise loudly on a malformed chain so a broken plugin fails at first
+    render/provision, never silently mid-sweep:
+
+    - duplicate product keys -> ``ChainError``
+    - a ``depends_on`` naming a product that isn't declared -> ``ChainError``
+    - a dependency cycle, whether inferred from data flow or declared via
+      ``depends_on`` (a self-loop is the degenerate 1-cycle) -> ``ChainCycleError``
+    """
+    seen: set[str] = set()
+    for defn in defs:
+        if defn.key in seen:
+            raise ChainError(f"duplicate product key '{defn.key}'")
+        seen.add(defn.key)
+
+    for defn in defs:
+        for dep in defn.depends_on:
+            if dep not in seen:
+                raise ChainError(
+                    f"product '{defn.key}' depends on unknown product '{dep}'"
+                )
+
+    graph = _raw_dependencies(defs)
+    # Three-colour DFS: WHITE=unseen, GREY=on the current path, BLACK=done.
+    # Re-encountering a GREY node closes a cycle.
+    WHITE, GREY, BLACK = 0, 1, 2
+    colour = {key: WHITE for key in graph}
+
+    def visit(node):
+        colour[node] = GREY
+        for nxt in graph.get(node, ()):
+            if colour[nxt] == GREY:
+                raise ChainCycleError(
+                    f"derived-product dependency cycle through '{nxt}'"
+                )
+            if colour[nxt] == WHITE:
+                visit(nxt)
+        colour[node] = BLACK
+
+    for key in graph:
+        if colour[key] == WHITE:
+            visit(key)
+
+
+def topological_stages(defs) -> list:
+    """
+    Group the products into topological stages (Kahn layering): every product in
+    stage *n* depends only on products in stages < *n*. Order within a stage,
+    and thus across the whole result, follows declaration order — so the wizard's
+    stage lanes are stable. Calls ``validate_chain`` first, so a malformed chain
+    raises rather than producing a partial layering.
+    """
+    validate_chain(defs)
+    deps = product_dependencies(defs)
+    by_key = {defn.key: defn for defn in defs}
+    order = [defn.key for defn in defs]
+
+    remaining = set(order)
+    placed: set[str] = set()
+    stages: list = []
+    while remaining:
+        ready = [k for k in order if k in remaining and deps[k] <= placed]
+        stages.append([by_key[k] for k in ready])
+        remaining -= set(ready)
+        placed |= set(ready)
+    return stages

--- a/georiva/src/georiva/core/test_derived_products.py
+++ b/georiva/src/georiva/core/test_derived_products.py
@@ -104,6 +104,24 @@ class DerivedProductDefinitionTests(SimpleTestCase):
     def test_default_enabled_can_be_declared_false(self):
         self.assertFalse(_definition(default_enabled=False).default_enabled)
 
+    def test_depends_on_defaults_to_empty(self):
+        self.assertEqual(_definition().depends_on, ())
+
+    def test_depends_on_accepts_declared_extras(self):
+        # Non-data-flow dependencies the tier-aware rule can't infer are declared
+        # explicitly; the chain module unions them with the inferred edges.
+        self.assertEqual(
+            _definition(depends_on=("climatology",)).depends_on, ("climatology",)
+        )
+
+    def test_empty_depends_on_entry_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _definition(depends_on=("",))
+
+    def test_self_referential_depends_on_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _definition(key="anomaly", depends_on=("anomaly",))
+
     def test_dependency_edges_derived_from_declared_inputs(self):
         # The dependency graph is computable from the declaration alone — no DB,
         # no recipe execution — so the chain UI and readiness can be built ahead

--- a/georiva/src/georiva/core/test_product_chain.py
+++ b/georiva/src/georiva/core/test_product_chain.py
@@ -1,0 +1,223 @@
+"""
+Tests for the pure product-dependency chain (ADR-0008/0009, issue #166).
+
+The chain is the product-level DAG: product P depends on product Q iff a
+*required* input of P at *published* tier names a collection among Q's outputs
+(tier-awareness is essential — staging inputs come from the loader, not another
+product), unioned with each definition's explicit ``depends_on``. All functions
+are pure over a sequence of DerivedProductDefinitions: no DB, no recipe
+execution, so the module is importable from both the feed layer and the engine
+(ADR-0005). The DB-backed resolution lives elsewhere; these tests assert the
+graph math only.
+
+The fixture is CHIRPS-shaped (one resolution): a promotion that serves raw
+staging data at published tier, a climatology built from staging, and an anomaly
+that consumes staging value + the *published* climatology baseline. The one true
+edge is anomaly -> climatology; a tier-blind rule would fabricate
+anomaly -> promotion, which these tests guard against.
+"""
+from django.test import SimpleTestCase
+
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from georiva.core.product_chain import (
+    ChainCycleError,
+    ChainError,
+    dependencies_closure,
+    dependents_closure,
+    product_dependencies,
+    product_dependents,
+    topological_stages,
+    validate_chain,
+)
+
+
+def _product(key, *, inputs=(), outputs=(), recipe_type="recipe", depends_on=()):
+    return DerivedProductDefinition(
+        key=key,
+        recipe_type=recipe_type,
+        label=key.title(),
+        description="",
+        config_schema=(),
+        inputs=tuple(inputs),
+        outputs=tuple(outputs),
+        trigger_mode="scheduled",
+        depends_on=tuple(depends_on),
+    )
+
+
+def _chirps_defs():
+    """CHIRPS 'monthly' resolution: promotion, climatology, anomaly."""
+    raw = "chirps-monthly"
+    clim = "chirps-monthly-climatology"
+    promotion = _product(
+        "promotion",
+        inputs=(InputRef(role="source", collection=raw, tier="staging"),),
+        outputs=(OutputRef(role="served", collection=raw),),
+    )
+    climatology = _product(
+        "climatology",
+        inputs=(InputRef(role="value", collection=raw, tier="staging"),),
+        outputs=(OutputRef(role="climatology", collection=clim),),
+    )
+    anomaly = _product(
+        "anomaly",
+        inputs=(
+            InputRef(role="value", collection=raw, tier="staging"),
+            InputRef(role="baseline", collection=clim, tier="published"),
+        ),
+        outputs=(OutputRef(role="anomaly", collection="chirps-monthly-anomaly"),),
+    )
+    # Declaration order matters for stable topological output.
+    return [promotion, climatology, anomaly]
+
+
+class ProductDependenciesTests(SimpleTestCase):
+    def test_anomaly_depends_on_climatology_and_not_promotion(self):
+        # anomaly's required published baseline names climatology's output -> an
+        # edge; its raw input is staging-tier, so no edge to promotion despite
+        # promotion also outputting the raw collection at published tier.
+        deps = product_dependencies(_chirps_defs())
+
+        self.assertEqual(deps["anomaly"], {"climatology"})
+        self.assertEqual(deps["climatology"], set())
+        self.assertEqual(deps["promotion"], set())
+
+    def test_explicit_depends_on_is_unioned_with_inferred_edges(self):
+        # A non-data-flow dependency the tier rule can't see is declared
+        # explicitly and joins the inferred set.
+        defs = [
+            _product("a", outputs=(OutputRef(role="o", collection="a-out"),)),
+            _product("b", depends_on=("a",)),
+        ]
+
+        self.assertEqual(product_dependencies(defs)["b"], {"a"})
+
+    def test_optional_or_staging_inputs_never_create_edges(self):
+        # Only required + published inputs infer a dependency.
+        producer = _product("p", outputs=(OutputRef(role="o", collection="shared"),))
+        optional = _product("opt", inputs=(
+            InputRef(role="x", collection="shared", tier="published", required=False),
+        ))
+        staging = _product("stg", inputs=(
+            InputRef(role="x", collection="shared", tier="staging"),
+        ))
+
+        deps = product_dependencies([producer, optional, staging])
+        self.assertEqual(deps["opt"], set())
+        self.assertEqual(deps["stg"], set())
+
+
+class ProductDependentsTests(SimpleTestCase):
+    def test_dependents_is_the_inverse_of_dependencies(self):
+        deps = product_dependents(_chirps_defs())
+
+        # climatology is depended on by anomaly; nothing depends on anomaly.
+        self.assertEqual(deps["climatology"], {"anomaly"})
+        self.assertEqual(deps["anomaly"], set())
+        self.assertEqual(deps["promotion"], set())
+
+
+def _three_tier_chain():
+    """a <- b <- c: c depends on b depends on a (published data-flow)."""
+    a = _product("a", outputs=(OutputRef(role="o", collection="a-out"),))
+    b = _product(
+        "b",
+        inputs=(InputRef(role="i", collection="a-out", tier="published"),),
+        outputs=(OutputRef(role="o", collection="b-out"),),
+    )
+    c = _product(
+        "c",
+        inputs=(InputRef(role="i", collection="b-out", tier="published"),),
+        outputs=(OutputRef(role="o", collection="c-out"),),
+    )
+    return [a, b, c]
+
+
+class ClosureTests(SimpleTestCase):
+    def test_dependencies_closure_is_transitive_upstream(self):
+        # c needs b needs a -> enabling c requires both b and a (the auto-tick /
+        # structural-gate set). Excludes the product itself.
+        closure = dependencies_closure(_three_tier_chain(), "c")
+
+        self.assertEqual(closure, {"a", "b"})
+
+    def test_dependents_closure_is_transitive_downstream(self):
+        # Disabling a cascades to b and c (the confirmation set).
+        closure = dependents_closure(_three_tier_chain(), "a")
+
+        self.assertEqual(closure, {"b", "c"})
+
+    def test_closures_of_an_independent_product_are_empty(self):
+        self.assertEqual(dependencies_closure(_three_tier_chain(), "a"), set())
+        self.assertEqual(dependents_closure(_three_tier_chain(), "c"), set())
+
+
+class ValidateChainTests(SimpleTestCase):
+    def test_a_well_formed_chain_validates_silently(self):
+        self.assertIsNone(validate_chain(_chirps_defs()))
+
+    def test_duplicate_keys_are_rejected(self):
+        with self.assertRaises(ChainError):
+            validate_chain([_product("dup"), _product("dup")])
+
+    def test_unknown_depends_on_target_is_rejected(self):
+        with self.assertRaises(ChainError):
+            validate_chain([_product("b", depends_on=("ghost",))])
+
+    def test_explicit_dependency_cycle_is_rejected(self):
+        a = _product("a", depends_on=("b",))
+        b = _product("b", depends_on=("a",))
+        with self.assertRaises(ChainCycleError):
+            validate_chain([a, b])
+
+    def test_data_flow_cycle_is_rejected(self):
+        # a consumes b's published output and b consumes a's -> a real cycle the
+        # tier-aware rule infers, caught before any run.
+        a = _product(
+            "a",
+            inputs=(InputRef(role="i", collection="b-out", tier="published"),),
+            outputs=(OutputRef(role="o", collection="a-out"),),
+        )
+        b = _product(
+            "b",
+            inputs=(InputRef(role="i", collection="a-out", tier="published"),),
+            outputs=(OutputRef(role="o", collection="b-out"),),
+        )
+        with self.assertRaises(ChainCycleError):
+            validate_chain([a, b])
+
+    def test_self_loop_via_data_flow_is_rejected(self):
+        # A product consuming its own published output at required tier.
+        loop = _product(
+            "loop",
+            inputs=(InputRef(role="i", collection="loop-out", tier="published"),),
+            outputs=(OutputRef(role="o", collection="loop-out"),),
+        )
+        with self.assertRaises(ChainCycleError):
+            validate_chain([loop])
+
+
+class TopologicalStagesTests(SimpleTestCase):
+    def test_dependencies_land_in_an_earlier_stage_than_dependents(self):
+        stages = topological_stages(_chirps_defs())
+        keys_by_stage = [[d.key for d in stage] for stage in stages]
+
+        # climatology (and promotion, independent) come before anomaly; order
+        # within a stage follows declaration order.
+        self.assertEqual(keys_by_stage, [["promotion", "climatology"], ["anomaly"]])
+
+    def test_stage_order_is_stable_by_declaration(self):
+        stages = topological_stages(_three_tier_chain())
+        self.assertEqual(
+            [[d.key for d in stage] for stage in stages], [["a"], ["b"], ["c"]]
+        )
+
+    def test_a_cyclic_chain_raises_rather_than_looping(self):
+        a = _product("a", depends_on=("b",))
+        b = _product("b", depends_on=("a",))
+        with self.assertRaises(ChainCycleError):
+            topological_stages([a, b])

--- a/georiva/src/georiva/sources/templates/georivasources/wizard_step4_products.html
+++ b/georiva/src/georiva/sources/templates/georivasources/wizard_step4_products.html
@@ -107,6 +107,48 @@
             gap: 0.75em;
             margin-top: 1.5em;
         }
+
+        .gprod-stage {
+            margin-bottom: 1.5em;
+        }
+
+        .gprod-stage__label {
+            display: flex;
+            align-items: center;
+            gap: 0.5em;
+            font-size: 0.75em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--w-color-grey-400);
+            margin: 0 0 0.6em;
+        }
+
+        .gprod-stage__label::after {
+            content: "";
+            flex: 1 1 auto;
+            height: 1px;
+            background: var(--w-color-border-furniture);
+        }
+
+        .gprod-needs {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.4em;
+            margin: 0.5em 0 0;
+            font-size: 0.78em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gprod-needs__chip {
+            padding: 0.15em 0.6em;
+            border-radius: 999px;
+            background: var(--w-color-surface-field);
+            border: 1px solid var(--w-color-border-furniture);
+            color: var(--w-color-text-label);
+            font-weight: 600;
+        }
     </style>
 {% endblock %}
 
@@ -134,48 +176,65 @@
             {% endif %}
 
             <p class="gprod-intro">
-                {% trans "Configure the derived products this feed produces. Each product turns the feed's data into a further derived layer." %}
+                {% trans "Configure the derived products this feed produces. Each product turns the feed's data into a further derived layer. Products are grouped by dependency stage — enabling one that needs another turns its prerequisites on automatically." %}
             </p>
 
-            {% for entry in product_entries %}
-                {% with defn=entry.definition form=entry.config_form %}
-                    <div class="gprod-card{% if not entry.checked %} gprod-card--disabled{% endif %}" id="gprod-{{ defn.key }}">
-                        <div class="gprod-card__header">
-                            <label class="gprod-card__toggle">
-                                <input type="checkbox" class="gprod-card__enable"
-                                       name="products" value="{{ defn.key }}"
-                                       {% if entry.checked %}checked{% endif %}>
-                                <span class="gprod-card__name">{{ defn.label }}</span>
-                            </label>
-                            {% if defn.description %}
-                                <p class="gprod-card__desc">{{ defn.description }}</p>
-                            {% endif %}
-                        </div>
+            {% for lane in stage_lanes %}
+                <div class="gprod-stage">
+                    <p class="gprod-stage__label">{% blocktrans with n=forloop.counter %}Stage {{ n }}{% endblocktrans %}</p>
+                    {% for entry in lane %}
+                        {% with defn=entry.definition form=entry.config_form %}
+                            <div class="gprod-card{% if not entry.checked %} gprod-card--disabled{% endif %}"
+                                 id="gprod-{{ defn.key }}" data-product-key="{{ defn.key }}">
+                                <div class="gprod-card__header">
+                                    <label class="gprod-card__toggle">
+                                        <input type="checkbox" class="gprod-card__enable"
+                                               name="products" value="{{ defn.key }}"
+                                               {% if entry.checked %}checked{% endif %}>
+                                        <span class="gprod-card__name">{{ defn.label }}</span>
+                                    </label>
+                                    {% if defn.description %}
+                                        <p class="gprod-card__desc">{{ defn.description }}</p>
+                                    {% endif %}
+                                    {% if entry.needs %}
+                                        <p class="gprod-needs">
+                                            <span>{% trans "needs:" %}</span>
+                                            {% for need in entry.needs %}
+                                                <span class="gprod-needs__chip">{{ need }}</span>
+                                            {% endfor %}
+                                        </p>
+                                    {% endif %}
+                                </div>
 
-                        {% if form %}
-                            <div class="gprod-config-section">
-                                {% for field in form %}
-                                    <div class="w-field__wrapper">
-                                        <label class="w-field__label" for="{{ field.id_for_label }}">
-                                            {{ field.label }}
-                                        </label>
-                                        {{ field }}
-                                        {% if field.help_text %}
-                                            <p class="w-field__help-text">{{ field.help_text }}</p>
-                                        {% endif %}
-                                        {% for error in field.errors %}
+                                {% if form %}
+                                    <div class="gprod-config-section">
+                                        {% for field in form %}
+                                            <div class="w-field__wrapper">
+                                                <label class="w-field__label" for="{{ field.id_for_label }}">
+                                                    {{ field.label }}
+                                                </label>
+                                                {{ field }}
+                                                {% if field.help_text %}
+                                                    <p class="w-field__help-text">{{ field.help_text }}</p>
+                                                {% endif %}
+                                                {% for error in field.errors %}
+                                                    <p class="error-message">{{ error }}</p>
+                                                {% endfor %}
+                                            </div>
+                                        {% endfor %}
+                                        {% for error in form.non_field_errors %}
                                             <p class="error-message">{{ error }}</p>
                                         {% endfor %}
                                     </div>
-                                {% endfor %}
-                                {% for error in form.non_field_errors %}
-                                    <p class="error-message">{{ error }}</p>
-                                {% endfor %}
+                                {% endif %}
                             </div>
-                        {% endif %}
-                    </div>
-                {% endwith %}
+                        {% endwith %}
+                    {% endfor %}
+                </div>
             {% endfor %}
+
+            {{ dependencies_closure_json|json_script:"product-chain-dependencies" }}
+            {{ dependents_closure_json|json_script:"product-chain-dependents" }}
 
             <div class="gprod-submit-row">
                 <button type="submit" class="button bicolor button--icon">
@@ -198,21 +257,55 @@
     {{ block.super }}
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            const cards = document.querySelectorAll('.gprod-card');
-            cards.forEach(function (card) {
-                const checkbox = card.querySelector('.gprod-card__enable');
+            const parse = function (id) {
+                const el = document.getElementById(id);
+                return el ? JSON.parse(el.textContent) : {};
+            };
+            // Adjacency emitted by the server: what each product needs (upstream
+            // closure) and what needs it (downstream closure). The gate is
+            // re-checked server-side on submit — this cascade is convenience only.
+            const dependencies = parse('product-chain-dependencies');
+            const dependents = parse('product-chain-dependents');
+
+            const boxByKey = {};
+            document.querySelectorAll('.gprod-card__enable').forEach(function (box) {
+                const card = box.closest('.gprod-card');
+                boxByKey[card.dataset.productKey] = box;
+            });
+
+            const syncCard = function (box) {
+                const card = box.closest('.gprod-card');
                 const config = card.querySelector('.gprod-config-section');
-                if (!checkbox) {
-                    return;
+                card.classList.toggle('gprod-card--disabled', !box.checked);
+                if (config) {
+                    config.hidden = !box.checked;
                 }
-                const sync = function () {
-                    card.classList.toggle('gprod-card--disabled', !checkbox.checked);
-                    if (config) {
-                        config.hidden = !checkbox.checked;
+            };
+
+            const setChecked = function (key, value) {
+                const box = boxByKey[key];
+                if (box && box.checked !== value) {
+                    box.checked = value;
+                    syncCard(box);
+                }
+            };
+
+            Object.keys(boxByKey).forEach(function (key) {
+                boxByKey[key].addEventListener('change', function (event) {
+                    if (event.target.checked) {
+                        // Ticking a product turns on everything it depends on.
+                        (dependencies[key] || []).forEach(function (dep) {
+                            setChecked(dep, true);
+                        });
+                    } else {
+                        // Unticking cascades to everything that depends on it.
+                        (dependents[key] || []).forEach(function (dep) {
+                            setChecked(dep, false);
+                        });
                     }
-                };
-                checkbox.addEventListener('change', sync);
-                sync();
+                    syncCard(event.target);
+                });
+                syncCard(boxByKey[key]);
             });
         });
     </script>

--- a/georiva/src/georiva/sources/tests/test_wizard_products.py
+++ b/georiva/src/georiva/sources/tests/test_wizard_products.py
@@ -54,6 +54,31 @@ def _definition(**overrides):
     return DerivedProductDefinition(**kwargs)
 
 
+def _chain_defs():
+    """A CHIRPS-shaped pair with the one real edge: anomaly depends on
+    climatology (its required published baseline names climatology's output)."""
+    clim = _definition(
+        key="climatology",
+        label="Climatology",
+        config_schema=(),
+        inputs=(InputRef(role="value", collection="chirps-monthly", tier="staging"),),
+        outputs=(OutputRef(role="climatology",
+                           collection="chirps-monthly-climatology"),),
+    )
+    anomaly = _definition(
+        key="anomaly",
+        label="Rainfall anomaly",
+        config_schema=(),
+        inputs=(
+            InputRef(role="value", collection="chirps-monthly", tier="staging"),
+            InputRef(role="baseline",
+                     collection="chirps-monthly-climatology", tier="published"),
+        ),
+        outputs=(OutputRef(role="anomaly", collection="chirps-monthly-anomaly"),),
+    )
+    return [clim, anomaly]
+
+
 def _checkbox_is_checked(html, key):
     """Whether the enable checkbox for ``key`` is rendered ``checked``."""
     match = re.search(
@@ -169,6 +194,65 @@ class Step4PostTests(WizardStepBase):
         # Re-renders the step (no redirect) because a ticked product is invalid.
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("selected_product_keys", self.client.session.get(SESSION_KEY, {}))
+
+
+class Step4DependencyTests(WizardStepBase):
+    """The wizard enforces the chain server-side: a selection that enables a
+    product without its dependencies is rejected, JS cascade or not."""
+
+    def test_post_rejects_a_product_selected_without_its_dependency(self):
+        self._set_session()
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=_chain_defs()),
+        ):
+            response = self.client.post(self._step4_url(), {
+                "products": ["anomaly"],   # climatology missing
+            })
+
+        # Re-renders (no redirect) and names the missing dependency.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Climatology")
+        self.assertNotIn("selected_product_keys", self.client.session.get(SESSION_KEY, {}))
+
+    def test_post_accepts_a_product_with_its_dependency_selected(self):
+        self._set_session()
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=_chain_defs()),
+        ):
+            response = self.client.post(self._step4_url(), {
+                "products": ["anomaly", "climatology"],
+            })
+
+        self.assertRedirects(
+            response,
+            reverse("wizard_provision", kwargs={"model_name": MODEL_NAME}),
+            fetch_redirect_response=False,
+        )
+        self.assertEqual(
+            set(self.client.session[SESSION_KEY]["selected_product_keys"]),
+            {"anomaly", "climatology"},
+        )
+
+    def test_get_renders_stage_lanes_with_a_needs_chip_and_adjacency_data(self):
+        self._set_session()
+
+        with (
+            patch("georiva.sources.views.get_child_model_by_name", return_value=DataFeed),
+            patch.object(DataFeed, "get_derived_products", return_value=_chain_defs()),
+        ):
+            response = self.client.get(self._step4_url())
+
+        html = response.content.decode()
+        self.assertEqual(response.status_code, 200)
+        # The dependent product advertises what it needs...
+        self.assertIn("needs", html.lower())
+        self.assertContains(response, "Climatology")
+        # ...and the client-side cascade adjacency is emitted for the JS.
+        self.assertContains(response, "product-chain-dependencies")
 
 
 class WizardProvisionSeamTests(WizardStepBase):

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -872,6 +872,48 @@ def wizard_step3_collections(request, model_name):
     })
 
 
+def _product_chain_context(definitions, label_by_key):
+    """The product-chain read-model the wizard step renders from: topological
+    stage lanes, each product's direct dependencies (for "needs" chips), and the
+    transitive closures both directions (the server-side gate and the client-side
+    cascade adjacency).
+
+    A malformed declaration (duplicate keys, unknown ``depends_on``, a cycle)
+    can't be laid out into stages; rather than 500, fall back to a single lane
+    and return the error string so the step still renders and names the problem.
+    """
+    from georiva.core.product_chain import (
+        ChainError,
+        dependencies_closure,
+        dependents_closure,
+        product_dependencies,
+        topological_stages,
+    )
+
+    keys = list(label_by_key)
+    try:
+        stages = topological_stages(definitions)
+        direct = {k: sorted(v) for k, v in product_dependencies(definitions).items()}
+        dep_closures = {k: dependencies_closure(definitions, k) for k in keys}
+        dependent_closures = {k: dependents_closure(definitions, k) for k in keys}
+        error = None
+    except ChainError as exc:
+        stages = [list(definitions)]
+        direct = {k: [] for k in keys}
+        dep_closures = {k: set() for k in keys}
+        dependent_closures = {k: set() for k in keys}
+        error = str(exc)
+
+    return {
+        "stages": stages,
+        "direct_deps": direct,
+        "dep_closures": dep_closures,
+        "dep_closures_json": {k: sorted(v) for k, v in dep_closures.items()},
+        "dependent_closures_json": {k: sorted(v) for k, v in dependent_closures.items()},
+        "error": error,
+    }
+
+
 def wizard_step4_products(request, model_name):
     """Step 4: configure the derived products the feed declares (ADR-0008).
 
@@ -898,7 +940,12 @@ def wizard_step4_products(request, model_name):
     session_selected = session_data.get("selected_product_keys")
     posted_selected = set(request.POST.getlist("products")) if request.method == "POST" else None
 
-    entries = []
+    label_by_key = {d.key: d.label for d in definitions}
+    chain = _product_chain_context(definitions, label_by_key)
+    if chain["error"]:
+        messages.error(request, chain["error"])
+
+    entries = {}
     for defn in definitions:
         form_cls = build_product_config_form(defn)
         if form_cls is None:
@@ -915,13 +962,23 @@ def wizard_step4_products(request, model_name):
         else:
             checked = defn.default_enabled
 
-        entries.append({"definition": defn, "config_form": form, "checked": checked})
+        entries[defn.key] = {
+            "definition": defn,
+            "config_form": form,
+            "checked": checked,
+            # Direct-dependency labels, for the card's "needs: X" chips.
+            "needs": [label_by_key[dep] for dep in chain["direct_deps"].get(defn.key, [])],
+        }
+
+    # Entries grouped into topological stage lanes (single lane on a broken chain).
+    stage_lanes = [[entries[d.key] for d in stage] for stage in chain["stages"]]
 
     if request.method == "POST":
         errors = []
         products_config = {}
-        for entry in entries:
-            defn, form = entry["definition"], entry["config_form"]
+        for defn in definitions:
+            entry = entries[defn.key]
+            form = entry["config_form"]
             # Config is validated only for ticked products; an unticked product
             # (or a ticked one with no options) provisions with schema defaults
             # (empty config), so a bad value on a product the operator opted out
@@ -935,10 +992,24 @@ def wizard_step4_products(request, model_name):
             else:
                 errors.append(f"{defn.label}: {'; '.join(form.errors.get('__all__', []))}".strip(": "))
 
+        # Enforce the chain server-side: every ticked product must have its whole
+        # dependency closure ticked too. JS cascade is advisory — this is the
+        # authoritative gate, so a hand-crafted POST can't smuggle in an orphan.
+        selected_keys = {k for k, e in entries.items() if e["checked"]}
+        for key in selected_keys:
+            missing = chain["dep_closures"].get(key, set()) - selected_keys
+            if missing:
+                errors.append(
+                    _("%(product)s needs %(deps)s to be enabled too.") % {
+                        "product": label_by_key[key],
+                        "deps": ", ".join(sorted(label_by_key.get(m, m) for m in missing)),
+                    }
+                )
+
         if not errors:
             session_data["derived_products_config"] = products_config
             session_data["selected_product_keys"] = [
-                e["definition"].key for e in entries if e["checked"]
+                k for k in label_by_key if entries[k]["checked"]
             ]
             request.session[_wizard_session_key(model_name)] = session_data
             return redirect("wizard_provision", model_name=model_name)
@@ -950,7 +1021,9 @@ def wizard_step4_products(request, model_name):
         "breadcrumbs_items": _wizard_breadcrumbs(model_name, verbose_name, _("Derived Products")),
         "model_name": model_name,
         "source_verbose_name": verbose_name,
-        "product_entries": entries,
+        "stage_lanes": stage_lanes,
+        "dependencies_closure_json": chain["dep_closures_json"],
+        "dependents_closure_json": chain["dependent_closures_json"],
         "step": 4,
     })
 


### PR DESCRIPTION
## What this does

Slice 2 of #164. The product dependency chain becomes **computable** and the wizard becomes **dependency-aware**.

Demo: in the CHIRPS wizard, untick climatology → anomaly unticks itself; re-tick anomaly → climatology auto-ticks; a hand-crafted POST missing climatology is rejected server-side.

Closes #166. Builds on #165 (merged).

## Changes by seam

| Seam | Change |
|------|--------|
| **Contract** (`core/derived_products.py`) | `depends_on: tuple = ()` on `DerivedProductDefinition`, validated (entries non-empty, not self-referential) — for non-data-flow dependencies the tier-aware rule can't infer. Defaulted, so existing declarations stay valid. |
| **New pure module** (`core/product_chain.py`) | No DB — importable from both the feed layer and the engine (ADR-0005). `product_dependencies` (tier-aware rule ∪ `depends_on`), `product_dependents`, `dependencies_closure`/`dependents_closure`, `validate_chain` (duplicate keys, unknown `depends_on`, self-loops, cycles → `ChainError`/`ChainCycleError`), `topological_stages` (Kahn layering, declaration-order stable). |
| **Wizard step 4** (`sources/views.py` + template) | Products render as topological **stage lanes** with "needs: X" chips. Dependency/dependent closures are emitted via `json_script` for a client-side tick cascade (tick auto-ticks the upstream closure; untick cascades downstream). The server **independently re-validates** that every ticked product's dependency closure is ticked, rejecting violations with a message naming the missing dependencies. |

## The tier-aware rule

Product **P depends on Q** iff a **required**, **published-tier** input of P names a collection among Q's outputs, unioned with `depends_on`. Tier-awareness is essential: in CHIRPS, anomaly's raw input is *staging* (fed by the loader) while its baseline input is the *published* climatology — so the one true edge is **anomaly → climatology**. A tier-blind rule would fabricate anomaly → promotion (promotion also outputs the raw collection at published tier). The pure tests assert exactly this.

## Acceptance criteria (#166)

- [x] Pure chain module: dependencies/dependents maps, closures, topological stages (stable order), validation errors for duplicate keys, unknown `depends_on`, self-dependency, and cycles (data-flow or explicit)
- [x] Tier-aware rule verified against CHIRPS-shaped declarations: exactly anomaly→climatology per resolution, no edge to promotion
- [x] `DerivedProductDefinition` gains `depends_on: tuple = ()`, validated
- [x] Wizard step renders stage lanes with needs-chips; tick/untick cascades both directions; config sections show/hide with tick state
- [x] Server-side validation rejects selections violating the dependency invariant with a message naming the missing dependencies
- [x] Pure-seam tests for the chain module; HTTP-seam tests for wizard validation; template follows Wagtail admin conventions (no inline styles, JS in the extra_js block)

## Testing

TDD, red→green throughout. **166** `georiva.core`+`georiva.sources` tests pass (+23 new); CHIRPS plugin's 39 tests still green (defaulted `depends_on` is backward-compatible).

- `core/test_product_chain.py` (new, 16 tests) — tier-aware rule, `depends_on` union, dependents inverse, transitive closures, topological stages, and all four validation errors
- `core/test_derived_products.py` — `depends_on` default/settable/rejects empty + self
- `sources/tests/test_wizard_products.py` — POST rejects a product selected without its dependency (names it), accepts a valid closure, and GET renders stage lanes with a needs-chip + adjacency `json_script`

## Notes

- **JS is advisory** — the browser tick-cascade is convenience; the server-side closure check is the authoritative gate (a hand-crafted POST can't smuggle in an orphan). The cascade itself isn't unit-tested (needs a browser); the gate is.
- **No CHIRPS change needed** — the published-tier baseline gives anomaly→climatology for free, so no explicit `depends_on`.
- **Malformed-chain fallback**: a cyclic/duplicate declaration renders a single lane + an error message rather than 500. Provisioning-side `validate_chain` enforcement is a later slice (#167).
- Stage lanes are rendered directly in `wizard_step4_products.html`; the shared feed-detail partial is slice 5 (#169).
