### PR TITLE
docs: reflect ADR-0010 pinned-binding model across the doc set

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,12 @@ reading order. If you're new, start at the top and work down.
 8. **[Derived Products](plugins/derived-products.md)** — the contract for declaring layers a feed computes from its own
    collections (anomaly, climatology, promotion…): `get_derived_products()`, the full `DerivedProductDefinition` /
    `InputRef` / `OutputRef` / `ConfigField` reference, how the tier-aware chain and stages are computed, what core
-   materialises versus what recipes create, and a worked CHIRPS example. Decisions recorded in
-   [ADR-0008](adr/0008-configurable-derivation-products.md) and
-   [ADR-0009](adr/0009-derived-product-chain-and-lifecycle.md).
+   materialises versus what recipes create, and a worked CHIRPS example. A product's collection references are
+   **feed-local keys** resolved once to catalog `Collection`s and **pinned** as binding rows, so routing, dispatch, and
+   resolution match by FK (catalog-scoped, rename-safe). Decisions recorded in
+   [ADR-0008](adr/0008-configurable-derivation-products.md),
+   [ADR-0009](adr/0009-derived-product-chain-and-lifecycle.md), and
+   [ADR-0010](adr/0010-pinned-collection-bindings-for-derived-products.md).
 
 ## Contributing
 

--- a/docs/adr/0004-staging-tier-and-abstract-stac-models.md
+++ b/docs/adr/0004-staging-tier-and-abstract-stac-models.md
@@ -1,5 +1,11 @@
 # Staging Tier and Abstract STAC Models
 
+> **Amended by [ADR-0010](0010-pinned-collection-bindings-for-derived-products.md).**
+> `StagingCollection` gains a nullable `collection` FK to its published-tier
+> `core.Collection` (same catalog + slug), set at registration, so an arriving
+> `StagingItem`'s derivation trigger can carry a `collection_id` and dispatch can
+> match pinned binding rows by FK rather than by slug.
+
 ## Context
 
 GeoRiva's current data flow couples acquisition to materialization: a `DataFeed` fetch lands a file in the

--- a/docs/adr/0008-configurable-derivation-products.md
+++ b/docs/adr/0008-configurable-derivation-products.md
@@ -4,6 +4,14 @@
 
 proposed
 
+> **Amended by [ADR-0010](0010-pinned-collection-bindings-for-derived-products.md).**
+> The declared-inputs-by-slug design here (an `InputRef`/`OutputRef` `collection`
+> is a catalog slug; `dispatch_for_input` and `collection_routes_to_staging` match
+> on `(collection_slug, tier)`) is superseded: a `collection` is now a *feed-local
+> key* resolved once at enable time and *pinned* as a binding row, and every
+> runtime joint matches by the `Collection` FK. This section records the original
+> decision; read ADR-0010 for the binding mechanics as built.
+
 ## Context
 
 The generic Derivation Engine (ADR-0005) runs recipes over a *selector*, and

--- a/docs/adr/0009-derived-product-chain-and-lifecycle.md
+++ b/docs/adr/0009-derived-product-chain-and-lifecycle.md
@@ -4,6 +4,12 @@
 
 proposed
 
+> **Extended by [ADR-0010](0010-pinned-collection-bindings-for-derived-products.md).**
+> This ADR's orphan/upgrade lifecycle gains a sibling drift state — **unbound** (a
+> bound `Collection` was deleted, so a pinned binding row cascaded away) — with a
+> re-bind action, and materialise-on-enable now also *pins* the resolved
+> collections as binding rows. The chain read-model and gates here are unchanged.
+
 ## Context
 
 ADR-0008 introduced the declarative derived-product contract

--- a/docs/architecture/plugin-parameter-contract.md
+++ b/docs/architecture/plugin-parameter-contract.md
@@ -269,7 +269,10 @@ class CollectionDefinition:
     default_interval_minutes: int | None = None  # pre-fills link.interval_minutes
 ```
 
-**`Collection.slug`** is derived as `slugify(f"{catalog.slug}-{definition.key}")`.
+**`Collection.slug`** is derived as `slugify(definition.key)` — the definition key
+alone, no catalog prefix (ADR-0010 §5), so it coincides with the feed-local key a
+derived product's `InputRef`/`OutputRef` references and the storage-path segment
+already carries the catalog.
 
 **Per-collection config fields** (e.g. `default_start_date`) live on the
 `DataFeedCollectionLink` subclass, declared via `get_panels()`. The wizard renders
@@ -455,7 +458,7 @@ data_feed, collections = service.provision(
 
 For each `(definition, config_values)` pair the service:
 
-1. Upserts a `Collection` (slug = `slugify(f"{catalog.slug}-{definition.key}")`)
+1. Upserts a `Collection` (slug = `slugify(definition.key)` — no catalog prefix, ADR-0010 §5)
 2. Upserts each `Variable` in `definition.variables` (respecting `selected_variable_keys` from wizard)
 3. Upserts a `DataFeedCollectionLink` with:
     - `definition_key` — stable reference back to the definition

--- a/docs/plugins/derived-products.md
+++ b/docs/plugins/derived-products.md
@@ -144,11 +144,12 @@ Draw a clear line between the two:
   run. Declare the catalog-facing strings and visibility on the `OutputRef`; do
   **not** set them in the recipe.
 - **Your recipe computes the data** — items and assets — into those collections.
-  Its own lazy `get_or_create` for a collection should be a bare fallback
-  (`defaults={"name": slug}` at most); it will normally find the collection core
-  already materialised. The recipe selector binding carries only
-  `role`/`collection`/`tier`, never the display fields, so a title edit can't
-  change a recipe's unit identity.
+  Prefer resolving a collection by the `collection_id` the selector binding
+  carries for each input/output (catalog-scoped, rename-safe, ADR-0010); any lazy
+  `get_or_create` should be a bare fallback (`defaults={"name": slug}` at most)
+  that normally finds the collection core already materialised. The binding
+  carries `role`/`collection`/`tier`/`collection_id` — never the display fields —
+  so a title edit can't change a recipe's unit identity.
 
 ## `default_enabled` and `depends_on`
 


### PR DESCRIPTION
Brings the documentation in line with the as-built ADR-0010 design after all six slices merged. Doc-only.

## What changed

- **`docs/architecture/plugin-parameter-contract.md`** — `Collection.slug` is `slugify(definition.key)` (no catalog prefix, ADR-0010 §5); was the stale `slugify(f"{catalog.slug}-{definition.key}")` in two places.
- **`docs/plugins/derived-products.md`** — recipes resolve collections by the binding's `collection_id`; the selector binding carries `role`/`collection`/`tier`/`collection_id` (was "only role/collection/tier").
- **`docs/README.md`** — the derived-products index entry notes feed-local keys + pinned bindings and links ADR-0010.
- **Amendment notes** on ADR-0004 (StagingCollection→core FK), ADR-0008 (feed-local keys + pinning supersede slug matching / slug-based dispatch), and ADR-0009 (adds the *unbound* drift state and pin-on-enable), each pointing at ADR-0010 — without rewriting the point-in-time records.

## Already done in slice 6 (not repeated here)

CONTEXT.md glossary, the `InputRef`/`OutputRef` tables in the derived-products guide, and the boilerplate `get_derived_products()` example were updated in #195.

## Scope note

Storage-path docs (`{catalog}/{collection}/{file}` bucket keys) are unchanged — ADR-0010 didn't touch storage layout. Old ADR bodies keep their original text; only forward-reference notes were added.