### PR TITLE
feat(sources): feed-namespace key validation + unified slug scheme (ADR-0010 slice 1)

### DIFF
--- a/docs/adr/0010-pinned-collection-bindings-for-derived-products.md
+++ b/docs/adr/0010-pinned-collection-bindings-for-derived-products.md
@@ -83,9 +83,14 @@ output key), so plugin churn is minimal.
 
 `core.product_chain.validate_chain` is extended: every `InputRef` key must
 resolve within the feed namespace (a definition key, or a sibling product's
-output key), and output keys must not collide with definition keys or each
-other. An unresolvable key is a plugin bug that **fails loudly** at declaration
-time — this check alone would have caught failure class 1.
+output key), and no two distinct products may declare the same output key
+(ambiguous provenance). An output key that *equals* a raw definition key is
+**allowed** — a promotion serving the raw collection 1:1 reuses the raw key as
+its own served output by design, and after §5's unified slug scheme the two
+resolve to the same `core.Collection`; the collision rule is therefore
+output-vs-output only, never output-vs-definition-key. An unresolvable key is a
+plugin bug that **fails loudly** at declaration time — this check alone would
+have caught failure class 1.
 
 ### 2. Bindings are resolved and pinned at provision/enable time
 

--- a/georiva/src/georiva/core/product_chain.py
+++ b/georiva/src/georiva/core/product_chain.py
@@ -99,15 +99,37 @@ def dependents_closure(defs, key) -> set:
     return _closure(product_dependents(defs), key)
 
 
-def validate_chain(defs) -> None:
+def output_keys(defs) -> set:
+    """Every collection key produced by some product in ``defs``."""
+    return {ref.collection for defn in defs for ref in defn.outputs}
+
+
+def collection_namespace(defs, collection_keys) -> set:
+    """The feed-local collection-key namespace an input may reference (ADR-0010
+    §1): the feed's raw ``CollectionDefinition`` keys unioned with every product
+    output key. A ``None`` ``collection_keys`` means "raw keys unknown here" —
+    only the output keys are namespaced (used by the pure structural callers that
+    don't have the collection definitions to hand)."""
+    return set(collection_keys or ()) | output_keys(defs)
+
+
+def validate_chain(defs, collection_keys=None) -> None:
     """
     Raise loudly on a malformed chain so a broken plugin fails at first
     render/provision, never silently mid-sweep:
 
     - duplicate product keys -> ``ChainError``
     - a ``depends_on`` naming a product that isn't declared -> ``ChainError``
+    - an output collection declared by more than one product -> ``ChainError``
     - a dependency cycle, whether inferred from data flow or declared via
       ``depends_on`` (a self-loop is the degenerate 1-cycle) -> ``ChainCycleError``
+
+    When ``collection_keys`` is supplied (the feed's raw ``CollectionDefinition``
+    keys), every input is additionally required to resolve within the feed-local
+    namespace — a raw collection key or a sibling product's output key (ADR-0010
+    §1) — else ``ChainError``. Omitting ``collection_keys`` skips only this input
+    check; an output key that *equals* a raw collection key is always allowed (a
+    promotion serving the raw collection 1:1 reuses its key by design).
     """
     seen: set[str] = set()
     for defn in defs:
@@ -121,6 +143,17 @@ def validate_chain(defs) -> None:
                 raise ChainError(
                     f"product '{defn.key}' depends on unknown product '{dep}'"
                 )
+
+    producers: dict[str, str] = {}
+    for defn in defs:
+        for ref in defn.outputs:
+            if ref.collection in producers:
+                raise ChainError(
+                    f"output collection '{ref.collection}' is declared by more "
+                    f"than one product ('{producers[ref.collection]}' and "
+                    f"'{defn.key}')"
+                )
+            producers[ref.collection] = defn.key
 
     graph = _raw_dependencies(defs)
     # Three-colour DFS: WHITE=unseen, GREY=on the current path, BLACK=done.
@@ -142,6 +175,17 @@ def validate_chain(defs) -> None:
     for key in graph:
         if colour[key] == WHITE:
             visit(key)
+
+    if collection_keys is not None:
+        namespace = collection_namespace(defs, collection_keys)
+        for defn in defs:
+            for ref in defn.inputs:
+                if ref.collection not in namespace:
+                    raise ChainError(
+                        f"product '{defn.key}' input '{ref.role}' names "
+                        f"collection '{ref.collection}', which is neither a feed "
+                        f"collection nor a product output"
+                    )
 
 
 def topological_stages(defs) -> list:

--- a/georiva/src/georiva/core/test_product_chain.py
+++ b/georiva/src/georiva/core/test_product_chain.py
@@ -200,6 +200,55 @@ class ValidateChainTests(SimpleTestCase):
         with self.assertRaises(ChainCycleError):
             validate_chain([loop])
 
+    def test_two_products_declaring_the_same_output_key_are_rejected(self):
+        # An output collection may have exactly one producer — two products
+        # claiming the same output key is ambiguous provenance (ADR-0010 §1).
+        a = _product("a", outputs=(OutputRef(role="o", collection="shared-out"),))
+        b = _product("b", outputs=(OutputRef(role="o", collection="shared-out"),))
+        with self.assertRaises(ChainError) as ctx:
+            validate_chain([a, b])
+        self.assertIn("shared-out", str(ctx.exception))
+
+    def test_input_key_outside_the_feed_namespace_is_rejected(self):
+        # When collection_keys is supplied, every input must resolve to either a
+        # raw collection-definition key or a sibling product's output key
+        # (ADR-0010 §1). A key that is neither is a plugin bug.
+        product = _product(
+            "clim",
+            inputs=(InputRef(role="value", collection="ghost-raw", tier="staging"),),
+            outputs=(OutputRef(role="o", collection="clim-out"),),
+        )
+        with self.assertRaises(ChainError) as ctx:
+            validate_chain([product], collection_keys={"chirps-monthly"})
+        self.assertIn("ghost-raw", str(ctx.exception))
+
+    def test_raw_input_resolving_only_via_a_collection_key_validates(self):
+        # A staging input whose collection is a raw definition key (not any
+        # product's output — e.g. a feed with no promotion) resolves through the
+        # collection namespace and validates silently.
+        product = _product(
+            "clim",
+            inputs=(InputRef(role="value", collection="chirps-monthly", tier="staging"),),
+            outputs=(OutputRef(role="o", collection="chirps-monthly-climatology"),),
+        )
+        self.assertIsNone(
+            validate_chain([product], collection_keys={"chirps-monthly"})
+        )
+
+    def test_promotion_output_may_reuse_the_raw_collection_key(self):
+        # A promotion serves the raw collection 1:1, so its output key *equals*
+        # the raw collection-definition key by design (ADR-0010 §1, softened).
+        # This must validate even with the raw collection namespace supplied —
+        # the collision rule is output-vs-output only, never output-vs-raw-key.
+        promotion = _product(
+            "promotion",
+            inputs=(InputRef(role="source", collection="chirps-monthly", tier="staging"),),
+            outputs=(OutputRef(role="served", collection="chirps-monthly"),),
+        )
+        self.assertIsNone(
+            validate_chain([promotion], collection_keys={"chirps-monthly"})
+        )
+
 
 class TopologicalStagesTests(SimpleTestCase):
     def test_dependencies_land_in_an_earlier_stage_than_dependents(self):

--- a/georiva/src/georiva/sources/product_service.py
+++ b/georiva/src/georiva/sources/product_service.py
@@ -239,15 +239,44 @@ def delete_orphan(product):
     product.delete()
 
 
+def _resolve_inputs_or_raise(feed, definition, definitions):
+    """Every declared input of ``definition`` must resolve within the feed's
+    collection-key namespace — a raw ``CollectionDefinition`` key or a sibling
+    product's output key (ADR-0010 §2). Raises ``ProductActionError`` naming the
+    first key that doesn't, so a mis-declared product fails loudly at enable time
+    rather than sitting inert (this slice checks resolvability; the next pins the
+    resolved ``Collection`` as rows)."""
+    from georiva.core.product_chain import collection_namespace
+
+    collection_keys = {d.key for d in type(feed).get_collection_definitions()}
+    namespace = collection_namespace(definitions, collection_keys)
+    for ref in definition.inputs:
+        if ref.collection not in namespace:
+            raise ProductActionError(
+                _("%(product)s input '%(role)s' names collection "
+                  "'%(collection)s', which this feed neither provides nor "
+                  "produces.") % {
+                    "product": _label_of(definition.key, definitions),
+                    "role": ref.role,
+                    "collection": ref.collection,
+                }
+            )
+
+
 def enable_product(product):
     """
-    Enable ``product`` after checking every transitive dependency exists and is
-    enabled. Raises ``ProductActionError`` (naming the missing dependencies by
-    display label) otherwise. Atomic.
+    Enable ``product`` after checking (a) every declared input resolves within
+    the feed namespace and (b) every transitive dependency exists and is
+    enabled. Raises ``ProductActionError`` (naming the unresolved input key, or
+    the missing dependencies by display label) otherwise. Atomic — a gate
+    failure leaves the row unchanged.
     """
     from georiva.core.product_chain import dependencies_closure
 
     feed, definitions, rows = _chain(product)
+    definition = _definition_of(product.definition_key, definitions)
+    if definition is not None:
+        _resolve_inputs_or_raise(feed, definition, definitions)
     needed = dependencies_closure(definitions, product.definition_key)
     missing = [
         _label_of(key, definitions)
@@ -261,7 +290,6 @@ def enable_product(product):
                 "deps": ", ".join(missing),
             }
         )
-    definition = _definition_of(product.definition_key, definitions)
     with transaction.atomic():
         # Output collections materialise at enable-time, so they appear in the
         # catalog with declared titles before any run.

--- a/georiva/src/georiva/sources/setup_service.py
+++ b/georiva/src/georiva/sources/setup_service.py
@@ -171,7 +171,11 @@ class SourceSetupService:
     
     def _provision_collection(self, *, catalog, definition: CollectionDefinition, data_feed, config_values: dict):
         """Create/update Collection + Variables + Link for one CollectionDefinition."""
-        slug = slugify(f"{catalog.slug}-{definition.key}")
+        # Slug is the definition key alone — no catalog prefix (ADR-0010 §5) — so
+        # it matches the key the derived-product InputRef/OutputRef declarations
+        # reference and the output collections materialise under. The bucket path
+        # already carries the catalog segment, so the prefix was redundant.
+        slug = slugify(definition.key)
         
         # selected_variable_keys is a wizard-only field, not stored on the link
         config_for_link = dict(config_values)

--- a/georiva/src/georiva/sources/tests/test_product_service.py
+++ b/georiva/src/georiva/sources/tests/test_product_service.py
@@ -140,6 +140,29 @@ class EnableGateTests(ProductServiceBase):
         self.rows["promotion"].refresh_from_db()
         self.assertTrue(self.rows["promotion"].is_enabled)
 
+    def test_enable_is_refused_when_an_input_key_does_not_resolve(self):
+        # A product whose declared input names a collection the feed neither
+        # provides (no CollectionDefinition / link) nor produces (no sibling
+        # output) can't be pinned — enabling it fails loudly, naming the key,
+        # and leaves the row disabled (ADR-0010 §2).
+        broken = _product(
+            "broken",
+            inputs=(InputRef(role="value", collection="ghost-raw", tier="staging"),),
+            outputs=(OutputRef(role="o", collection="broken-out"),),
+        )
+        row = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="broken",
+            recipe_type="recipe", is_enabled=False,
+        )
+
+        with patch.object(DataFeed, "get_derived_products", return_value=[broken]):
+            with self.assertRaises(ProductActionError) as ctx:
+                enable_product(row)
+
+        self.assertIn("ghost-raw", str(ctx.exception))
+        row.refresh_from_db()
+        self.assertFalse(row.is_enabled)
+
     def test_enable_materialises_the_products_output_collections(self):
         # Enabling makes the output collection appear in the catalog immediately,
         # before any recipe run.

--- a/georiva/src/georiva/sources/tests/test_setup_service.py
+++ b/georiva/src/georiva/sources/tests/test_setup_service.py
@@ -6,7 +6,11 @@ from django.test import TestCase
 
 from georiva.core.models import Catalog, Collection
 from georiva.core.unit_utils import ureg
-from georiva.sources.collection_definitions import CollectionVariable
+from georiva.sources.collection_definitions import (
+    CollectionDefinition,
+    CollectionVariable,
+)
+from georiva.sources.models import DataFeed
 from georiva.sources.parameters import SourceKey
 from georiva.sources.setup_service import SourceSetupService
 
@@ -14,6 +18,35 @@ from georiva.sources.setup_service import SourceSetupService
 def _collection():
     catalog = Catalog.objects.create(name="Cat", slug="cat", file_format="grib2")
     return Collection.objects.create(name="Col", slug="col", catalog=catalog)
+
+
+class ProvisionCollectionSlugTests(TestCase):
+    """The provisioned raw collection's slug is derived from the definition key
+    alone — no catalog prefix (ADR-0010 §5), so the slug matches the key the
+    derived-product declarations reference."""
+
+    def test_slug_is_the_definition_key_without_a_catalog_prefix(self):
+        service = SourceSetupService()
+        catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        feed = DataFeed.objects.create(name="Rain Feed", catalog=catalog)
+        definition = CollectionDefinition(
+            key="chirps-monthly",
+            name="CHIRPS Monthly",
+            time_resolution="monthly",
+            variables=(CollectionVariable(
+                key="precip", name="Precipitation", source_units="mm",
+                source_variable=SourceKey(name="band_1"),
+            ),),
+        )
+
+        collection = service.provision_collection(
+            catalog=catalog, definition=definition, data_feed=feed,
+            config_values={},
+        )
+
+        self.assertEqual(collection.slug, "chirps-monthly")
 
 
 class UpsertVariableUnitsTests(TestCase):


### PR DESCRIPTION
Closes #183. First slice of ADR-0010 (*Pinned collection bindings for derived products*).

## What changed

Derived-product `InputRef`/`OutputRef` collections are now feed-local **keys**, and a mis-declared reference fails loudly instead of leaving the product chain silently inert.

- **`validate_chain`** — rejects two distinct products declaring the same output key; when `collection_keys` is supplied, rejects any input key outside `{raw collection keys} ∪ {product output keys}`. An output key equal to a raw collection key is **allowed** — a promotion serves the raw collection 1:1 and reuses its key by design.
- **`enable_product`** — resolves each declared input against the feed namespace and raises `ProductActionError` naming the key; atomic, no half-enabled row.
- **`SourceSetupService`** — provisioned raw collection slug is `slugify(definition.key)`, dropping the redundant catalog prefix so the slug matches the key the declarations reference (this is the root cause of failure class 1).
- **e2e regression** — provisions a CHIRPS feed through the *real* setup service (not hand-created collections) and asserts the raw collection routes to staging and dispatches an arriving staged input to the promotion. This path was previously masked by every test hand-creating the collection with the correct slug.

## Design decision (recorded in ADR §1)

The literal ADR wording ("output keys must not collide with definition keys") would have rejected the CHIRPS promotion, which deliberately reuses the raw key as its served output. Softened to **output-vs-output collisions only**; ADR-0010 §1 updated to match.

## Scope

This slice *checks* resolvability; **pinning** the resolved `Collection` as binding rows is slice 2 (#185). Enable-time resolution uses the declaration namespace (definition keys ∪ product outputs), not DB link lookups, so it doesn't require collections to be provisioned before a chain is enabled — preserving the existing "enable before data" behavior.

## Tests

Built TDD, one behavior at a time. All 338 tests across `core`, `sources`, `processing`, and the CHIRPS plugin pass.