### PR TITLE
feat(sources): chain diagram alignment with product enablement states (#172)

### DIFF
--- a/georiva/src/georiva/sources/derivation_chain.py
+++ b/georiva/src/georiva/sources/derivation_chain.py
@@ -24,8 +24,14 @@ class ChainNode:
 
 @dataclass
 class ChainEdge:
-    """A product: a hyperedge from its input collections to its output ones."""
-    product_id: int
+    """A product: a hyperedge from its input collections to its output ones.
+
+    ``state`` mirrors the management panel's vocabulary so the two agree:
+    ``enabled`` (configured and on), ``disabled`` (configured but off), ``new``
+    (a declared definition with no row yet), or ``orphaned`` (a row the plugin no
+    longer declares). ``product_id`` is None for a ``new`` edge.
+    """
+    product_id: int | None
     label: str
     recipe_type: str
     trigger_mode: str
@@ -34,6 +40,7 @@ class ChainEdge:
     status: str = "idle"
     ready: bool = True
     reason: str | None = None
+    state: str = "enabled"
 
 
 @dataclass
@@ -43,33 +50,62 @@ class ChainGraph:
 
 
 def build_chain_graph(data_feed) -> ChainGraph:
-    """Turn a feed's enabled products + their declarations into a planned DAG."""
+    """Turn a feed's declarations + configured products into a planned DAG that
+    agrees with the management panel: every declared product is an edge tagged
+    with its state (enabled / disabled / new), plus a flagged orphan edge for any
+    row the plugin no longer declares. Enabled edges keep the status/readiness
+    overlay."""
     from georiva.sources.derivation_tracking import product_readiness, product_status
     from georiva.sources.models import DerivedProduct
 
+    real_feed = data_feed.get_real_instance()
+    definitions = real_feed.get_derived_products()
+    rows = {row.definition_key: row for row in DerivedProduct.objects.filter(data_feed=data_feed)}
+    declared_keys = {d.key for d in definitions}
+
     edges = []
     node_slugs = []
-    for product in DerivedProduct.objects.filter(data_feed=data_feed, is_enabled=True):
-        definition = definition_for(product)
-        if definition is None:
-            continue
-        inputs = [ref.collection for ref in definition.inputs]
-        outputs = [ref.collection for ref in definition.outputs]
-        for slug in inputs + outputs:
+
+    def _add_nodes(slugs):
+        for slug in slugs:
             if slug not in node_slugs:
                 node_slugs.append(slug)
-        readiness = product_readiness(product)
+
+    for definition in definitions:
+        inputs = [ref.collection for ref in definition.inputs]
+        outputs = [ref.collection for ref in definition.outputs]
+        _add_nodes(inputs + outputs)
+        row = rows.get(definition.key)
+        if row is None:
+            # A declared definition an upgrade added, not yet provisioned.
+            edges.append(ChainEdge(
+                product_id=None, label=definition.label,
+                recipe_type=definition.recipe_type,
+                trigger_mode=definition.trigger_mode,
+                inputs=inputs, outputs=outputs, state="new",
+            ))
+            continue
+        readiness = product_readiness(row)
         edges.append(ChainEdge(
-            product_id=product.pk,
-            label=definition.label,
+            product_id=row.pk, label=row.display_label,
             recipe_type=definition.recipe_type,
             trigger_mode=definition.trigger_mode,
-            inputs=inputs,
-            outputs=outputs,
-            status=product_status(product).status,
-            ready=readiness.ready,
-            reason=readiness.reason,
+            inputs=inputs, outputs=outputs,
+            status=product_status(row).status,
+            ready=readiness.ready, reason=readiness.reason,
+            state="enabled" if row.is_enabled else "disabled",
         ))
+
+    # Orphaned rows: no declaration, so no inputs/outputs to draw — a flagged,
+    # collection-less edge listed after the topology.
+    for row in rows.values():
+        if row.definition_key not in declared_keys:
+            edges.append(ChainEdge(
+                product_id=row.pk, label=row.display_label,
+                recipe_type=row.recipe_type, trigger_mode="",
+                inputs=[], outputs=[],
+                status=product_status(row).status, state="orphaned",
+            ))
 
     return ChainGraph(nodes=[ChainNode(slug) for slug in node_slugs], edges=edges)
 

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_chain.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_chain.html
@@ -23,6 +23,53 @@
             border-color: var(--w-color-critical-200);
         }
 
+        .gchain-edge--disabled {
+            opacity: 0.6;
+        }
+
+        .gchain-edge--new {
+            border-style: dashed;
+            border-color: var(--w-color-info-100);
+        }
+
+        .gchain-edge--orphaned {
+            border-style: dashed;
+            border-color: var(--w-color-critical-200);
+        }
+
+        .gchain-state {
+            font-size: 0.68em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            padding: 0.15em 0.6em;
+            border-radius: 999px;
+        }
+
+        .gchain-state--enabled {
+            background: color-mix(in srgb, var(--w-color-positive-100) 15%, transparent);
+            color: var(--w-color-positive-100);
+        }
+
+        .gchain-state--disabled {
+            background: var(--w-color-grey-100);
+            color: var(--w-color-grey-400);
+        }
+
+        .gchain-state--new {
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+        }
+
+        .gchain-state--orphaned {
+            background: color-mix(in srgb, var(--w-color-critical-200) 15%, transparent);
+            color: var(--w-color-critical-200);
+        }
+
+        .gchain-flow--orphan .gchain-product {
+            background: var(--w-color-grey-400);
+        }
+
         .gchain-flow {
             display: flex;
             align-items: center;
@@ -79,31 +126,42 @@
 
     <div class="nice-padding">
         <p class="gchain-intro">
-            {% trans "How this feed's products interconnect — collections are nodes, products are edges. Configured-but-unrun (blocked) edges show why." %}
+            {% trans "How this feed's products interconnect — collections are nodes, products are edges. Each edge is tagged with its state (enabled, disabled, new, or no longer provided), matching the management panel; blocked enabled edges show why." %}
         </p>
 
         {% if graph.edges %}
             {% for edge in graph.edges %}
-                <div class="gchain-edge {% if not edge.ready %}gchain-edge--blocked{% endif %}">
-                    <div class="gchain-flow">
+                <div class="gchain-edge gchain-edge--{{ edge.state }}{% if edge.state == 'enabled' and not edge.ready %} gchain-edge--blocked{% endif %}">
+                    <div class="gchain-flow{% if edge.state == 'orphaned' %} gchain-flow--orphan{% endif %}">
                         {% for slug in edge.inputs %}
                             <span class="gchain-node">{{ slug }}</span>
                         {% endfor %}
-                        <span class="gchain-arrow">→</span>
+                        {% if edge.inputs %}<span class="gchain-arrow">→</span>{% endif %}
                         <span class="gchain-product">{{ edge.label }}</span>
-                        <span class="gchain-arrow">→</span>
+                        {% if edge.outputs %}<span class="gchain-arrow">→</span>{% endif %}
                         {% for slug in edge.outputs %}
                             <span class="gchain-node">{{ slug }}</span>
                         {% endfor %}
+                        <span class="gchain-state gchain-state--{{ edge.state }}">
+                            {% if edge.state == "enabled" %}{% trans "Enabled" %}
+                            {% elif edge.state == "disabled" %}{% trans "Disabled" %}
+                            {% elif edge.state == "new" %}{% trans "New — not enabled" %}
+                            {% elif edge.state == "orphaned" %}{% trans "No longer provided" %}
+                            {% endif %}
+                        </span>
                     </div>
                     <div class="gchain-meta">
                         <span>{% trans "Recipe" %}: {{ edge.recipe_type }}</span>
-                        <span>{% trans "Trigger" %}: {{ edge.trigger_mode }}</span>
-                        <span>{% trans "Status" %}: {{ edge.status }}</span>
-                        {% if edge.ready %}
-                            <span>{% trans "Ready" %}</span>
-                        {% else %}
-                            <span class="gchain-reason">{% trans "Blocked" %}: {{ edge.reason }}</span>
+                        {% if edge.trigger_mode %}<span>{% trans "Trigger" %}: {{ edge.trigger_mode }}</span>{% endif %}
+                        {% if edge.state == "enabled" or edge.state == "disabled" %}
+                            <span>{% trans "Status" %}: {{ edge.status }}</span>
+                        {% endif %}
+                        {% if edge.state == "enabled" %}
+                            {% if edge.ready %}
+                                <span>{% trans "Ready" %}</span>
+                            {% else %}
+                                <span class="gchain-reason">{% trans "Blocked" %}: {{ edge.reason }}</span>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/georiva/src/georiva/sources/tests/test_derivation_chain.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_chain.py
@@ -98,15 +98,57 @@ class BuildChainGraphTests(TestCase):
         self.assertFalse(edge.ready)              # required input empty
         self.assertIn("value", edge.reason)       # blocking reason named
 
-    def test_disabled_product_is_not_an_edge(self):
+    def test_enabled_product_edge_is_tagged_enabled(self):
+        definition = _definition()
+        self._product(definition)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        self.assertEqual(graph.edges[0].state, "enabled")
+
+    def test_disabled_product_is_a_configured_off_edge(self):
+        # The diagram now agrees with the management panel: a disabled product is
+        # a configured-but-off edge, not omitted.
         definition = _definition()
         self._product(definition, is_enabled=False)
 
         with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
             graph = build_chain_graph(self.feed)
 
-        self.assertEqual(graph.edges, [])
-        self.assertEqual(graph.nodes, [])
+        self.assertEqual(len(graph.edges), 1)
+        self.assertEqual(graph.edges[0].state, "disabled")
+        # Its collections are still nodes in the topology.
+        self.assertEqual(
+            {n.collection for n in graph.nodes}, {"rainfall", "rainfall-anomaly"}
+        )
+
+    def test_declared_definition_without_a_row_is_a_new_edge(self):
+        # A plugin update added a product; no row yet.
+        definition = _definition()
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
+            graph = build_chain_graph(self.feed)
+
+        self.assertEqual(len(graph.edges), 1)
+        edge = graph.edges[0]
+        self.assertEqual(edge.state, "new")
+        self.assertIsNone(edge.product_id)
+        self.assertEqual(edge.inputs, ["rainfall"])
+        self.assertEqual(edge.outputs, ["rainfall-anomaly"])
+
+    def test_orphaned_row_is_a_flagged_edge(self):
+        # A row the declaration no longer includes -> orphan edge.
+        definition = _definition()
+        self._product(definition)
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[]):
+            graph = build_chain_graph(self.feed)
+
+        self.assertEqual(len(graph.edges), 1)
+        edge = graph.edges[0]
+        self.assertEqual(edge.state, "orphaned")
+        self.assertEqual(edge.label, "anomaly")  # no declaration -> key fallback
 
 
 class ItemLineageTests(TestCase):
@@ -175,6 +217,25 @@ class ChainViewTests(TestCase):
         self.assertContains(response, "rainfall")           # an input node
         self.assertContains(response, "rainfall-anomaly")   # an output node
         self.assertContains(response, "Rainfall anomaly")   # the product edge label
+
+    def test_chain_page_labels_the_product_states(self):
+        from django.urls import reverse
+
+        # anomaly has a row (enabled); a second declared 'promotion' has no row
+        # (new); the diagram should label both, consistent with the panel.
+        promotion = _definition(
+            key="promotion", label="Serve raw",
+            inputs=(InputRef(role="source", collection="rainfall", tier="staging"),),
+            outputs=(OutputRef(role="served", collection="rainfall"),),
+        )
+        with patch.object(DataFeed, "get_derived_products",
+                          return_value=[_definition(), promotion]):
+            response = self.client.get(
+                reverse("derived_product_chain", kwargs={"feed_pk": self.feed.pk})
+            )
+
+        self.assertContains(response, "Enabled")
+        self.assertContains(response, "New — not enabled")
 
 
 class ItemLineageViewTests(TestCase):


### PR DESCRIPTION
## What this does

Slice 8 of #164. The chain **diagram** (the planned-DAG topology view from PR #160, closing #150) now **agrees with the chain management panel** — it drew enabled products only; now it shows every state.

Demo: with anomaly disabled and an orphan present, the topology page shows all edge states matching what the feed panel shows.

Closes #172. Builds on #171 (merged).

## Changes

- **`ChainEdge` gains a `state`** field (`enabled` / `disabled` / `new` / `orphaned`), mirroring the panel's vocabulary; `product_id` is None for a `new` edge.
- **`build_chain_graph` drops the `is_enabled=True` filter**: every declared product is an edge tagged with its state; a declared-but-rowless definition is a **new** edge; a row the plugin no longer declares is a flagged, collection-less **orphaned** edge. Enabled edges keep the status/readiness overlay. `item_lineage` is untouched.
- **`derived_product_chain.html`** renders a state pill per edge with distinct styling, labeled consistently with the management panel ("Enabled", "Disabled", "New — not enabled", "No longer provided").

## Acceptance criteria (#172)

- [x] The graph builder includes disabled, new (declared-but-no-row), and orphaned products with their state
- [x] The rendered diagram visually distinguishes the three states and labels them consistently with the management panel
- [x] Enabled-only filtering is removed; existing behaviour for enabled products (status/readiness overlay) is preserved
- [x] Pure-seam tests for the graph builder extended to the new states; item lineage unchanged

## Testing

TDD, red→green. **272** `georiva.core` + `georiva.sources` + `georiva_source_chirps` tests pass.

- Pure-seam: `enabled`/`disabled`/`new`/`orphaned` edge states; the old "disabled is not an edge" test **inverts** to "disabled is a configured-off edge"; existing enabled status/readiness overlay preserved; `item_lineage` tests unchanged.
- View-seam: chain page labels the states.
- **Verified end-to-end** against a real CHIRPS feed (anomaly disabled + an orphan row): chain page 200 showing Enabled / Disabled / "No longer provided" edges with their distinct styling classes.
