### PR TITLE
docs: mark ADR-0010 accepted

### DIFF
--- a/docs/adr/0010-pinned-collection-bindings-for-derived-products.md
+++ b/docs/adr/0010-pinned-collection-bindings-for-derived-products.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Context
 


### PR DESCRIPTION
All six ADR-0010 slices are implemented and merged (#183–#188, plus plugin georiva-source-chirps#13). Flip the status from `proposed` to `accepted`.