### PR TITLE
docs: derived-products blueprint — ADR-0009, plugin guide, boilerplate skeleton (#173)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,10 +29,16 @@ reading order. If you're new, start at the top and work down.
 7. **[Source Plugin Parameter Contract & Setup Wizard](architecture/plugin-parameter-contract.md)** — *(RFC, draft)* a
    proposed declarative `describe_parameters()` contract so plugins can provision their Catalog/Collection/Variable
    hierarchy automatically.
+8. **[Derived Products](plugins/derived-products.md)** — the contract for declaring layers a feed computes from its own
+   collections (anomaly, climatology, promotion…): `get_derived_products()`, the full `DerivedProductDefinition` /
+   `InputRef` / `OutputRef` / `ConfigField` reference, how the tier-aware chain and stages are computed, what core
+   materialises versus what recipes create, and a worked CHIRPS example. Decisions recorded in
+   [ADR-0008](adr/0008-configurable-derivation-products.md) and
+   [ADR-0009](adr/0009-derived-product-chain-and-lifecycle.md).
 
 ## Contributing
 
-8. **[Contributing Guide](contributing.md)** — dev environment, running the stack and tests, branching model, and code
+9. **[Contributing Guide](contributing.md)** — dev environment, running the stack and tests, branching model, and code
    conventions.
 
 ## Cross-cutting patterns (for maintainers)

--- a/docs/adr/0008-configurable-derivation-products.md
+++ b/docs/adr/0008-configurable-derivation-products.md
@@ -140,4 +140,6 @@ button overlays all modes.
   declarations + `DerivedProduct`s) removes the `target_tier`-vs-products drift
   class entirely.
 
-See ADR-0005 (engine), ADR-0006/0007 (plugin recipe families).
+See ADR-0005 (engine), ADR-0006/0007 (plugin recipe families), and **ADR-0009**
+(the chain computation, enablement/readiness gates, always-provision +
+materialise-on-enable, and the orphan/upgrade lifecycle built on this contract).

--- a/docs/adr/0009-derived-product-chain-and-lifecycle.md
+++ b/docs/adr/0009-derived-product-chain-and-lifecycle.md
@@ -1,0 +1,174 @@
+# Derived-product chain, gates, and lifecycle
+
+## Status
+
+proposed
+
+## Context
+
+ADR-0008 introduced the declarative derived-product contract
+(`DerivedProductDefinition` / `DerivedProduct`), product-driven invocation, and
+the tracking/chain UI. It established the vocabulary — **products are edges,
+collections are nodes** — and left the pipeline *topology* declared but only
+lightly consumed: the wizard showed products with no opt-out, the declared
+dependency between products (an anomaly needs its climatology baseline) was
+never computed or enforced, output collections were created as a recipe side
+effect, and nothing was operator-editable or upgrade-aware.
+
+This ADR records the decisions taken while turning that contract into a
+lifecycle every plugin can rely on, implemented with CHIRPS as the reference. It
+covers how the **chain** is computed, the **two gates** that decide whether a
+product may run, how products are **provisioned and materialised**, what happens
+across a **plugin upgrade**, which properties are **editable**, and the **known
+boundaries** we chose not to cross.
+
+Everything here stays within the ADR-0005 layering: the generic engine remains
+unaware of products; the chain math is a pure module in `core`, and its DB-bound
+use lives in the `sources` application layer.
+
+## Decision
+
+### 1. The chain is a tier-aware, computed DAG
+
+`core/product_chain.py` computes the product-level dependency graph as **pure
+functions** over a `Sequence[DerivedProductDefinition]` — no DB, no recipe
+execution — so it is importable from both the feed layer and the engine
+(ADR-0005).
+
+Product **P depends on product Q** iff a **required** input of P at the
+**published** tier names a collection among Q's outputs, unioned with any
+explicit `depends_on` extras P declares.
+
+Tier awareness is the crux. A staging-tier input is fed by the loader, not by
+another product; a published-tier input is another product's served output. In
+CHIRPS the anomaly reads the raw slice at *staging* and the climatology baseline
+at *published* — so the one true edge is **anomaly → climatology**. A tier-blind
+rule would additionally fabricate **anomaly → promotion** (promotion also
+outputs the raw collection at the published tier), which is wrong. The rule
+therefore filters on `required and tier == "published"`.
+
+`depends_on` exists for the rare non-data-flow dependency the rule can't infer
+(a product needing another's side effect rather than its output collection). In
+practice it is usually empty — a published-tier input gives the edge for free.
+
+The module exposes `product_dependencies` / `product_dependents`, transitive
+`dependencies_closure` / `dependents_closure`, `topological_stages` (Kahn
+layering, stable in declaration order — the wizard and panel render lanes from
+it), and `validate_chain`.
+
+**Cycles are plugin bugs that fail loudly.** `validate_chain` raises
+`ChainError` on duplicate keys or an unknown `depends_on` target, and
+`ChainCycleError` on any cycle (data-flow, explicit, or a degenerate self-loop),
+at first render/provision — never silently mid-sweep. The wizard degrades to a
+single flat lane with the error surfaced; provisioning refuses the batch.
+
+### 2. Two distinct gates
+
+A product may run only if it passes **both**, and they are deliberately separate:
+
+- **Structural enablement gate** (`product_service.enable_product`): a product
+  may be enabled only if every product in its transitive `dependencies_closure`
+  has a row that exists *and* is enabled. Enabling an anomaly whose climatology
+  is off is refused, naming the missing dependency by its display label.
+- **Runtime readiness gate** (`derivation_tracking.product_readiness`): a
+  product may *run* only when every required input collection exists and is
+  non-empty — the same data gate the tracking dashboard already used.
+
+Enablement is about structure and can be satisfied ahead of any data: an
+operator may enable a whole chain in one pass (climatology, then anomaly) before
+a single byte has been fetched. Readiness is about data and is checked at
+dispatch. Keeping them separate is what lets an operator configure the pipeline
+up front and let data catch up.
+
+### 3. Cascade-disable through a single write-path
+
+All enable/disable flows — wizard, feed panel, tracking dashboard — route
+through `product_service`, so the invariant *no enabled product may have a
+disabled (or missing) dependency* holds from every surface. Disabling a product
+with enabled dependents shows a confirmation listing the transitive downstream
+set; the confirming request **recomputes the closure server-side** (never trusts
+the submitted list) and disables the whole set atomically.
+
+### 4. Always provision a row; materialise output collections on enable
+
+Provisioning writes a `DerivedProduct` row for **every** declared definition,
+whether the operator ticked it in the wizard or not; the opt-out lives in
+`is_enabled`, not in a missing row. `is_enabled` is written **once, at row
+creation** (via `update_or_create(create_defaults=…)`), so re-running the wizard
+edits config but never clobbers a toggle an operator changed later. An unticked
+product is fully inert (every dispatch path filters on `is_enabled`) but stays
+visible, one toggle from being enabled.
+
+A product's output **Collections materialise when it is enabled** — including at
+provision time for products enabled in the wizard — from each `OutputRef`'s
+`title` / `description` / `visibility` metadata. Materialisation is
+**get-or-create only, never update**: an operator's later rename, re-description,
+or visibility change survives every subsequent enable, upgrade, or run. The
+recipes' own lazy `get_or_create` becomes an inert fallback that finds the
+pre-materialised row. Everything catalog-facing about an output is therefore
+**declaration**, not recipe side effect; the recipe selector binding never
+carries the display fields, so a display edit can't change a recipe's unit
+identity.
+
+### 5. Orphan / upgrade lifecycle
+
+The chain panel and diagram merge the **live declaration** with **database
+state**, so both stay truthful across plugin upgrades:
+
+- A **declared definition with no row** (added by an update) renders as a
+  "New — not enabled" card/edge with an inline enable action that shows its
+  config form, provisions the row, runs the structural gate, and materialises
+  its collections — no wizard re-run.
+- A **row whose definition key is no longer declared** (removed/renamed by an
+  update) is an **orphan**: flagged distinctly, excluded from all invocation
+  (its definition lookup returns nothing, so every dispatch path already skips
+  it), with a delete action whose confirmation states that already-published
+  collections and their data are kept — deletion removes only the config row.
+
+### 6. Semantic vs structural editability
+
+Editable **semantic** properties (a separate edit view): nullable
+`title` / `description` overrides on `DerivedProduct` (blank falls back to the
+declared label/description, so un-overridden text refreshes on upgrade), the
+`name` / `description` of each materialised output Collection, and the operator
+config plus the schedule interval — the last clearly flagged **"affects future
+runs only"**. Read-only **structural** identity: definition key, recipe type,
+collection slugs, inputs/outputs, and trigger mode are fixed by the plugin
+declaration. Every surface that names a product uses the display fallback.
+
+## Known boundaries
+
+- **Completion chaining stays recipe-driven.** When a produced item is
+  published, the engine fans it to all recipes without knowing about products
+  (`processing/invocation.py`), and it cannot learn about them without a
+  `processing → sources` import, which ADR-0005 forbids. CHIRPS recipes
+  self-defend via their `candidate_units`. Making completion chaining
+  product-aware is out of scope and would require a different layering.
+- **The enable-after-ingest staging gap.** Data fetched while a
+  staging-consuming product was *disabled* routed to the sources bucket, not
+  staging (staging routing is auto-derived from *enabled* products). Enabling
+  the product later finds its staging input empty, so readiness reports blocked.
+  The chain panel surfaces a specific hint — *re-run the feed to backfill* — and
+  no cache invalidation is needed (`collection_routes_to_staging` is computed
+  live per loader run). Automatic backfill on enable is out of scope.
+
+## Consequences
+
+- **New contract fields** (all defaulted, so existing declarations compile
+  unchanged): `DerivedProductDefinition.default_enabled`, `.depends_on`;
+  `OutputRef.title` / `.description` / `.visibility`.
+- **New model fields / migration:** `DerivedProduct.title` / `.description`
+  overrides.
+- **New pure module** `core/product_chain.py` and **service module**
+  `sources/product_service.py` (the single enable/disable/provision/materialise
+  write-path).
+- **CHIRPS is the blueprint:** it declares output titles/descriptions and the
+  internal climatology visibility, needs no `depends_on` (the published baseline
+  gives the edge), and moved its recipe's hardcoded visibility into the
+  declaration.
+- **The engine is still untouched** — all of the above lives in `core` (pure
+  contract + chain) and the `sources` application layer.
+
+See ADR-0008 (the derived-product contract this builds on), ADR-0005 (the
+generic engine and its layering boundary), ADR-0007 (the CHIRPS recipe family),
+and `docs/plugins/derived-products.md` (the developer guide).

--- a/docs/plugins/derived-products.md
+++ b/docs/plugins/derived-products.md
@@ -1,0 +1,191 @@
+# Derived products — plugin developer guide
+
+A **derived product** is a layer a feed computes from its own collections by
+running a registered recipe: a promotion that serves raw data 1:1, a climatology
+normal, an anomaly against that normal, and so on. This guide is the contract for
+declaring them. See ADR-0008 for the original design and ADR-0009 for the chain,
+gates, and lifecycle decisions.
+
+Vocabulary (used throughout): in the chain DAG **products are edges** and
+**collections are nodes**. A collection lives at a **tier** — `staging`
+(loader-fed, pre-publish, never served) or `published` (served via
+STAC/EDR/tiles). One product may emit several output collections.
+
+## Declaring products
+
+A feed declares the products it offers by implementing `get_derived_products()`.
+It is an **instance** method (unlike `get_collection_definitions`, which is a
+classmethod): a product's inputs and outputs bind to *this feed's actual
+collections*, which is instance state. Return one `DerivedProductDefinition` per
+product; the base default is an empty list (a feed that only ingests raw data
+declares none).
+
+```python
+def get_derived_products(self):
+    from georiva.core.derived_products import (
+        ConfigField, DerivedProductDefinition, InputRef, OutputRef,
+    )
+    return [
+        DerivedProductDefinition(
+            key="rainfall-anomaly",
+            recipe_type="my-anomaly",
+            label="Rainfall anomaly",
+            description="Departure from the climatological normal.",
+            config_schema=(
+                ConfigField(key="min_years", type="int", default=30),
+            ),
+            inputs=(
+                InputRef(role="value", collection="rainfall", tier="staging"),
+                InputRef(role="baseline", collection="rainfall-climatology",
+                         tier="published"),
+            ),
+            outputs=(
+                OutputRef(role="anomaly", collection="rainfall-anomaly",
+                          title="Rainfall anomaly",
+                          description="Absolute departure from the normal."),
+            ),
+            trigger_mode="event",
+        ),
+    ]
+```
+
+The contract is **pure declaration** — dataclasses with string enums, no DB or
+engine imports — so the wizard (form + validation), invocation (selector
+building), tracking (run grouping), and the chain UI all read from the same
+source of truth. The DB-backed resolution of a declared input into the catalog
+items it points at lives in the engine layer, not in your declaration.
+
+## Contract reference
+
+### `DerivedProductDefinition`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `key` | str | — | Unique per feed. Identifies the product's config row and stamps its run origin. Stable — changing it orphans the old row. |
+| `recipe_type` | str | — | The registered recipe this product runs (a `@recipe_registry.register` name). |
+| `label` | str | — | Human name shown in the wizard, chain panel, and diagram. |
+| `description` | str | — | One-line "what it means", shown alongside the label. |
+| `config_schema` | tuple[`ConfigField`] | — | Operator options → the wizard form and validation. Empty tuple = no options. |
+| `inputs` | tuple[`InputRef`] | — | The collections this product consumes, declared (not buried in the recipe). |
+| `outputs` | tuple[`OutputRef`] | — | The collections this product produces. |
+| `trigger_mode` | str | — | `event` (fire on each arriving input), `scheduled` (per-interval), or `manual` (operator-triggered only). |
+| `default_enabled` | bool | `True` | Whether the product is pre-ticked in the wizard's opt-in step. |
+| `depends_on` | tuple[str] | `()` | Extra product keys this one depends on, for a non-data-flow dependency the tier rule can't infer (see below). |
+
+`validate_config(config)` (called by the wizard and the setup service) coerces
+each supplied option to its declared type, fills missing options from their
+defaults, constrains `choice` values, and rejects unknown keys — so a bad option
+is caught before any row is written.
+
+### `InputRef`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `role` | str | — | The recipe's name for this input (e.g. `value`, `baseline`). |
+| `collection` | str | — | The collection slug consumed. |
+| `tier` | str | — | `staging` or `published`. Determines both routing and dependency edges (below). |
+| `required` | bool | `True` | An optional input never blocks readiness and never creates a dependency edge. |
+
+### `OutputRef`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `role` | str | — | The recipe's name for this output. |
+| `collection` | str | — | The output collection slug. |
+| `title` | str | `""` | Catalog display name of the materialised collection. Blank → the slug. |
+| `description` | str | `""` | Catalog description of the collection. |
+| `visibility` | str | `"public"` | `public` (served) or `internal` (a derivation intermediate — read by the engine, never served). |
+
+### `ConfigField`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `key` | str | — | Option name (a key in the saved `config`). |
+| `type` | str | — | `str`, `int`, `float`, `bool`, or `choice`. |
+| `default` | any | `None` | Value used when the operator leaves it blank. |
+| `choices` | tuple | `None` | Required for `choice`; the allowed values (and `default`, if set, must be one). |
+
+## How edges and stages are computed
+
+The chain is a **computed DAG**, pure over your declarations
+(`core/product_chain.py`) — no DB, no run needed to draw it.
+
+- **Edge rule:** product **P depends on Q** iff a **required** input of P at the
+  **published** tier names a collection among Q's outputs, unioned with P's
+  `depends_on`. Tier awareness is essential: a staging input is fed by the
+  loader, so a required *staging* input never creates a product edge; only a
+  required *published* input (another product's served output) does.
+- **Stages:** products are laid out in topological stages (Kahn layering, stable
+  in declaration order) — the lanes the wizard step and feed panel render. A
+  product sits one stage after its dependencies.
+- **Cycles fail loudly:** duplicate keys, an unknown `depends_on` target, or any
+  cycle (data-flow, explicit, or self-loop) raise at first render/provision, so
+  a broken declaration never runs half-applied. Keep your graph acyclic.
+
+## Core materialises; recipes compute
+
+Draw a clear line between the two:
+
+- **Core materialises output collections** from your `OutputRef` metadata when a
+  product is enabled (including at provision time). It uses **get-or-create
+  only** — it never overwrites an existing collection's `name`, `description`, or
+  `visibility`, so an operator's rename survives every later enable, upgrade, or
+  run. Declare the catalog-facing strings and visibility on the `OutputRef`; do
+  **not** set them in the recipe.
+- **Your recipe computes the data** — items and assets — into those collections.
+  Its own lazy `get_or_create` for a collection should be a bare fallback
+  (`defaults={"name": slug}` at most); it will normally find the collection core
+  already materialised. The recipe selector binding carries only
+  `role`/`collection`/`tier`, never the display fields, so a title edit can't
+  change a recipe's unit identity.
+
+## `default_enabled` and `depends_on`
+
+- **`default_enabled`** controls only the *pre-tick* in the wizard's opt-in step.
+  Leave it `True` for products an operator will usually want; set `False` for an
+  advanced or expensive product they should opt into deliberately. Either way a
+  row is always provisioned — the opt-out lives in `is_enabled`, so an unticked
+  product stays visible (disabled) and is one toggle from running.
+- **`depends_on`** is almost always unnecessary. If product P consumes product
+  Q's output at the published tier (the normal case — an anomaly reading a
+  climatology baseline), the edge is inferred for free; do **not** also list it.
+  Reach for `depends_on` only for a genuine dependency with no data-flow edge
+  (P needs Q to have run for a side effect, not for its output collection).
+  Entries must be non-empty and must not name the product itself.
+
+## Worked example: CHIRPS
+
+CHIRPS (`georiva-source-chirps`) is the reference implementation. Per selected
+resolution (e.g. `monthly`) it declares three products:
+
+- **Promotion** — `recipe_type="promotion"`, `trigger_mode="event"`. Input: the
+  raw slice at **staging**. Output: the same slug at **published** (title
+  "CHIRPS monthly rainfall"). Serves each staged slice 1:1.
+- **Climatology** — `recipe_type="chirps-climatology"`, `trigger_mode="manual"`.
+  Input: the raw slice at **staging**. Output:
+  `chirps-monthly-climatology`, declared **`visibility="internal"`** (a baseline
+  the anomaly reads, never served). Config: `baseline_start`, `baseline_end`,
+  `min_count`.
+- **Anomaly** — `recipe_type="chirps-anomaly"`, `trigger_mode="event"`. Inputs:
+  the raw slice at **staging** *and* the climatology at **published** (role
+  `baseline`, required). Outputs: `chirps-monthly-anomaly` and
+  `chirps-monthly-relative-anomaly`, both public.
+
+From these declarations alone the chain computes exactly **anomaly →
+climatology** (the anomaly's required published baseline is climatology's
+output) and **no** edge to promotion (the anomaly's raw input is staging-tier).
+Promotion and climatology land in stage 1, anomaly in stage 2. CHIRPS needs no
+`depends_on` — the published baseline gives the edge — and its climatology
+recipe no longer sets visibility: the `OutputRef` owns it, materialised on
+enable.
+
+## Lifecycle, in brief
+
+Once declared, products are managed from the feed's **Derived Products** panel
+(and cross-monitored on the tracking dashboard). Enabling a product is gated on
+its dependencies being enabled; running it is separately gated on its input data
+being ready. Disabling one that others depend on cascades (with confirmation).
+Output collections appear in the catalog the moment a product is enabled.
+Adding a product in a later plugin release surfaces it as "New — not enabled"
+with inline enable; removing one leaves an "orphan" row that is inert and
+deletable (its published data is kept). See ADR-0009 for the full rationale.

--- a/source-plugin-boilerplate/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_module }}/models.py
+++ b/source-plugin-boilerplate/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_module }}/models.py
@@ -11,6 +11,14 @@ The plugin contract a DataFeed must satisfy:
   * get_catalog_defaults() — pre-fills the wizard's catalog step.
   * data_source_cls — the BaseDataSource (source.py) that fetches the data.
   * get_loader_config() — feed-wide settings merged into the source's config.
+
+Optionally, a feed can declare **derived products** — layers computed from its
+collections by a registered recipe (anomaly, climatology, promotion, …):
+  * get_derived_products() — the list of DerivedProductDefinitions this feed
+    offers (ADR-0008/0009). It is an *instance* method (a product's inputs bind
+    to this feed's actual collections). See the commented skeleton at the bottom
+    of the DataFeed below, and docs/plugins/derived-products.md for the full
+    contract. In the chain DAG, products are edges and collections are nodes.
 """
 
 from django.db import models
@@ -94,3 +102,60 @@ class {{ cookiecutter.project_module|replace('_', ' ')|title|replace(' ', '') }}
     def get_loader_config(self) -> dict:
         """Feed-wide settings merged into the data source's config dict."""
         return {}
+
+    # -- derived products (optional) ----------------------------------------
+    #
+    # Uncomment and adapt to declare layers computed from this feed's
+    # collections by a registered recipe. Delete this block if the plugin only
+    # ingests raw data. Full guide: docs/plugins/derived-products.md.
+    #
+    # get_derived_products() is an *instance* method: a product's InputRef /
+    # OutputRef bind to this feed's actual collection slugs. Return one
+    # DerivedProductDefinition per product the feed offers.
+    #
+    # def get_derived_products(self):
+    #     from georiva.core.derived_products import (
+    #         ConfigField, DerivedProductDefinition, InputRef, OutputRef,
+    #     )
+    #     return [
+    #         DerivedProductDefinition(
+    #             key="example-anomaly",          # unique per feed; the origin/config key
+    #             recipe_type="my-anomaly",       # a recipe registered via @recipe_registry.register
+    #             label="Example anomaly",        # shown in the wizard + chain panel
+    #             description="Departure from the climatological normal.",
+    #             # Operator options -> the wizard form + validation. Types:
+    #             # str | int | float | bool | choice (choice requires `choices`).
+    #             config_schema=(
+    #                 ConfigField(key="min_years", type="int", default=30),
+    #                 ConfigField(key="quantity", type="choice",
+    #                             choices=("anomaly", "value"), default="anomaly"),
+    #             ),
+    #             # Declared inputs (not buried in the recipe). tier is "staging"
+    #             # (loader-fed, pre-publish) or "published". A required input at
+    #             # the *published* tier that names another product's output creates
+    #             # a dependency edge (anomaly -> climatology).
+    #             inputs=(
+    #                 InputRef(role="value", collection="example-collection", tier="staging"),
+    #                 InputRef(role="baseline", collection="example-collection-climatology",
+    #                          tier="published", required=True),
+    #             ),
+    #             # Output collections this product materialises. title/description/
+    #             # visibility drive the catalog Collection created on enable
+    #             # (get-or-create only, so operator renames survive). visibility is
+    #             # "public" (served) or "internal" (a derivation intermediate).
+    #             outputs=(
+    #                 OutputRef(role="anomaly", collection="example-collection-anomaly",
+    #                           title="Example anomaly",
+    #                           description="Absolute departure from the normal.",
+    #                           visibility="public"),
+    #             ),
+    #             # "event" (fire on each arriving input), "scheduled" (interval), or
+    #             # "manual" (operator-triggered only).
+    #             trigger_mode="event",
+    #             # Pre-ticked in the wizard's opt-in step (default True).
+    #             default_enabled=True,
+    #             # Extra non-data-flow dependencies the tier rule can't infer
+    #             # (usually unnecessary — a published-tier input gives the edge).
+    #             depends_on=(),
+    #         ),
+    #     ]


### PR DESCRIPTION
## What this does

Slice 9 (final) of #164. The **blueprint** that makes the derived-products framework a contract for every plugin — three artifacts, written against the shipped implementation.

Closes #173. Builds on #168 + #171 (merged).

## Artifacts

1. **ADR-0009** (`docs/adr/0009-derived-product-chain-and-lifecycle.md`) — records the decisions: tier-aware DAG computation (published-tier data edges + explicit `depends_on` extras; cycles fail loudly), the **two distinct gates** (structural enablement vs runtime readiness), cascade-disable via a single write-path, **always-provision rows** with materialise-on-enable from `OutputRef` metadata (get-or-create, so renames survive), the orphan/upgrade lifecycle, the semantic-vs-structural editability split, and the **known boundaries** (completion chaining stays recipe-driven per ADR-0005; the enable-after-ingest staging gap + re-run remedy). Cross-linked from ADR-0008.
2. **Plugin developer guide** (`docs/plugins/derived-products.md`) — how to declare products, the full `DerivedProductDefinition` / `InputRef` / `OutputRef` / `ConfigField` field reference (tables), how edges and stages are computed, what core materialises vs what recipes create, `default_enabled` / `depends_on` guidance, and **CHIRPS as the worked example**. Linked from `docs/README.md`.
3. **Boilerplate skeleton** (`source-plugin-boilerplate`) — a commented `get_derived_products()` showing **every** contract field, plus the contract in the module docstring, so new plugins meet it from day one.

## Acceptance criteria (#173)

- [x] ADR-0009 added covering the decisions above, linked from ADR-0008
- [x] Developer guide published in the plugin docs with the complete contract reference and worked CHIRPS example
- [x] Boilerplate template includes the commented declaration skeleton and its module docstring lists the derived-products contract; a fresh cookiecutter render imports cleanly
- [x] Docs use the project's domain vocabulary (product = edge, collection = node; staging vs published tiers)

## Verification

- **A fresh `cookiecutter --no-input` render of the boilerplate parses cleanly** (`ast.parse`), and the rendered `models.py` contains the full skeleton (all of `DerivedProductDefinition`, `InputRef`, `OutputRef`, `ConfigField`, `default_enabled`, `depends_on`, `visibility`, `trigger_mode`).
- CHIRPS facts in the guide/ADR checked against the source (trigger modes, internal climatology visibility, the anomaly → climatology edge).
- Docs-only slice — no app code changed, so the suite is unchanged from the prior slice.

## 🎉 This completes the #164 epic

All nine slices landed: opt-out wizard (#165) → chain module (#166) → enable gate + cascade (#167) → output metadata + materialisation (#168) → feed panel (#169) → edit view (#170) → upgrade lifecycle (#171) → chain-diagram alignment (#172) → this blueprint (#173).
