### PR TITLE
feat(core,sources): declared output metadata + collection materialisation on enable (#168)

### DIFF
--- a/georiva/src/georiva/core/derived_products.py
+++ b/georiva/src/georiva/core/derived_products.py
@@ -24,6 +24,10 @@ from dataclasses import dataclass
 TRIGGER_MODES = ("event", "scheduled", "manual")
 CONFIG_FIELD_TYPES = ("str", "int", "float", "bool", "choice")
 TIERS = ("staging", "published")
+# Output-collection visibility (mirrors core.Collection.Visibility): a "public"
+# output is served via STAC/EDR/tiles; an "internal" one is a derivation
+# intermediate — read by the engine but never served.
+VISIBILITIES = ("public", "internal")
 
 _SCALAR_COERCERS = {"str": str, "int": int, "float": float, "bool": bool}
 
@@ -65,15 +69,29 @@ class InputRef:
 
 @dataclass(frozen=True)
 class OutputRef:
-    """One collection a product produces."""
+    """One collection a product produces.
+
+    The display metadata (``title``/``description``/``visibility``) is the single
+    source of truth for the output Collection materialised in the catalog when
+    the product is enabled — it is *not* injected into recipe selectors, which
+    stay keyed on ``role``/``collection`` only.
+    """
     role: str
     collection: str
+    title: str = ""
+    description: str = ""
+    visibility: str = "public"
 
     def __post_init__(self):
         if not self.role:
             raise ValueError("OutputRef: 'role' is required and must be non-empty")
         if not self.collection:
             raise ValueError("OutputRef: 'collection' is required and must be non-empty")
+        if self.visibility not in VISIBILITIES:
+            raise ValueError(
+                f"OutputRef '{self.role}': visibility must be one of "
+                f"{VISIBILITIES}, got '{self.visibility}'"
+            )
 
 
 @dataclass(frozen=True)

--- a/georiva/src/georiva/core/test_derived_products.py
+++ b/georiva/src/georiva/core/test_derived_products.py
@@ -53,6 +53,29 @@ class OutputRefTests(SimpleTestCase):
         with self.assertRaises(ValueError):
             OutputRef(role="anomaly", collection="")
 
+    def test_display_metadata_defaults_keep_bare_declarations_valid(self):
+        # An OutputRef declared with only role+collection still compiles: the
+        # catalog-facing metadata is optional and defaults sensibly.
+        ref = OutputRef(role="anomaly", collection="rainfall-anomaly")
+        self.assertEqual(ref.title, "")
+        self.assertEqual(ref.description, "")
+        self.assertEqual(ref.visibility, "public")
+
+    def test_display_metadata_is_settable(self):
+        ref = OutputRef(
+            role="climatology", collection="rainfall-normals",
+            title="Rainfall normals", description="1991–2020 baseline.",
+            visibility="internal",
+        )
+        self.assertEqual(ref.title, "Rainfall normals")
+        self.assertEqual(ref.description, "1991–2020 baseline.")
+        self.assertEqual(ref.visibility, "internal")
+
+    def test_unknown_visibility_is_rejected(self):
+        with self.assertRaises(ValueError):
+            OutputRef(role="anomaly", collection="rainfall-anomaly",
+                      visibility="secret")
+
 
 def _definition(**overrides):
     """A minimal valid DerivedProductDefinition, overridable per-test."""

--- a/georiva/src/georiva/sources/product_service.py
+++ b/georiva/src/georiva/sources/product_service.py
@@ -26,13 +26,13 @@ class ProductActionError(Exception):
 
 
 def _chain(product):
-    """Resolve a product's feed chain: (declarations, rows_by_key). Declarations
-    come from an *instance* ``get_derived_products()`` on the real feed
-    subclass (it binds products to the feed's collections)."""
+    """Resolve a product's feed chain: (feed, declarations, rows_by_key).
+    Declarations come from an *instance* ``get_derived_products()`` on the real
+    feed subclass (it binds products to the feed's collections)."""
     feed = product.data_feed.get_real_instance()
     definitions = feed.get_derived_products()
     rows_by_key = {row.definition_key: row for row in feed.derived_products.all()}
-    return definitions, rows_by_key
+    return feed, definitions, rows_by_key
 
 
 def _label_of(key, definitions):
@@ -42,11 +42,48 @@ def _label_of(key, definitions):
     return key
 
 
+def _definition_of(key, definitions):
+    for defn in definitions:
+        if defn.key == key:
+            return defn
+    return None
+
+
 def product_label(product):
     """The product's display label from its feed declaration, falling back to
     its definition key (e.g. an orphaned row whose definition is gone)."""
-    definitions, _ = _chain(product)
+    _feed, definitions, _rows = _chain(product)
     return _label_of(product.definition_key, definitions)
+
+
+def materialise_output_collections(feed, definition):
+    """
+    Get-or-create the catalog Collections a product declares as outputs, from
+    each ``OutputRef``'s display metadata (name = title, slug fallback;
+    description; visibility). Called when a product is enabled — including at
+    provision time — so its outputs appear in the catalog with proper titles
+    *before* any recipe run.
+
+    Get-or-create **only**, never update: an operator's later rename, description
+    or visibility edit survives every subsequent enable, upgrade, or run. The
+    recipes' own lazy get_or_create then finds this pre-materialised row and
+    becomes an inert fallback. Returns the Collections (created or pre-existing).
+    """
+    from georiva.core.models import Collection
+
+    collections = []
+    for ref in definition.outputs:
+        collection, _created = Collection.objects.get_or_create(
+            catalog=feed.catalog,
+            slug=ref.collection,
+            defaults={
+                "name": ref.title or ref.collection,
+                "description": ref.description,
+                "visibility": ref.visibility,
+            },
+        )
+        collections.append(collection)
+    return collections
 
 
 def enable_product(product):
@@ -57,7 +94,7 @@ def enable_product(product):
     """
     from georiva.core.product_chain import dependencies_closure
 
-    definitions, rows = _chain(product)
+    feed, definitions, rows = _chain(product)
     needed = dependencies_closure(definitions, product.definition_key)
     missing = [
         _label_of(key, definitions)
@@ -71,7 +108,12 @@ def enable_product(product):
                 "deps": ", ".join(missing),
             }
         )
+    definition = _definition_of(product.definition_key, definitions)
     with transaction.atomic():
+        # Output collections materialise at enable-time, so they appear in the
+        # catalog with declared titles before any run.
+        if definition is not None:
+            materialise_output_collections(feed, definition)
         product.is_enabled = True
         product.save(update_fields=["is_enabled"])
     return product
@@ -83,7 +125,7 @@ def enabled_dependents(product):
     list). Excludes ``product`` itself."""
     from georiva.core.product_chain import dependents_closure
 
-    definitions, rows = _chain(product)
+    _feed, definitions, rows = _chain(product)
     downstream = dependents_closure(definitions, product.definition_key)
     return [
         rows[defn.key]

--- a/georiva/src/georiva/sources/setup_service.py
+++ b/georiva/src/georiva/sources/setup_service.py
@@ -121,6 +121,7 @@ class SourceSetupService:
         clobbers an enable/disable toggle an operator changed after setup.
         """
         from georiva.sources.models import DerivedProduct
+        from georiva.sources.product_service import materialise_output_collections
 
         with transaction.atomic():
             products = []
@@ -137,6 +138,12 @@ class SourceSetupService:
                     defaults=shared,
                     create_defaults={**shared, "is_enabled": bool(enabled)},
                 )
+                # An enabled product materialises its output collections now, so
+                # they appear in the catalog with declared titles before any run
+                # (keyed on the row's actual state, not the wizard arg, so a
+                # re-run never materialises for a product the operator disabled).
+                if product.is_enabled:
+                    materialise_output_collections(data_feed, definition)
                 products.append(product)
                 logger.info(
                     "DerivedProduct %s: feed=%s product=%s enabled=%s",

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -110,6 +110,28 @@ class DispatchForInputTests(TestCase):
             [{"role": "served", "collection": "rainfall"}],
         )
 
+    def test_selector_binding_omits_output_display_metadata(self):
+        # OutputRef's title/description/visibility drive catalog materialisation,
+        # NOT recipe behaviour — they must never enter the selector, or a display
+        # edit would change a recipe's unit identity.
+        definition = _definition(outputs=(
+            OutputRef(role="served", collection="rainfall",
+                      title="Served rainfall", description="Raw, promoted.",
+                      visibility="internal"),
+        ))
+        self._product(definition)
+
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            dispatch_for_input(_staging_trigger(), dispatch=False)
+
+        self.assertEqual(
+            run.call_args.args[1]["outputs"],
+            [{"role": "served", "collection": "rainfall"}],
+        )
+
     def test_product_on_a_different_collection_is_not_dispatched(self):
         definition = _definition(inputs=(
             InputRef(role="source", collection="temperature", tier="staging"),

--- a/georiva/src/georiva/sources/tests/test_derived_products.py
+++ b/georiva/src/georiva/sources/tests/test_derived_products.py
@@ -188,6 +188,35 @@ class ProvisionDerivedProductsTests(TestCase):
         product = DerivedProduct.objects.get(data_feed=self.feed, definition_key="anomaly")
         self.assertEqual(product.config, {"quantity": "anomaly", "min_years": 30})
 
+    def test_provisioning_enabled_product_materialises_its_output_collections(self):
+        # A product enabled in the wizard has its outputs materialised at
+        # provision time, with the declared metadata.
+        defn = _definition(outputs=(
+            OutputRef(role="anomaly", collection="rainfall-anomaly",
+                      title="Rainfall Anomaly", visibility="internal"),
+        ))
+
+        self.service.provision_derived_products(self.feed, [(defn, {}, True)])
+
+        collection = Collection.objects.get(
+            catalog=self.catalog, slug="rainfall-anomaly"
+        )
+        self.assertEqual(collection.name, "Rainfall Anomaly")
+        self.assertEqual(collection.visibility, Collection.Visibility.INTERNAL)
+
+    def test_provisioning_disabled_product_does_not_materialise_outputs(self):
+        # An unticked product's outputs stay latent — they materialise only when
+        # it is enabled later.
+        defn = _definition(outputs=(
+            OutputRef(role="anomaly", collection="rainfall-anomaly"),
+        ))
+
+        self.service.provision_derived_products(self.feed, [(defn, {}, False)])
+
+        self.assertFalse(
+            Collection.objects.filter(slug="rainfall-anomaly").exists()
+        )
+
 
 class BuildProductConfigFormTests(TestCase):
     def test_form_has_a_field_per_config_option_with_defaults(self):

--- a/georiva/src/georiva/sources/tests/test_product_service.py
+++ b/georiva/src/georiva/sources/tests/test_product_service.py
@@ -21,13 +21,14 @@ from georiva.core.derived_products import (
     InputRef,
     OutputRef,
 )
-from georiva.core.models import Catalog
+from georiva.core.models import Catalog, Collection
 from georiva.sources.models import DataFeed, DerivedProduct
 from georiva.sources.product_service import (
     ProductActionError,
     disable_product,
     enable_product,
     enabled_dependents,
+    materialise_output_collections,
 )
 
 User = get_user_model()
@@ -131,6 +132,24 @@ class EnableGateTests(ProductServiceBase):
         self.rows["promotion"].refresh_from_db()
         self.assertTrue(self.rows["promotion"].is_enabled)
 
+    def test_enable_materialises_the_products_output_collections(self):
+        # Enabling makes the output collection appear in the catalog immediately,
+        # before any recipe run.
+        self.rows["anomaly"].is_enabled = False
+        self.rows["anomaly"].save(update_fields=["is_enabled"])
+        self.assertFalse(
+            Collection.objects.filter(slug="chirps-monthly-anomaly").exists()
+        )
+
+        with self._patch_defs():
+            enable_product(self.rows["anomaly"])
+
+        self.assertTrue(
+            Collection.objects.filter(
+                catalog=self.catalog, slug="chirps-monthly-anomaly"
+            ).exists()
+        )
+
 
 class DisableCascadeTests(ProductServiceBase):
     def test_enabled_dependents_lists_the_transitive_downstream_set(self):
@@ -184,6 +203,68 @@ class DisableCascadeTests(ProductServiceBase):
             row.refresh_from_db()
         self.assertTrue(self.rows["climatology"].is_enabled)
         self.assertTrue(self.rows["anomaly"].is_enabled)
+
+
+class MaterialiseOutputCollectionsTests(TestCase):
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+
+    def _definition(self, outputs):
+        return _product("anomaly", outputs=outputs)
+
+    def test_creates_a_collection_per_output_with_declared_metadata(self):
+        definition = self._definition((
+            OutputRef(role="anomaly", collection="chirps-monthly-anomaly",
+                      title="CHIRPS Monthly Anomaly",
+                      description="Absolute rainfall anomaly."),
+            OutputRef(role="climatology", collection="chirps-monthly-climatology",
+                      title="CHIRPS Monthly Climatology", visibility="internal"),
+        ))
+
+        materialise_output_collections(self.feed, definition)
+
+        anomaly = Collection.objects.get(catalog=self.catalog, slug="chirps-monthly-anomaly")
+        self.assertEqual(anomaly.name, "CHIRPS Monthly Anomaly")
+        self.assertEqual(anomaly.description, "Absolute rainfall anomaly.")
+        self.assertEqual(anomaly.visibility, Collection.Visibility.PUBLIC)
+
+        clim = Collection.objects.get(catalog=self.catalog, slug="chirps-monthly-climatology")
+        self.assertEqual(clim.visibility, Collection.Visibility.INTERNAL)
+
+    def test_name_falls_back_to_slug_when_no_title_declared(self):
+        definition = self._definition((
+            OutputRef(role="anomaly", collection="chirps-monthly-anomaly"),
+        ))
+
+        materialise_output_collections(self.feed, definition)
+
+        collection = Collection.objects.get(slug="chirps-monthly-anomaly")
+        self.assertEqual(collection.name, "chirps-monthly-anomaly")
+
+    def test_never_overwrites_an_operators_edits(self):
+        # The operator renamed the collection and flipped its visibility after the
+        # first materialisation; a subsequent enable/upgrade must not clobber that.
+        Collection.objects.create(
+            catalog=self.catalog, slug="chirps-monthly-anomaly",
+            name="My Renamed Anomaly", description="Operator note.",
+            visibility=Collection.Visibility.INTERNAL,
+        )
+        definition = self._definition((
+            OutputRef(role="anomaly", collection="chirps-monthly-anomaly",
+                      title="CHIRPS Monthly Anomaly", description="Declared.",
+                      visibility="public"),
+        ))
+
+        materialise_output_collections(self.feed, definition)
+
+        collection = Collection.objects.get(slug="chirps-monthly-anomaly")
+        self.assertEqual(collection.name, "My Renamed Anomaly")
+        self.assertEqual(collection.description, "Operator note.")
+        self.assertEqual(collection.visibility, Collection.Visibility.INTERNAL)
+        self.assertEqual(Collection.objects.filter(slug="chirps-monthly-anomaly").count(), 1)
 
 
 class TrackingToggleFlowTests(ProductServiceBase):


### PR DESCRIPTION
## What this does

Slice 4 of #164. Everything user-visible about a product's outputs becomes **declaration**, not recipe side-effect: `OutputRef` gains display metadata, and enabling a product materialises its output Collections in the catalog from that metadata — before any run.

Demo: enable anomaly on a fresh CHIRPS feed → the anomaly and relative-anomaly collections appear immediately in the catalog with proper titles; the climatology collection is internal.

Closes #168. Builds on #167 (merged). **Paired with** wmo-raf/georiva-source-chirps#12 (the CHIRPS reference implementation).

## Changes by seam

| Seam | Change |
|------|--------|
| **Contract** (`core/derived_products.py`) | `OutputRef` gains `title=""`, `description=""`, `visibility="public"` (validated against `VISIBILITIES`). All defaulted → existing declarations compile unchanged. Metadata is **not** injected into recipe selectors. |
| **`product_service.py`** | `materialise_output_collections(feed, definition)` — `get_or_create` each declared output Collection (name = title, slug fallback; description; visibility). **Get-or-create only, never update** → operator renames survive. Wired into `enable_product` (atomic, before run). |
| **`setup_service.py`** | `provision_derived_products` materialises outputs for enabled rows — keyed on the row's actual `is_enabled`, so a re-run never materialises for a product the operator disabled. |

## Selector stability

`_binding` already extracts only `role`/`collection`/`tier`, so the new OutputRef fields can't leak into recipe selectors (a display edit must not change a recipe's unit identity). A dedicated regression test (`test_selector_binding_omits_output_display_metadata`) locks this.

## Acceptance criteria (#168)

- [x] `OutputRef` has validated `title`/`description`/`visibility`; existing declarations compile unchanged
- [x] Enabling a product materialises each declared output Collection with the declared name (title, slug fallback), description, and visibility — before any recipe run
- [x] Materialisation never overwrites an existing collection's name, description, or visibility (rename-survival test)
- [x] CHIRPS declares titles/descriptions on all outputs and internal visibility on climatology; the climatology recipe no longer sets visibility in its fallback → **georiva-source-chirps#12**
- [x] Recipe selector binding unchanged (no display fields); existing CHIRPS recipe tests pass
- [x] Service-seam tests for materialisation; CHIRPS plugin declaration tests extended

## Testing

TDD, red→green. **227** tests pass across `georiva.core` + `georiva.sources` + `georiva_source_chirps`.

New/updated coverage:
- `core/test_derived_products.py` — OutputRef metadata default/settable, invalid visibility rejected
- `sources/tests/test_product_service.py` — materialisation (creation with metadata, slug fallback, **rename survival**, enable-time)
- `sources/tests/test_derived_products.py` — provisioning materialises enabled outputs / skips disabled
- `sources/tests/test_derivation_invocation.py` — selector binding omits display metadata

## Notes

- **Two PRs**: this (core+sources) and georiva-source-chirps#12 (CHIRPS declarations + recipe fallback). Merge core first; the plugin PR depends on the OutputRef fields.
- The recipes' lazy `get_or_create` remains as an **inert fallback** — it now finds the pre-materialised row.
