### PR TITLE
feat(sources): route and dispatch derived products by binding-row FK (ADR-0010 slice 4)

### DIFF
--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -37,78 +37,97 @@ def definition_for(product):
     return None
 
 
-def _binding(definition) -> dict:
-    """The product's declared collections, flattened into selector keys (ADR-0008).
-
-    Injected into every selector so a recipe can read its source/baseline/output
-    collection slugs from the declaration instead of reconstructing them — the
-    only way a scheduled/manual product (which has no trigger to learn from) can
-    know which collections it operates on. The engine still treats the selector
-    as opaque; only recipes interpret these keys.
+def _binding(product) -> dict:
+    """The product's *pinned* collections, flattened into selector keys (ADR-0008/
+    0010 §4). Read from the ``DerivedProductInput`` / ``DerivedProductOutput``
+    binding rows — so every entry carries a resolved ``collection_id`` (an FK,
+    rename-safe) alongside the declared ``collection`` key and ``tier`` a recipe
+    reads. Injected into every selector so a recipe can read its source/baseline/
+    output collections without reconstructing slugs — the only way a scheduled/
+    manual product (no trigger to learn from) knows which collections it operates
+    on. The engine still treats the selector as opaque; only recipes interpret it.
     """
     return {
         "inputs": [
-            {"role": r.role, "collection": r.collection, "tier": r.tier}
-            for r in definition.inputs
+            {"role": b.role, "collection": b.source_key, "tier": b.tier,
+             "collection_id": b.collection_id}
+            for b in product.input_bindings.all()
         ],
         "outputs": [
-            {"role": r.role, "collection": r.collection}
-            for r in definition.outputs
+            {"role": b.role, "collection": b.output_key,
+             "collection_id": b.collection_id}
+            for b in product.output_bindings.all()
         ],
     }
 
 
-def _matches(definition, collection_slug: str, tier: str) -> bool:
-    """True if the definition declares an input on this collection at this tier."""
-    return any(
-        ref.collection == collection_slug and ref.tier == tier
-        for ref in definition.inputs
-    )
-
-
 def collection_routes_to_staging(data_feed, collection_slug: str) -> bool:
     """
-    Auto-derived target tier (ADR-0008): a collection routes to staging iff some
-    enabled DerivedProduct of this feed consumes it at the staging tier.
-    Otherwise it publishes directly (no StagingItems) — "no derivation, no
-    staging". Replaces the manual DataFeed.target_tier field, removing the
-    publish-vs-products drift.
+    Auto-derived target tier (ADR-0008; ADR-0010 §4): a collection routes to
+    staging iff some enabled DerivedProduct of this feed has a *pinned* staging
+    input on it. Otherwise it publishes directly (no StagingItems) — "no
+    derivation, no staging". Matched by the input binding's ``Collection`` FK
+    (resolved from this feed's catalog + slug), not by re-matching declarations,
+    so there are no ``get_derived_products()`` calls on this path.
     """
-    from georiva.sources.models import DerivedProduct
+    from georiva.core.models import Collection
+    from georiva.sources.models import DerivedProductInput
 
-    for product in DerivedProduct.objects.filter(data_feed=data_feed, is_enabled=True):
-        definition = definition_for(product)
-        if definition is not None and _matches(definition, collection_slug, "staging"):
-            return True
-    return False
+    if data_feed.catalog_id is None:
+        return False
+    collection = Collection.objects.filter(
+        catalog_id=data_feed.catalog_id, slug=collection_slug
+    ).first()
+    if collection is None:
+        return False
+    return DerivedProductInput.objects.filter(
+        product__data_feed=data_feed,
+        product__is_enabled=True,
+        tier="staging",
+        collection=collection,
+    ).exists()
 
 
 def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
     """
-    Route an arriving-input ``trigger`` to every enabled DerivedProduct that
-    consumes it. For each match, build
-    ``selector = {**config, **binding, **trigger}`` (binding = the definition's
-    declared inputs/outputs) and run the product's recipe, stamping the run with
-    the product origin.
+    Route an arriving-input ``trigger`` to every enabled DerivedProduct with a
+    *pinned* input on the trigger's collection at its tier (ADR-0010 §4). Matched
+    by ``collection_id`` + tier against ``DerivedProductInput`` rows in one
+    indexed query — feed/catalog scoping falls out of the FK, so an item in one
+    catalog can't trigger another catalog's products even with a shared slug, and
+    an unbound product (no rows) simply never matches. For each match, build
+    ``selector = {**config, **binding, **trigger}`` and run the product's recipe,
+    stamping the run with the product origin. No ``get_derived_products()`` here:
+    the recipe comes from the stored ``recipe_type`` and the binding from the
+    pinned rows.
     """
     from georiva.processing.engine import run
     from georiva.processing.registry import recipe_registry
 
-    from georiva.sources.models import DerivedProduct
+    from georiva.sources.models import DerivedProduct, DerivedProductInput
 
-    collection_slug = trigger.get("collection_slug")
+    collection_id = trigger.get("collection_id")
     tier = _trigger_tier(trigger)
+    if collection_id is None:
+        return []
+
+    product_ids = (
+        DerivedProductInput.objects.filter(
+            collection_id=collection_id, tier=tier, product__is_enabled=True
+        )
+        .values_list("product_id", flat=True)
+        .distinct()
+    )
 
     results = []
-    for product in DerivedProduct.objects.filter(is_enabled=True):
-        definition = definition_for(product)
-        if definition is None or not _matches(definition, collection_slug, tier):
-            continue
-        recipe = recipe_registry.get(definition.recipe_type)
+    for product in DerivedProduct.objects.filter(pk__in=list(product_ids)):
+        recipe = recipe_registry.get(product.recipe_type)
         if recipe is None:
-            logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
+            logger.error(
+                "Product %s names unknown recipe '%s'", product.pk, product.recipe_type
+            )
             continue
-        selector = {**(product.config or {}), **_binding(definition), **trigger}
+        selector = {**(product.config or {}), **_binding(product), **trigger}
         results.extend(
             run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
         )
@@ -118,11 +137,11 @@ def dispatch_for_input(trigger: dict, *, dispatch: bool = True) -> list:
 def run_product_now(product, *, dispatch: bool = True) -> list:
     """
     Manually trigger a product (ADR-0008) with a *wide* selector built from its
-    config plus its declared binding (inputs/outputs) and no event coordinate, so
-    the recipe enumerates all of the product's units — the same path as a
-    backfill. Reuses the engine's run() and
-    the product origin stamping. The caller (the tracking view) gates this on
-    product readiness; the engine's per-unit readiness still applies underneath.
+    config plus its pinned binding (inputs/outputs, with collection_id) and no
+    event coordinate, so the recipe enumerates all of the product's units — the
+    same path as a backfill. Reuses the engine's run() and the product origin
+    stamping. The caller (the tracking view) gates this on product readiness; the
+    engine's per-unit readiness still applies underneath.
     """
     from georiva.processing.engine import run
     from georiva.processing.registry import recipe_registry
@@ -133,14 +152,21 @@ def run_product_now(product, *, dispatch: bool = True) -> list:
     if not product.is_enabled:
         return []
 
-    definition = definition_for(product)
-    if definition is None:
+    # An orphan (definition the plugin no longer declares) is inert too. The
+    # event path excludes it structurally — an orphan has no matching binding row
+    # — but the manual/scheduled overlay isn't collection-triggered, so it guards
+    # explicitly here (this is not the event dispatch path ADR-0010 §4 keeps
+    # get_derived_products-free).
+    if definition_for(product) is None:
         return []
-    recipe = recipe_registry.get(definition.recipe_type)
+
+    recipe = recipe_registry.get(product.recipe_type)
     if recipe is None:
-        logger.error("Product %s names unknown recipe '%s'", product.pk, definition.recipe_type)
+        logger.error(
+            "Product %s names unknown recipe '%s'", product.pk, product.recipe_type
+        )
         return []
-    selector = {**(product.config or {}), **_binding(definition)}
+    selector = {**(product.config or {}), **_binding(product)}
     return run(recipe, selector, origin=product_origin(product), dispatch=dispatch)
 
 

--- a/georiva/src/georiva/sources/tests/test_auto_tier.py
+++ b/georiva/src/georiva/sources/tests/test_auto_tier.py
@@ -6,8 +6,6 @@ products, not a stored field: it routes to staging iff some enabled
 DerivedProduct consumes it at the staging tier; otherwise it publishes directly
 ("no derivation -> no staging"). This removes the target_tier-vs-products drift.
 """
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from georiva.core.derived_products import (
@@ -15,9 +13,13 @@ from georiva.core.derived_products import (
     InputRef,
     OutputRef,
 )
-from georiva.core.models import Catalog
+from georiva.core.models import Catalog, Collection
 from georiva.sources.derivation_invocation import collection_routes_to_staging
-from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.sources.models import (
+    DataFeed,
+    DerivedProduct,
+    DerivedProductInput,
+)
 
 
 def _definition(**overrides):
@@ -36,6 +38,9 @@ def _definition(**overrides):
 
 
 class CollectionRoutesToStagingTests(TestCase):
+    """Auto-derived tier is now driven by the pinned staging-input binding rows,
+    not by re-matching declarations (ADR-0010 §4)."""
+
     def setUp(self):
         self.catalog = Catalog.objects.create(
             name="CHIRPS", slug="chirps", file_format="geotiff"
@@ -43,40 +48,41 @@ class CollectionRoutesToStagingTests(TestCase):
         self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
 
     def _product(self, definition, **overrides):
-        return DerivedProduct.objects.create(
+        """Create the product and pin its input binding (a core Collection per
+        input key + a DerivedProductInput carrying the FK), the way the enable
+        path would."""
+        product = DerivedProduct.objects.create(
             data_feed=self.feed,
             definition_key=definition.key,
             recipe_type=definition.recipe_type,
             is_enabled=overrides.get("is_enabled", True),
         )
+        for ref in definition.inputs:
+            col, _ = Collection.objects.get_or_create(
+                catalog=self.catalog, slug=ref.collection,
+                defaults={"name": ref.collection},
+            )
+            DerivedProductInput.objects.create(
+                product=product, role=ref.role, tier=ref.tier,
+                required=ref.required, source_key=ref.collection, collection=col,
+            )
+        return product
 
     def test_collection_consumed_at_staging_routes_to_staging(self):
-        definition = _definition()
-        self._product(definition)
-
-        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
-            self.assertTrue(collection_routes_to_staging(self.feed, "rainfall"))
+        self._product(_definition())
+        self.assertTrue(collection_routes_to_staging(self.feed, "rainfall"))
 
     def test_collection_with_no_consuming_product_publishes(self):
-        definition = _definition()
-        self._product(definition)
-
-        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
-            # A different collection that no product consumes -> not staging.
-            self.assertFalse(collection_routes_to_staging(self.feed, "temperature"))
+        self._product(_definition())
+        # A different collection that no product consumes -> not staging.
+        self.assertFalse(collection_routes_to_staging(self.feed, "temperature"))
 
     def test_disabled_product_does_not_stage_its_collection(self):
-        definition = _definition()
-        self._product(definition, is_enabled=False)
-
-        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
-            self.assertFalse(collection_routes_to_staging(self.feed, "rainfall"))
+        self._product(_definition(), is_enabled=False)
+        self.assertFalse(collection_routes_to_staging(self.feed, "rainfall"))
 
     def test_a_published_tier_input_does_not_route_to_staging(self):
-        definition = _definition(inputs=(
+        self._product(_definition(inputs=(
             InputRef(role="value", collection="rainfall", tier="published"),
-        ))
-        self._product(definition)
-
-        with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
-            self.assertFalse(collection_routes_to_staging(self.feed, "rainfall"))
+        )))
+        self.assertFalse(collection_routes_to_staging(self.feed, "rainfall"))

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -52,8 +52,41 @@ def _definition(**overrides):
     return DerivedProductDefinition(**kwargs)
 
 
-def _staging_trigger(collection_slug="rainfall", staging_item_id=5):
-    return {"staging_item_id": staging_item_id, "collection_slug": collection_slug}
+def _staging_trigger(collection_slug="rainfall", staging_item_id=5, collection_id=None):
+    return {
+        "staging_item_id": staging_item_id,
+        "collection_id": collection_id,
+        "collection_slug": collection_slug,
+    }
+
+
+def _pin(product, definition, catalog):
+    """Pin binding rows for a product the way the enable path would (ADR-0010
+    §2): a core Collection per referenced key, plus DerivedProductInput /
+    DerivedProductOutput rows carrying the resolved collection FK. Dispatch now
+    matches these rows by collection_id, so a test product must be bound to be
+    dispatched."""
+    from georiva.sources.models import DerivedProductInput, DerivedProductOutput
+
+    def _col(slug):
+        col, _ = Collection.objects.get_or_create(
+            catalog=catalog, slug=slug, defaults={"name": slug}
+        )
+        return col
+
+    for ref in definition.inputs:
+        DerivedProductInput.objects.update_or_create(
+            product=product, role=ref.role,
+            defaults={
+                "tier": ref.tier, "required": ref.required,
+                "source_key": ref.collection, "collection": _col(ref.collection),
+            },
+        )
+    for ref in definition.outputs:
+        DerivedProductOutput.objects.update_or_create(
+            product=product, role=ref.role,
+            defaults={"output_key": ref.collection, "collection": _col(ref.collection)},
+        )
 
 
 class DispatchForInputTests(TestCase):
@@ -64,23 +97,31 @@ class DispatchForInputTests(TestCase):
         self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
 
     def _product(self, definition, **overrides):
-        return DerivedProduct.objects.create(
+        product = DerivedProduct.objects.create(
             data_feed=self.feed,
             definition_key=definition.key,
             recipe_type=definition.recipe_type,
             config=overrides.get("config", {}),
             is_enabled=overrides.get("is_enabled", True),
         )
+        _pin(product, definition, self.catalog)
+        return product
+
+    def _trigger(self, collection_slug="rainfall", staging_item_id=5):
+        col, _ = Collection.objects.get_or_create(
+            catalog=self.catalog, slug=collection_slug, defaults={"name": collection_slug}
+        )
+        return _staging_trigger(
+            collection_slug=collection_slug, staging_item_id=staging_item_id,
+            collection_id=col.pk,
+        )
 
     def test_matching_enabled_product_runs_with_selector_and_origin(self):
         definition = _definition()
         product = self._product(definition, config={"baseline": "1991-2020"})
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(), dispatch=False)
 
         run.assert_called_once()
         selector = run.call_args.args[1]
@@ -90,26 +131,25 @@ class DispatchForInputTests(TestCase):
         self.assertEqual(run.call_args.kwargs["origin"], f"derived_product:{product.pk}")
 
     def test_selector_carries_declared_inputs_and_outputs(self):
-        # The recipe must be able to read the product's declared collections
-        # from the selector (ADR-0008): a scheduled/manual recipe has no trigger
-        # to learn them from, so the invocation layer injects the declaration.
+        # The recipe reads the product's collections from the selector — now from
+        # the pinned binding rows, so each entry also carries a resolved
+        # collection_id (ADR-0010 §4) alongside the declared key + tier.
         definition = _definition()
         self._product(definition)
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(), dispatch=False)
 
+        rain = Collection.objects.get(catalog=self.catalog, slug="rainfall")
         selector = run.call_args.args[1]
         self.assertEqual(
             selector["inputs"],
-            [{"role": "source", "collection": "rainfall", "tier": "staging"}],
+            [{"role": "source", "collection": "rainfall", "tier": "staging",
+              "collection_id": rain.pk}],
         )
         self.assertEqual(
             selector["outputs"],
-            [{"role": "served", "collection": "rainfall"}],
+            [{"role": "served", "collection": "rainfall", "collection_id": rain.pk}],
         )
 
     def test_selector_binding_omits_output_display_metadata(self):
@@ -123,28 +163,25 @@ class DispatchForInputTests(TestCase):
         ))
         self._product(definition)
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(), dispatch=False)
 
+        rain = Collection.objects.get(catalog=self.catalog, slug="rainfall")
         self.assertEqual(
             run.call_args.args[1]["outputs"],
-            [{"role": "served", "collection": "rainfall"}],
+            [{"role": "served", "collection": "rainfall", "collection_id": rain.pk}],
         )
 
     def test_product_on_a_different_collection_is_not_dispatched(self):
+        # The product consumes 'temperature'; a 'rainfall' arrival (a distinct,
+        # existing collection) must not match its binding.
         definition = _definition(inputs=(
             InputRef(role="source", collection="temperature", tier="staging"),
         ))
         self._product(definition)
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(collection_slug="rainfall"), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(collection_slug="rainfall"), dispatch=False)
 
         run.assert_not_called()
 
@@ -152,11 +189,8 @@ class DispatchForInputTests(TestCase):
         definition = _definition()
         self._product(definition, is_enabled=False)
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(), dispatch=False)
 
         run.assert_not_called()
 
@@ -168,11 +202,8 @@ class DispatchForInputTests(TestCase):
         ))
         self._product(definition)
 
-        with (
-            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
-            patch("georiva.processing.engine.run") as run,
-        ):
-            dispatch_for_input(_staging_trigger(), dispatch=False)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(self._trigger(), dispatch=False)
 
         run.assert_not_called()
 
@@ -197,7 +228,8 @@ class EndToEndPromotionTests(TestCase):
             unit=self.unit_dim, value_min=0, value_max=2000,
         )
         self.scol = StagingCollection.objects.create(
-            catalog=self.catalog, slug="rainfall", name="Rainfall"
+            catalog=self.catalog, slug="rainfall", name="Rainfall",
+            collection=self.pub_col,
         )
         self.sitem = StagingItem.objects.create(
             collection=self.scol, datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
@@ -213,12 +245,16 @@ class EndToEndPromotionTests(TestCase):
             data_feed=self.feed, definition_key=self.definition.key,
             recipe_type="promotion", config={}, is_enabled=True,
         )
+        _pin(self.product, self.definition, self.catalog)
 
     def test_staging_arrival_promotes_and_stamps_product_origin(self):
-        trigger = {"staging_item_id": self.sitem.pk, "collection_slug": "rainfall"}
+        trigger = {
+            "staging_item_id": self.sitem.pk,
+            "collection_id": self.pub_col.pk,
+            "collection_slug": "rainfall",
+        }
 
         with (
-            patch.object(DataFeed, "get_derived_products", return_value=[self.definition]),
             patch("georiva.core.storage.storage") as st,
             patch("georiva.ingestion.asset_writer.AssetWriter", return_value=_mock_writer()),
         ):
@@ -300,30 +336,34 @@ class RunProductNowTests(TestCase):
             name="CHIRPS", slug="chirps", file_format="geotiff"
         )
         self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.definition = _definition()
         self.product = DerivedProduct.objects.create(
             data_feed=self.feed, definition_key="serve-raw",
             recipe_type="promotion", config={"baseline": "1991-2020"}, is_enabled=True,
         )
+        _pin(self.product, self.definition, self.catalog)
 
     def test_runs_recipe_with_config_selector_and_product_origin(self):
         with (
-            patch.object(DataFeed, "get_derived_products", return_value=[_definition()]),
+            patch.object(DataFeed, "get_derived_products", return_value=[self.definition]),
             patch("georiva.processing.engine.run") as run,
         ):
             run_product_now(self.product, dispatch=False)
 
         run.assert_called_once()
         selector = run.call_args.args[1]
-        # Wide selector = the product's config + declared binding (no event
-        # trigger) -> backfill that can still read its collections.
+        rain = Collection.objects.get(catalog=self.catalog, slug="rainfall")
+        # Wide selector = the product's config + pinned binding (no event
+        # trigger) -> backfill that can still read its collections, now by FK.
         self.assertEqual(selector["baseline"], "1991-2020")
         self.assertEqual(
             selector["inputs"],
-            [{"role": "source", "collection": "rainfall", "tier": "staging"}],
+            [{"role": "source", "collection": "rainfall", "tier": "staging",
+              "collection_id": rain.pk}],
         )
         self.assertEqual(
             selector["outputs"],
-            [{"role": "served", "collection": "rainfall"}],
+            [{"role": "served", "collection": "rainfall", "collection_id": rain.pk}],
         )
         self.assertEqual(run.call_args.kwargs["origin"], product_origin(self.product))
 
@@ -335,7 +375,7 @@ class RunProductNowTests(TestCase):
         self.product.save(update_fields=["is_enabled"])
 
         with (
-            patch.object(DataFeed, "get_derived_products", return_value=[_definition()]),
+            patch.object(DataFeed, "get_derived_products", return_value=[self.definition]),
             patch("georiva.processing.engine.run") as run,
         ):
             result = run_product_now(self.product, dispatch=False)
@@ -364,8 +404,14 @@ class OrphanExclusionTests(TestCase):
         return patch.object(DataFeed, "get_derived_products", return_value=[])
 
     def test_orphan_is_excluded_from_event_dispatch(self):
+        # A real, existing collection — the orphan is skipped because it has no
+        # binding row on it (unbound), not because the trigger is empty.
+        col = Collection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        trigger = _staging_trigger(collection_id=col.pk)
         with self._orphaned(), patch("georiva.processing.engine.run") as run:
-            result = dispatch_for_input(_staging_trigger(), dispatch=False)
+            result = dispatch_for_input(trigger, dispatch=False)
         run.assert_not_called()
         self.assertEqual(result, [])
 
@@ -385,3 +431,70 @@ class OrphanExclusionTests(TestCase):
         # Its (absent) declaration can't opt any collection into staging.
         with self._orphaned():
             self.assertFalse(collection_routes_to_staging(self.feed, "rainfall"))
+
+
+class CrossCatalogIsolationTests(TestCase):
+    """Two feeds of the same shape in different catalogs share a collection slug;
+    an arriving item in one catalog must trigger only its own feed's product,
+    because dispatch matches the collection FK, not the slug (ADR-0010 §4 AC2)."""
+
+    def _feed_with_product(self, catalog_slug):
+        catalog = Catalog.objects.create(
+            name=catalog_slug, slug=catalog_slug, file_format="geotiff"
+        )
+        feed = DataFeed.objects.create(name=f"Feed {catalog_slug}", catalog=catalog)
+        definition = _definition()
+        product = DerivedProduct.objects.create(
+            data_feed=feed, definition_key=definition.key,
+            recipe_type=definition.recipe_type, is_enabled=True,
+        )
+        _pin(product, definition, catalog)
+        rainfall = Collection.objects.get(catalog=catalog, slug="rainfall")
+        return product, rainfall
+
+    def test_arrival_in_one_catalog_triggers_only_its_own_product(self):
+        product_a, rainfall_a = self._feed_with_product("cat-a")
+        product_b, rainfall_b = self._feed_with_product("cat-b")
+
+        # An arrival for catalog A's rainfall collection (same slug as B's).
+        trigger = _staging_trigger(collection_id=rainfall_a.pk)
+        with patch("georiva.processing.engine.run") as run:
+            dispatch_for_input(trigger, dispatch=False)
+
+        run.assert_called_once()
+        self.assertEqual(
+            run.call_args.kwargs["origin"], product_origin(product_a)
+        )
+
+
+class UnboundProductSkippedTests(TestCase):
+    """An enabled, still-declared product with no binding rows (e.g. its input
+    collection was deleted) is inert on the event path — it simply never matches
+    (ADR-0010 §4 AC4)."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.rainfall = Collection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+
+    def test_enabled_product_without_bindings_is_not_dispatched(self):
+        definition = _definition()
+        # Enabled + declared, but never pinned -> no DerivedProductInput rows.
+        DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key=definition.key,
+            recipe_type=definition.recipe_type, is_enabled=True,
+        )
+
+        trigger = _staging_trigger(collection_id=self.rainfall.pk)
+        with (
+            patch.object(DataFeed, "get_derived_products", return_value=[definition]),
+            patch("georiva.processing.engine.run") as run,
+        ):
+            result = dispatch_for_input(trigger, dispatch=False)
+
+        run.assert_not_called()
+        self.assertEqual(result, [])

--- a/georiva/src/georiva/sources/tests/test_staging_routing.py
+++ b/georiva/src/georiva/sources/tests/test_staging_routing.py
@@ -20,7 +20,7 @@ from georiva.core.derived_products import (
 from georiva.core.models import Catalog, Collection
 from georiva.core.storage import BucketType
 from georiva.sources.loader import Loader
-from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.sources.models import DataFeed, DerivedProduct, DerivedProductInput
 
 
 def _staging_definition(collection_slug="tas"):
@@ -50,9 +50,15 @@ class TargetTierRoutingTests(TestCase):
         return Loader(data_source=ds, collection=self.collection, data_feed=feed)
 
     def _enable_staging_product(self):
-        DerivedProduct.objects.create(
+        # Routing is driven by the pinned staging-input binding (ADR-0010 §4),
+        # so create the product and pin its input to the 'tas' collection.
+        product = DerivedProduct.objects.create(
             data_feed=self.feed, definition_key="anomaly",
             recipe_type="climatology", is_enabled=True,
+        )
+        DerivedProductInput.objects.create(
+            product=product, role="value", tier="staging", source_key="tas",
+            collection=self.collection,
         )
 
     def test_collection_consumed_at_staging_routes_to_staging_bucket(self):


### PR DESCRIPTION
Closes #186. Fourth slice of ADR-0010 (*Pinned collection bindings for derived products*). Builds on #185 and #184.

## What changed

The feed-layer runtime joints now match **indexed FK queries over the pinned binding rows** instead of slug string-matching.

- **`collection_routes_to_staging`** — an existence query on `DerivedProductInput` (the feed's enabled products, staging tier, the resolved `Collection`). No `get_derived_products()`.
- **`dispatch_for_input`** — matches the trigger's `collection_id` + tier against `DerivedProductInput` in one indexed query, replacing the scan of every enabled `DerivedProduct` (which called `get_derived_products()` per row). The recipe comes from the stored `recipe_type`, the binding from the rows — **no `get_derived_products()` on the dispatch path**.
- **`_binding`** is built from the binding rows, so every input/output selector entry carries a resolved `collection_id` alongside the declared key + tier.
- **`run_product_now`** uses `recipe_type` + the pinned binding; keeps an explicit orphan guard (its manual/scheduled path isn't collection-triggered, so it can't rely on binding-row absence).

## Why it's correct

- **Cross-catalog isolation (AC2)** falls out of the FK: two feeds of the same shape in different catalogs share a collection slug, but an arrival in one catalog matches only its own catalog's `Collection` pk — proven by a new test.
- **Unbound = inert (AC4)**: a product with no binding rows never matches — new test.

## Tests

Existing invocation / auto-tier / staging-routing / CHIRPS routing tests updated to provision bindings and carry `collection_id` (the AC5 work), plus new cross-catalog-isolation and unbound-skip tests. All **629 tests** across sources, processing, ingestion, staging, core, and CHIRPS pass.

## Note

Recipes still read the declared `collection` **slug/key** from the binding for their own DB queries; migrating them to consume `collection_id` is slice 5 (#188), which this unblocks. Slice 6 (#187) is also unblocked.