### PR TITLE
feat(sources): structural enable gate + cascade disable via product service (#167)

### DIFF
--- a/georiva/src/georiva/sources/product_service.py
+++ b/georiva/src/georiva/sources/product_service.py
@@ -1,0 +1,111 @@
+"""
+Single write-path for derived-product enable/disable (ADR-0008/0009).
+
+Every surface — the wizard, the feed-detail panel, the tracking dashboard —
+routes enable/disable through this module so the structural invariant *no
+enabled product may have a disabled (or missing) dependency* holds everywhere.
+
+- Enabling is gated on the transitive dependency closure: each upstream product
+  must have a row that exists and is enabled, else ``ProductActionError`` names
+  the offenders. Data availability is a *separate* runtime gate (``product_
+  readiness``) — a whole chain may be enabled before any upstream data exists.
+- Disabling cascades to the transitive dependent closure, atomically, with the
+  closure recomputed here from the declaration (never trusted from a request).
+
+The chain math lives in the pure ``core.product_chain`` module; this layer binds
+it to the feed's ``DerivedProduct`` rows.
+"""
+from __future__ import annotations
+
+from django.db import transaction
+from django.utils.translation import gettext as _
+
+
+class ProductActionError(Exception):
+    """An enable/disable action would break the dependency invariant."""
+
+
+def _chain(product):
+    """Resolve a product's feed chain: (declarations, rows_by_key). Declarations
+    come from an *instance* ``get_derived_products()`` on the real feed
+    subclass (it binds products to the feed's collections)."""
+    feed = product.data_feed.get_real_instance()
+    definitions = feed.get_derived_products()
+    rows_by_key = {row.definition_key: row for row in feed.derived_products.all()}
+    return definitions, rows_by_key
+
+
+def _label_of(key, definitions):
+    for defn in definitions:
+        if defn.key == key:
+            return defn.label
+    return key
+
+
+def product_label(product):
+    """The product's display label from its feed declaration, falling back to
+    its definition key (e.g. an orphaned row whose definition is gone)."""
+    definitions, _ = _chain(product)
+    return _label_of(product.definition_key, definitions)
+
+
+def enable_product(product):
+    """
+    Enable ``product`` after checking every transitive dependency exists and is
+    enabled. Raises ``ProductActionError`` (naming the missing dependencies by
+    display label) otherwise. Atomic.
+    """
+    from georiva.core.product_chain import dependencies_closure
+
+    definitions, rows = _chain(product)
+    needed = dependencies_closure(definitions, product.definition_key)
+    missing = [
+        _label_of(key, definitions)
+        for key in sorted(needed)
+        if rows.get(key) is None or not rows[key].is_enabled
+    ]
+    if missing:
+        raise ProductActionError(
+            _("%(product)s needs %(deps)s to be enabled first.") % {
+                "product": _label_of(product.definition_key, definitions),
+                "deps": ", ".join(missing),
+            }
+        )
+    with transaction.atomic():
+        product.is_enabled = True
+        product.save(update_fields=["is_enabled"])
+    return product
+
+
+def enabled_dependents(product):
+    """The currently-enabled rows that transitively depend on ``product``, in
+    declaration order — the set a disable would cascade to (the confirmation
+    list). Excludes ``product`` itself."""
+    from georiva.core.product_chain import dependents_closure
+
+    definitions, rows = _chain(product)
+    downstream = dependents_closure(definitions, product.definition_key)
+    return [
+        rows[defn.key]
+        for defn in definitions
+        if defn.key in downstream and defn.key in rows and rows[defn.key].is_enabled
+    ]
+
+
+def disable_product(product):
+    """
+    Disable ``product`` and every enabled product that transitively depends on
+    it, in a single transaction. The dependent closure is recomputed here from
+    the declaration — never trusted from a caller — so a stale or forged list
+    can't leave an enabled product with a disabled dependency. Returns the rows
+    that were disabled (the product first, then its dependents).
+    """
+    dependents = enabled_dependents(product)
+    with transaction.atomic():
+        disabled = []
+        for row in [product, *dependents]:
+            if row.is_enabled:
+                row.is_enabled = False
+                row.save(update_fields=["is_enabled"])
+            disabled.append(row)
+    return disabled

--- a/georiva/src/georiva/sources/templates/georivasources/product_disable_confirm.html
+++ b/georiva/src/georiva/sources/templates/georivasources/product_disable_confirm.html
@@ -1,0 +1,77 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% trans "Disable Derived Product" %} — {{ product_label }}{% endblock %}
+
+{% block extra_css %}
+    <style>
+        .pdc-warning-box {
+            background: color-mix(in srgb, var(--w-color-warning-100) 12%, transparent);
+            border: 1px solid color-mix(in srgb, var(--w-color-warning-100) 45%, transparent);
+            border-radius: 6px;
+            padding: 1.1em 1.25em;
+            margin-bottom: 1.5em;
+        }
+
+        .pdc-warning-title {
+            font-weight: 700;
+            color: var(--w-color-text-label);
+            margin: 0 0 0.5em;
+            font-size: 0.95em;
+        }
+
+        .pdc-warning-intro {
+            font-size: 0.9em;
+            margin: 0 0 0.6em;
+            color: var(--w-color-text-label);
+        }
+
+        .pdc-dependent-list {
+            margin: 0.5em 0 0 1.2em;
+            padding: 0;
+            font-size: 0.9em;
+            line-height: 1.8;
+        }
+
+        .pdc-actions {
+            display: flex;
+            gap: 1em;
+            margin-top: 1.5em;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Disable Derived Product") subtitle=product_label icon="warning" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        <div class="pdc-warning-box">
+            <p class="pdc-warning-title">
+                {% blocktrans %}Disabling “{{ product_label }}” will also disable the products that depend on it:{% endblocktrans %}
+            </p>
+            <ul class="pdc-dependent-list">
+                {% for label in dependent_labels %}
+                    <li><strong>{{ label }}</strong></li>
+                {% endfor %}
+            </ul>
+            <p class="pdc-warning-intro">
+                {% trans "Their configuration is kept — they can be re-enabled later once their dependencies are on again." %}
+            </p>
+        </div>
+
+        <form method="post" action="{% url 'derived_product_tracking' %}">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="toggle">
+            <input type="hidden" name="product_pk" value="{{ product.pk }}">
+            <input type="hidden" name="confirmed" value="1">
+            <div class="pdc-actions">
+                <button type="submit" class="button no">
+                    {% trans "Yes, disable all" %}
+                </button>
+                <a href="{% url 'derived_product_tracking' %}" class="button button-secondary">
+                    {% trans "Cancel" %}
+                </a>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/tests/test_product_service.py
+++ b/georiva/src/georiva/sources/tests/test_product_service.py
@@ -1,0 +1,251 @@
+"""
+Service-seam tests for the single enable/disable write-path (ADR-0008/0009,
+issue #167).
+
+Every surface (wizard, feed detail, tracking dashboard) routes enable/disable
+through ``sources.product_service`` so the invariant "no enabled product with a
+disabled dependency" can't be broken. Enabling is structurally gated on the
+transitive dependency closure; disabling cascades to the transitive dependent
+closure atomically. Data availability is a *separate* runtime gate, not checked
+here — a whole chain may be enabled before any upstream data exists.
+"""
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.test import TestCase
+from django.urls import reverse
+
+from georiva.core.derived_products import (
+    DerivedProductDefinition,
+    InputRef,
+    OutputRef,
+)
+from georiva.core.models import Catalog
+from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.sources.product_service import (
+    ProductActionError,
+    disable_product,
+    enable_product,
+    enabled_dependents,
+)
+
+User = get_user_model()
+
+
+def _product(key, *, inputs=(), outputs=(), recipe_type="recipe"):
+    return DerivedProductDefinition(
+        key=key,
+        recipe_type=recipe_type,
+        label=key.replace("-", " ").title(),
+        description="",
+        config_schema=(),
+        inputs=tuple(inputs),
+        outputs=tuple(outputs),
+        trigger_mode="scheduled",
+    )
+
+
+def _chirps_defs():
+    """CHIRPS 'monthly' resolution: anomaly depends on climatology (its required
+    published baseline); promotion is independent."""
+    raw = "chirps-monthly"
+    clim = "chirps-monthly-climatology"
+    return [
+        _product(
+            "promotion",
+            inputs=(InputRef(role="source", collection=raw, tier="staging"),),
+            outputs=(OutputRef(role="served", collection=raw),),
+        ),
+        _product(
+            "climatology",
+            inputs=(InputRef(role="value", collection=raw, tier="staging"),),
+            outputs=(OutputRef(role="climatology", collection=clim),),
+        ),
+        _product(
+            "anomaly",
+            inputs=(
+                InputRef(role="value", collection=raw, tier="staging"),
+                InputRef(role="baseline", collection=clim, tier="published"),
+            ),
+            outputs=(OutputRef(role="anomaly", collection="chirps-monthly-anomaly"),),
+        ),
+    ]
+
+
+class ProductServiceBase(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+        self.rows = {}
+        for defn in _chirps_defs():
+            self.rows[defn.key] = DerivedProduct.objects.create(
+                data_feed=self.feed, definition_key=defn.key,
+                recipe_type=defn.recipe_type, is_enabled=True,
+            )
+
+    def _patch_defs(self):
+        return patch.object(
+            DataFeed, "get_derived_products", return_value=_chirps_defs()
+        )
+
+
+class EnableGateTests(ProductServiceBase):
+    def test_enable_is_refused_when_a_dependency_is_disabled(self):
+        # climatology off, anomaly off -> enabling anomaly alone is blocked and
+        # the error names the missing dependency by its display label.
+        self.rows["climatology"].is_enabled = False
+        self.rows["climatology"].save(update_fields=["is_enabled"])
+        self.rows["anomaly"].is_enabled = False
+        self.rows["anomaly"].save(update_fields=["is_enabled"])
+
+        with self._patch_defs():
+            with self.assertRaises(ProductActionError) as ctx:
+                enable_product(self.rows["anomaly"])
+
+        self.assertIn("Climatology", str(ctx.exception))
+        self.rows["anomaly"].refresh_from_db()
+        self.assertFalse(self.rows["anomaly"].is_enabled)
+
+    def test_enable_succeeds_when_all_dependencies_are_enabled(self):
+        # climatology stays enabled -> anomaly may be enabled, even with no data
+        # yet (data readiness is a separate gate, not checked here).
+        self.rows["anomaly"].is_enabled = False
+        self.rows["anomaly"].save(update_fields=["is_enabled"])
+
+        with self._patch_defs():
+            enable_product(self.rows["anomaly"])
+
+        self.rows["anomaly"].refresh_from_db()
+        self.assertTrue(self.rows["anomaly"].is_enabled)
+
+    def test_independent_product_enables_without_dependencies(self):
+        self.rows["promotion"].is_enabled = False
+        self.rows["promotion"].save(update_fields=["is_enabled"])
+
+        with self._patch_defs():
+            enable_product(self.rows["promotion"])
+
+        self.rows["promotion"].refresh_from_db()
+        self.assertTrue(self.rows["promotion"].is_enabled)
+
+
+class DisableCascadeTests(ProductServiceBase):
+    def test_enabled_dependents_lists_the_transitive_downstream_set(self):
+        with self._patch_defs():
+            dependents = enabled_dependents(self.rows["climatology"])
+
+        self.assertEqual(
+            [d.definition_key for d in dependents], ["anomaly"]
+        )
+
+    def test_enabled_dependents_excludes_already_disabled_rows(self):
+        self.rows["anomaly"].is_enabled = False
+        self.rows["anomaly"].save(update_fields=["is_enabled"])
+
+        with self._patch_defs():
+            self.assertEqual(enabled_dependents(self.rows["climatology"]), [])
+
+    def test_disable_cascades_to_transitive_dependents(self):
+        with self._patch_defs():
+            disabled = disable_product(self.rows["climatology"])
+
+        # climatology and its dependent anomaly both go down, in one pass.
+        self.assertEqual(
+            sorted(d.definition_key for d in disabled), ["anomaly", "climatology"]
+        )
+        for row in self.rows.values():
+            row.refresh_from_db()
+        self.assertFalse(self.rows["climatology"].is_enabled)
+        self.assertFalse(self.rows["anomaly"].is_enabled)
+        # An unrelated product is untouched.
+        self.assertTrue(self.rows["promotion"].is_enabled)
+
+    def test_disable_of_a_leaf_touches_only_itself(self):
+        with self._patch_defs():
+            disabled = disable_product(self.rows["anomaly"])
+
+        self.assertEqual([d.definition_key for d in disabled], ["anomaly"])
+        self.rows["climatology"].refresh_from_db()
+        self.assertTrue(self.rows["climatology"].is_enabled)
+
+    def test_disable_is_atomic_no_partial_write_on_error(self):
+        # If the save of a cascaded row blows up, nothing is left half-disabled.
+        with self._patch_defs():
+            with patch.object(
+                DerivedProduct, "save", side_effect=RuntimeError("boom")
+            ):
+                with self.assertRaises(RuntimeError):
+                    disable_product(self.rows["climatology"])
+
+        for row in self.rows.values():
+            row.refresh_from_db()
+        self.assertTrue(self.rows["climatology"].is_enabled)
+        self.assertTrue(self.rows["anomaly"].is_enabled)
+
+
+class TrackingToggleFlowTests(ProductServiceBase):
+    """The tracking dashboard's Disable/Enable button routes through the service,
+    so the dependency gate and cascade-disable confirmation hold from that
+    surface too (issue #167)."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_superuser("dash", "d@test.com", "pw")
+        self.client.force_login(self.user)
+
+    def _toggle(self, product, **extra):
+        return self.client.post(reverse("derived_product_tracking"), {
+            "action": "toggle", "product_pk": product.pk, **extra,
+        })
+
+    def test_disabling_a_product_with_enabled_dependents_asks_to_confirm(self):
+        with self._patch_defs():
+            response = self._toggle(self.rows["climatology"])
+
+        # A confirmation page listing the transitive downstream set — nothing
+        # disabled yet.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Anomaly")
+        self.rows["climatology"].refresh_from_db()
+        self.rows["anomaly"].refresh_from_db()
+        self.assertTrue(self.rows["climatology"].is_enabled)
+        self.assertTrue(self.rows["anomaly"].is_enabled)
+
+    def test_confirming_disables_the_whole_downstream_set(self):
+        with self._patch_defs():
+            response = self._toggle(self.rows["climatology"], confirmed="1")
+
+        self.rows["climatology"].refresh_from_db()
+        self.rows["anomaly"].refresh_from_db()
+        self.assertFalse(self.rows["climatology"].is_enabled)
+        self.assertFalse(self.rows["anomaly"].is_enabled)
+        # The result message names everything that was disabled.
+        msgs = " ".join(str(m) for m in get_messages(response.wsgi_request))
+        self.assertIn("Climatology", msgs)
+        self.assertIn("Anomaly", msgs)
+
+    def test_disabling_a_leaf_proceeds_without_confirmation(self):
+        with self._patch_defs():
+            self._toggle(self.rows["anomaly"])
+
+        self.rows["anomaly"].refresh_from_db()
+        self.rows["climatology"].refresh_from_db()
+        self.assertFalse(self.rows["anomaly"].is_enabled)
+        self.assertTrue(self.rows["climatology"].is_enabled)
+
+    def test_enabling_a_product_with_a_disabled_dependency_is_blocked(self):
+        self.rows["climatology"].is_enabled = False
+        self.rows["climatology"].save(update_fields=["is_enabled"])
+        self.rows["anomaly"].is_enabled = False
+        self.rows["anomaly"].save(update_fields=["is_enabled"])
+
+        with self._patch_defs():
+            response = self._toggle(self.rows["anomaly"])
+
+        self.rows["anomaly"].refresh_from_db()
+        self.assertFalse(self.rows["anomaly"].is_enabled)
+        msgs = " ".join(str(m) for m in get_messages(response.wsgi_request))
+        self.assertIn("Climatology", msgs)

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1126,18 +1126,46 @@ def derived_product_tracking(request):
     from georiva.sources.derivation_invocation import run_product_now
     from georiva.sources.derivation_tracking import product_readiness, product_status
     from georiva.sources.models import DerivedProduct
+    from georiva.sources.product_service import (
+        ProductActionError,
+        disable_product,
+        enable_product,
+        enabled_dependents,
+        product_label,
+    )
 
     if request.method == "POST" and request.POST.get("action") == "toggle":
         product = get_object_or_404(DerivedProduct, pk=request.POST.get("product_pk"))
-        product.is_enabled = not product.is_enabled
-        product.save(update_fields=["is_enabled"])
-        messages.success(
-            request,
-            _("'%(key)s' %(state)s.") % {
-                "key": product.definition_key,
-                "state": _("enabled") if product.is_enabled else _("disabled"),
-            },
-        )
+        # Enable/disable go through the product service so the dependency
+        # invariant (no enabled product with a disabled dependency) holds from
+        # this surface too — never flip is_enabled raw here.
+        if product.is_enabled:
+            dependents = enabled_dependents(product)
+            if dependents and request.POST.get("confirmed") != "1":
+                # Cascade-disable needs acknowledgement; the closure is recomputed
+                # on the confirming POST, so the listed set is advisory only.
+                return render(request, "georivasources/product_disable_confirm.html", {
+                    "breadcrumbs_items": [
+                        {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+                        {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+                        {"url": reverse("derived_product_tracking"), "label": _("Derived Products")},
+                        {"url": "", "label": _("Disable")},
+                    ],
+                    "product": product,
+                    "product_label": product_label(product),
+                    "dependent_labels": [product_label(d) for d in dependents],
+                })
+            disabled = disable_product(product)
+            messages.success(
+                request,
+                _("Disabled: %s.") % ", ".join(product_label(d) for d in disabled),
+            )
+        else:
+            try:
+                enable_product(product)
+                messages.success(request, _("'%s' enabled.") % product_label(product))
+            except ProductActionError as exc:
+                messages.error(request, str(exc))
         return redirect("derived_product_tracking")
 
     if request.method == "POST" and request.POST.get("action") == "run_now":


### PR DESCRIPTION
## What this does

Slice 3 of #164. Post-provision enable/disable becomes **dependency-safe** through a single write-path service (`sources/product_service.py`) that every surface must use — closing the invariant hole where the tracking-dashboard toggle flipped `is_enabled` raw.

Demo: with the CHIRPS chain enabled, disable climatology from the tracking dashboard → confirmation lists anomaly → confirm → both disabled; attempt to enable anomaly alone → blocked with a message naming climatology.

Closes #167. Builds on #166 (merged).

## The service — `sources/product_service.py`

| Function | Behavior |
|----------|----------|
| `enable_product(product)` | **Structural gate**: every transitive dependency (`dependencies_closure`) must have a row that exists **and** is enabled, else `ProductActionError` names the missing ones by display label. Atomic. Data availability stays the *separate* runtime readiness gate — a whole chain may be enabled before upstream data exists. |
| `enabled_dependents(product)` | The transitive enabled downstream set, in declaration order — the confirmation list. |
| `disable_product(product)` | Atomically disables the product **plus** its enabled transitive dependents. The closure is **recomputed here** from the declaration, never trusted from the request. Returns what was disabled. |

The chain math is the pure `core.product_chain` module from #166; this layer binds it to the feed's `DerivedProduct` rows.

## Tracking dashboard rerouting

The `toggle` action now routes through the service:
- **Enable** → gate; on `ProductActionError`, flash the error naming the missing deps.
- **Disable** with enabled dependents → render `product_disable_confirm.html` listing the transitive downstream set; the confirming POST (`confirmed=1`) recomputes the closure server-side and cascade-disables atomically, flashing everything disabled.
- **Disable** with no enabled dependents → proceeds immediately.

## Acceptance criteria (#167)

- [x] Enabling is refused when any transitive dependency row is missing or disabled; the error names the dependencies
- [x] Disabling with enabled dependents shows a confirmation listing the transitive set; confirming disables all in one transaction; the result message lists everything disabled
- [x] Disabling with no enabled dependents proceeds immediately
- [x] The tracking dashboard's toggle routes through the service (same gate, same confirmation flow)
- [x] All operations are atomic; the confirming POST recomputes the dependent set server-side (no trust in the submitted list)
- [x] Service-seam tests (gate, transitive cascade, atomicity) and HTTP-seam tests (confirm flow end-to-end)

## Testing

TDD, red→green. **178** `georiva.core`+`georiva.sources` tests pass (+12 new); CHIRPS plugin unaffected.

`sources/tests/test_product_service.py` (new, 12 tests): enable gate (blocked / succeeds / independent), `enabled_dependents` (transitive / excludes-disabled), `disable_product` (cascade / leaf / **atomic-rollback-on-error**), and the tracking HTTP flow (confirm page shown / confirm cascades / leaf immediate / enable-blocked names dep).

## Notes

- **Orphan checks and output-collection materialisation on enable are later slices** (#168 / #171) — `enable_product` here is the structural gate only.
- The `product_disable_confirm.html` confirm list is **advisory** — the confirming POST recomputes the closure, so a stale/forged list can't leave an enabled product with a disabled dependency.
- The tracking view's per-row label logic is left as-is (pre-existing); the service's `product_label` is used for the action messages and confirm page.
