### PR TITLE
feat: resolve derived-product inputs by collection identity (ADR-0010 slice 5)

### DIFF
--- a/georiva/src/georiva/processing/recipe.py
+++ b/georiva/src/georiva/processing/recipe.py
@@ -61,35 +61,67 @@ class ResolvedInput:
 
 def resolve_declared_inputs(inputs, *, unit=None) -> "dict[str, ResolvedInput]":
     """
-    Resolve a product's declared ``InputRef``s into ``ResolvedInput``s by
-    querying the catalog — the StagingItem tier for ``tier="staging"`` inputs,
-    the Published Item tier for ``tier="published"`` — filtered by collection
-    slug (ADR-0008).
+    Resolve a product's declared inputs into ``ResolvedInput``s by querying the
+    catalog — the StagingItem tier for ``tier="staging"`` inputs, the Published
+    Item tier for ``tier="published"``.
 
-    This is the engine-side glue that lets a recipe consume *declared* inputs
-    instead of hardcoding slugs in ``resolve_inputs``: the dependency graph and
-    product readiness become computable from the declaration. An input whose
-    collection has no rows resolves to an absent (``present=False``)
-    ``ResolvedInput`` keyed by its role, which is how readiness reports a blocked
-    product. ``unit`` is accepted for forward compatibility (per-unit time
-    narrowing arrives with product-driven invocation) and is unused here.
+    Each input is resolved by its **collection identity** when it carries a
+    ``collection_id`` (the pinned binding rows do — ADR-0010 §5): the staging
+    tier through the ``StagingCollection -> core Collection`` link
+    (``collection__collection_id``), the published tier directly
+    (``collection_id``). This scopes resolution to one catalog's collection, so
+    two catalogs sharing a slug never cross-contaminate, and an operator slug
+    rename can't misroute it. An input without a ``collection_id`` (a bare
+    ``InputRef`` from the generic declaration contract) falls back to a slug
+    match.
+
+    An input whose collection has no rows resolves to an absent
+    (``present=False``) ``ResolvedInput`` keyed by its role, which is how product
+    readiness reports a blocked product. ``unit`` is accepted for forward
+    compatibility and is unused here.
     """
     from georiva.core.models import Item
     from georiva.staging.models import StagingItem
 
     resolved: dict[str, ResolvedInput] = {}
     for ref in inputs:
-        model = StagingItem if ref.tier == "staging" else Item
-        items = list(
-            model.objects
-            .filter(collection__slug=ref.collection)
-            .prefetch_related("assets")
-        )
+        staging = ref.tier == "staging"
+        model = StagingItem if staging else Item
+        collection_id = getattr(ref, "collection_id", None)
+        if collection_id is not None:
+            # Resolve by identity (FK), not slug. Staging items reach the core
+            # Collection through their StagingCollection's link.
+            field = "collection__collection_id" if staging else "collection_id"
+            qs = model.objects.filter(**{field: collection_id})
+        else:
+            qs = model.objects.filter(collection__slug=ref.collection)
+        items = list(qs.prefetch_related("assets"))
         assets = [a for it in items for a in it.assets.all()]
         resolved[ref.role] = ResolvedInput(
             ref.role, required=ref.required, items=items, assets=assets
         )
     return resolved
+
+
+def binding_input_collection_id(selector, tier):
+    """The pinned ``collection_id`` of the first selector-binding input at
+    ``tier`` (ADR-0010 §5), or ``None``. Recipes query the catalog by this FK
+    instead of the declared slug, so resolution is catalog-scoped and rename-safe.
+    """
+    for ref in (selector or {}).get("inputs", []):
+        if ref.get("tier") == tier:
+            return ref.get("collection_id")
+    return None
+
+
+def binding_output_collection_id(selector, role):
+    """The pinned ``collection_id`` of the selector-binding output with ``role``
+    (ADR-0010 §5), or ``None`` — the materialised output collection a recipe
+    writes into, resolved by FK rather than by rebuilding its slug."""
+    for ref in (selector or {}).get("outputs", []):
+        if ref.get("role") == role:
+            return ref.get("collection_id")
+    return None
 
 
 @dataclass

--- a/georiva/src/georiva/processing/recipes/promotion.py
+++ b/georiva/src/georiva/processing/recipes/promotion.py
@@ -32,13 +32,19 @@ class PromotionRecipe(BaseRecipe):
     # ---- declarative surface ------------------------------------------------
 
     def enumerate_units(self, selector) -> Iterable[ProductionUnit]:
+        from georiva.processing.recipe import binding_input_collection_id
         from georiva.staging.models import StagingItem
 
         selector = selector or {}
         qs = StagingItem.objects.all()
         if selector.get("staging_item_ids"):
             qs = qs.filter(pk__in=selector["staging_item_ids"])
-        if selector.get("collection_slug"):
+        # Prefer the pinned collection FK (catalog-scoped, rename-safe); fall
+        # back to a slug filter for the CLI/backfill convenience path.
+        collection_id = binding_input_collection_id(selector, "staging")
+        if collection_id is not None:
+            qs = qs.filter(collection__collection_id=collection_id)
+        elif selector.get("collection_slug"):
             qs = qs.filter(collection__slug=selector["collection_slug"])
         for sid in qs.values_list("pk", flat=True):
             yield {"staging_item_id": sid}
@@ -126,9 +132,16 @@ class PromotionRecipe(BaseRecipe):
 
     @staticmethod
     def _published_collection(staging_item):
+        """The served core Collection this staging item promotes into. Resolved
+        by the StagingCollection -> core Collection FK (ADR-0010 §3/§5) when
+        linked, so an operator slug rename never misroutes it or spawns a
+        duplicate; falls back to a catalog+slug get-or-create for a staging
+        collection registered before the link existed."""
         from georiva.core.models import Collection
 
         sc = staging_item.collection
+        if sc.collection_id is not None:
+            return sc.collection
         collection, _ = Collection.objects.get_or_create(
             catalog=sc.catalog,
             slug=sc.slug,

--- a/georiva/src/georiva/processing/tests/test_derived_inputs.py
+++ b/georiva/src/georiva/processing/tests/test_derived_inputs.py
@@ -110,6 +110,63 @@ class ResolveDeclaredInputsTests(TestCase):
         self.assertIn("value", resolved)
         self.assertFalse(resolved["value"].present)
 
+    def test_input_carrying_a_collection_id_resolves_by_identity_not_slug(self):
+        # A binding-shaped input (with a resolved collection_id) resolves the
+        # staging tier through the StagingCollection -> core Collection link,
+        # scoped to that exact collection — not every catalog sharing the slug
+        # (ADR-0010 §5). A second catalog with the same slug must not leak in.
+        from collections import namedtuple
+
+        Spec = namedtuple("Spec", "role collection tier required collection_id")
+
+        self.staging_col.collection = self.pub_col  # link staging -> a core col
+        self.staging_col.save(update_fields=["collection"])
+        mine = self._add_staging()
+
+        # A different catalog, same 'rainfall' slug, with its own staged item.
+        other_cat = Catalog.objects.create(
+            name="Other", slug="other", file_format="geotiff"
+        )
+        other_core = Collection.objects.create(
+            catalog=other_cat, slug="rainfall", name="Rainfall"
+        )
+        other_staging = StagingCollection.objects.create(
+            catalog=other_cat, slug="rainfall", name="Rainfall", collection=other_core
+        )
+        StagingItem.objects.create(
+            collection=other_staging, datetime=_TIME,
+            bounds=[0, 0, 8, 8], crs="EPSG:4326", width=4, height=4,
+        )
+
+        resolved = resolve_declared_inputs([
+            Spec(role="value", collection="rainfall", tier="staging",
+                 required=True, collection_id=self.pub_col.pk),
+        ])
+
+        self.assertEqual([it.pk for it in resolved["value"].items], [mine.pk])
+
+    def test_published_input_with_collection_id_resolves_by_identity(self):
+        from collections import namedtuple
+
+        Spec = namedtuple("Spec", "role collection tier required collection_id")
+        item = self._add_published()
+
+        # Another catalog's collection with the same slug and its own item.
+        other_cat = Catalog.objects.create(
+            name="Other", slug="other", file_format="geotiff"
+        )
+        other = Collection.objects.create(
+            catalog=other_cat, slug="rainfall-normals", name="Normals"
+        )
+        Item.objects.create(collection=other, time=_TIME)
+
+        resolved = resolve_declared_inputs([
+            Spec(role="normals", collection="rainfall-normals", tier="published",
+                 required=True, collection_id=self.pub_col.pk),
+        ])
+
+        self.assertEqual([it.pk for it in resolved["normals"].items], [item.pk])
+
     def test_recipe_declaring_inputs_resolves_them_without_an_override(self):
         # A declaration-driven recipe sets declared_inputs and inherits the
         # default resolve_inputs — no hardcoded slugs in a bespoke override.

--- a/georiva/src/georiva/processing/tests/test_engine.py
+++ b/georiva/src/georiva/processing/tests/test_engine.py
@@ -152,6 +152,24 @@ class PromotionThroughEngineTests(_PromotionFixture):
         _, kwargs = task.delay.call_args
         self.assertEqual(kwargs["recipe_type"], "promotion")
 
+    def test_promotion_targets_the_linked_core_collection_after_a_slug_rename(self):
+        # The staging collection is linked to its core Collection (ADR-0010 §3).
+        # Promotion resolves the output by that FK, so renaming the core
+        # collection's slug afterwards doesn't spawn a second collection (§5 AC4).
+        self.scol.collection = self.pub_col
+        self.scol.save(update_fields=["collection"])
+        self.pub_col.slug = "tas-renamed-by-operator"
+        self.pub_col.save(update_fields=["slug"])
+
+        result = self._run_promotion()
+
+        item = Item.objects.get(pk=result.item_id)
+        self.assertEqual(item.collection, self.pub_col)
+        # No stray collection created from the old slug.
+        self.assertEqual(
+            Collection.objects.filter(catalog=self.catalog).count(), 1
+        )
+
 
 class DerivationLinkConstraintTests(_PromotionFixture):
     def _item(self):

--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -26,9 +26,11 @@ class ProductReadiness:
 
 def product_readiness(product) -> ProductReadiness:
     """
-    A product is ready iff every *required* declared input collection exists and
-    is non-empty — derived from the declaration, no recipe execution. Optional
-    inputs never block. When blocked, names the first empty required input.
+    A product is ready iff every *required* declared input is pinned to a
+    collection that exists and is non-empty — resolved from the product's binding
+    rows by collection identity (ADR-0010 §5), no recipe execution. A required
+    input with no binding row (unbound) blocks, as does one whose collection has
+    no items. Optional inputs never block. When blocked, names the first offender.
     """
     from georiva.processing.recipe import resolve_declared_inputs
 
@@ -36,9 +38,12 @@ def product_readiness(product) -> ProductReadiness:
     if definition is None:
         return ProductReadiness(ready=False, reason="no product definition")
 
-    resolved = resolve_declared_inputs(definition.inputs)
+    bindings = {b.role: b for b in product.input_bindings.all()}
+    resolved = resolve_declared_inputs(list(bindings.values()))
     for ref in definition.inputs:
-        if ref.required and not resolved[ref.role].present:
+        if not ref.required:
+            continue
+        if ref.role not in bindings or not resolved[ref.role].present:
             return ProductReadiness(
                 ready=False, blocked_by=ref.role, reason=f"{ref.role} empty",
             )

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -17,11 +17,11 @@ from georiva.core.derived_products import (
     InputRef,
     OutputRef,
 )
-from georiva.core.models import Catalog
+from georiva.core.models import Catalog, Collection
 from georiva.processing.models import DerivationRun
 from georiva.sources.derivation_invocation import product_origin
 from georiva.sources.derivation_tracking import product_status
-from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.sources.models import DataFeed, DerivedProduct, DerivedProductInput
 from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
 
 User = get_user_model()
@@ -157,8 +157,14 @@ class TrackingViewTests(TestCase):
         self.assertTrue(DerivedProduct.objects.filter(pk=self.product.pk).exists())
 
     def _add_rainfall_staging(self):
-        scol = StagingCollection.objects.create(
+        # Readiness now resolves through the product's binding rows by collection
+        # identity (ADR-0010 §5), so link the staging collection to its core
+        # Collection and pin the product's 'value' input to it.
+        core = Collection.objects.create(
             catalog=self.catalog, slug="rainfall", name="Rainfall"
+        )
+        scol = StagingCollection.objects.create(
+            catalog=self.catalog, slug="rainfall", name="Rainfall", collection=core
         )
         si = StagingItem.objects.create(
             collection=scol, datetime=datetime(2020, 1, 1, tzinfo=timezone.utc),
@@ -167,6 +173,13 @@ class TrackingViewTests(TestCase):
         StagingAsset.objects.create(
             item=si, href="chirps/rainfall/f.tif", roles=["source"],
             format="geotiff", checksum="r1",
+        )
+        DerivedProductInput.objects.update_or_create(
+            product=self.product, role="value",
+            defaults={
+                "tier": "staging", "required": True, "source_key": "rainfall",
+                "collection": core,
+            },
         )
 
     def test_blocked_product_shows_its_blocking_reason(self):

--- a/georiva/src/georiva/sources/tests/test_product_readiness.py
+++ b/georiva/src/georiva/sources/tests/test_product_readiness.py
@@ -18,7 +18,11 @@ from georiva.core.derived_products import (
 )
 from georiva.core.models import Catalog, Collection, Item, Unit, Variable
 from georiva.sources.derivation_tracking import product_readiness
-from georiva.sources.models import DataFeed, DerivedProduct
+from georiva.sources.models import (
+    DataFeed,
+    DerivedProduct,
+    DerivedProductInput,
+)
 from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
 
 _TIME = datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -49,9 +53,16 @@ class ProductReadinessTests(TestCase):
             data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
         )
 
+    def _core(self, slug):
+        col, _ = Collection.objects.get_or_create(
+            catalog=self.catalog, slug=slug, defaults={"name": slug}
+        )
+        return col
+
     def _add_staging(self, slug="rainfall"):
+        """A staged item in a staging collection linked to its core Collection."""
         scol = StagingCollection.objects.create(
-            catalog=self.catalog, slug=slug, name=slug
+            catalog=self.catalog, slug=slug, name=slug, collection=self._core(slug)
         )
         si = StagingItem.objects.create(
             collection=scol, datetime=_TIME,
@@ -63,7 +74,20 @@ class ProductReadinessTests(TestCase):
         )
         return si
 
+    def _pin(self, definition):
+        """Pin the product's input bindings to core Collections, as the enable
+        path would — readiness now resolves through these rows."""
+        for ref in definition.inputs:
+            DerivedProductInput.objects.update_or_create(
+                product=self.product, role=ref.role,
+                defaults={
+                    "tier": ref.tier, "required": ref.required,
+                    "source_key": ref.collection, "collection": self._core(ref.collection),
+                },
+            )
+
     def _readiness(self, definition):
+        self._pin(definition)
         with patch.object(DataFeed, "get_derived_products", return_value=[definition]):
             return product_readiness(self.product)
 
@@ -98,3 +122,38 @@ class ProductReadinessTests(TestCase):
         verdict = self._readiness(definition)
 
         self.assertTrue(verdict.ready)
+
+    def test_readiness_is_scoped_to_the_bound_collection_not_the_slug(self):
+        # Another catalog has the same 'rainfall' slug WITH data; this product's
+        # own catalog has none. Readiness must resolve through the pinned
+        # collection_id, so it stays blocked (ADR-0010 §5) — no cross-catalog leak.
+        other_cat = Catalog.objects.create(
+            name="Other", slug="other", file_format="geotiff"
+        )
+        other_core = Collection.objects.create(
+            catalog=other_cat, slug="rainfall", name="Rainfall"
+        )
+        other_staging = StagingCollection.objects.create(
+            catalog=other_cat, slug="rainfall", name="Rainfall", collection=other_core
+        )
+        StagingItem.objects.create(
+            collection=other_staging, datetime=_TIME,
+            bounds=[0, 0, 1, 1], crs="EPSG:4326", width=4, height=4,
+        )
+        # This product's own 'rainfall' core Collection exists but has no items.
+        self._core("rainfall")
+
+        verdict = self._readiness(_definition())
+
+        self.assertFalse(verdict.ready)
+        self.assertEqual(verdict.blocked_by, "value")
+
+    def test_unbound_required_input_blocks(self):
+        # An enabled product whose required input was never pinned (no binding
+        # row) is blocked — there is no collection to resolve.
+        self._add_staging("rainfall")
+        with patch.object(DataFeed, "get_derived_products", return_value=[_definition()]):
+            verdict = product_readiness(self.product)   # note: no _pin()
+
+        self.assertFalse(verdict.ready)
+        self.assertEqual(verdict.blocked_by, "value")


### PR DESCRIPTION
Closes #188. Final runtime slice of ADR-0010 (*Pinned collection bindings for derived products*). Builds on #186. **Companion plugin PR: wmo-raf/georiva-source-chirps#13** (CHIRPS recipes).

## What changed

The engine-side resolution glue and the recipes now resolve collections by the **pinned `collection_id`** the binding carries, not by slug.

- **`resolve_declared_inputs`** resolves by `collection_id` when the input carries one (binding rows do): staging via the `StagingCollection → core` link (`collection__collection_id`), published by `collection_id`. Two catalogs sharing a slug resolve only their own items. A bare `InputRef` (generic declaration contract) still falls back to slug.
- **`product_readiness`** resolves through the product's `DerivedProductInput` rows, so a required input that is unbound, or points at an empty bound collection, blocks — scoped by identity.
- **promotion** — `_published_collection` targets the `StagingCollection → core` FK (rename-safe, no duplicate collection); `enumerate_units` prefers the binding `collection_id`. Added shared `binding_input_collection_id` / `binding_output_collection_id` helpers in `recipe.py`.
- **CHIRPS recipes** (climatology, anomaly) are migrated in the companion plugin PR (georiva-source-chirps#13).

## ACs

- Cross-catalog isolation + rename-safety proven by new tests (`resolve_declared_inputs`, `product_readiness`, promotion rename, CHIRPS id-path).
- **636 tests** pass across core, processing, sources, staging, ingestion, and CHIRPS.

## Deliberate scoping note

The remaining `collection__slug` filters are **fallbacks** behind `if collection_id is not None` guards — hit only by legacy/CLI selectors that carry no binding (e.g. `run_recipe --collection`). The production dispatch/readiness path always carries the id, so it is fully identity-based and catalog-scoped. Fully deleting the slug fallbacks would require reworking the CLI selector contract and is left out of this slice.