### PR TITLE
feat(processing): promotion emits COG + visual PNG (fixes empty datasets page)

### DIFF
--- a/georiva/src/georiva/processing/engine.py
+++ b/georiva/src/georiva/processing/engine.py
@@ -85,9 +85,16 @@ def _register_asset(item, oa, writer):
     path = _asset_output_path(item, oa.variable, oa.format)
 
     if oa.array is not None:
-        href = writer.write_cog(
-            oa.array, path, tuple(oa.bounds) if oa.bounds else None, oa.crs,
-        )
+        if oa.format == "png":
+            # Encode the data array to RGBA and write a PNG (the visual asset),
+            # mirroring ingestion's COG+PNG output for served items.
+            from georiva.ingestion.encoder import VariableEncoder
+            rgba = VariableEncoder().encode_to_rgba(oa.array, oa.variable)
+            href = writer.write_png(rgba, path)
+        else:
+            href = writer.write_cog(
+                oa.array, path, tuple(oa.bounds) if oa.bounds else None, oa.crs,
+            )
     elif oa.passthrough is not None:
         src_bucket_type, src_href = oa.passthrough
         data = storage.bucket(src_bucket_type).read_bytes(src_href)

--- a/georiva/src/georiva/processing/recipe.py
+++ b/georiva/src/georiva/processing/recipe.py
@@ -143,9 +143,12 @@ class OutputAsset:
     One asset the engine should write + register under the output Item.
 
     Exactly one production mode:
-      - ``array`` set        → engine writes a COG via AssetWriter.write_cog
-      - ``passthrough`` set  → engine copies an existing object (bucket, href)
-                               into the assets bucket as-is (e.g. Promotion)
+      - ``array`` + ``format="cog"`` (default) → engine writes a COG via
+                               AssetWriter.write_cog
+      - ``array`` + ``format="png"``           → engine encodes the array to RGBA
+                               (VariableEncoder) and writes a visual PNG
+      - ``passthrough`` set    → engine copies an existing object (bucket, href)
+                               into the assets bucket as-is
     """
     variable: Any                         # core.Variable
     roles: list = field(default_factory=lambda: ["data"])

--- a/georiva/src/georiva/processing/recipes/promotion.py
+++ b/georiva/src/georiva/processing/recipes/promotion.py
@@ -24,10 +24,28 @@ from georiva.processing.recipe import (
 from georiva.processing.registry import RecipeRegistry
 
 
+def _array_stats(data) -> dict:
+    """min/max/mean/std over the finite pixels of a raster band."""
+    import numpy as np
+
+    finite = data[np.isfinite(data)]
+    if finite.size == 0:
+        return {}
+    return {
+        "min": float(np.min(finite)),
+        "max": float(np.max(finite)),
+        "mean": float(np.mean(finite)),
+        "std": float(np.std(finite)),
+    }
+
+
 @RecipeRegistry.register
 class PromotionRecipe(BaseRecipe):
     type = "promotion"
-    version = "1"
+    # v2: promotion now materialises a COG + a visual PNG (was a raw-GeoTIFF
+    # passthrough), so the served item is tile-servable and shows in the catalog.
+    # Bumping the version re-derives already-promoted items on the next sweep.
+    version = "2"
 
     # ---- declarative surface ------------------------------------------------
 
@@ -115,18 +133,45 @@ class PromotionRecipe(BaseRecipe):
                     f"Promotion: no Variable for staging asset {asset.pk}; "
                     f"set one on the asset or on collection '{collection.slug}'"
                 )
+            data, bounds, crs, width, height = self.read_raster(
+                BucketType.STAGING, asset.href
+            )
+            stats = _array_stats(data)
+            # A served COG (data) + a visual PNG (encoded by the engine), the
+            # same pair ingestion writes — so promotion output is tile-servable
+            # and shows in the public catalog (which is COG-gated).
             out.append(OutputAsset(
-                variable=variable,
-                roles=["data"],
-                format=asset.format or "geotiff",
-                passthrough=(BucketType.STAGING, asset.href),
-                bounds=si.bounds,
-                crs=si.crs,
-                width=si.width,
-                height=si.height,
-                checksum=asset.checksum,
+                variable=variable, roles=["data"], format="cog", array=data,
+                bounds=bounds, crs=crs, width=width, height=height,
+                stats=stats, checksum=asset.checksum,
+            ))
+            out.append(OutputAsset(
+                variable=variable, roles=["visual"], format="png", array=data,
+                bounds=bounds, crs=crs, width=width, height=height,
             ))
         return out
+
+    # ---- I/O seam (mocked in tests) -----------------------------------------
+
+    def read_raster(self, bucket_type, href):
+        """Read a stored single-band raster into
+        ``(data, bounds, crs, width, height)`` — the recipe's only real I/O,
+        patched in unit tests. Nodata is mapped to NaN so the COG stats and the
+        PNG alpha both skip it."""
+        import numpy as np
+        import rasterio
+        from rasterio.io import MemoryFile
+
+        from georiva.core.storage import storage
+
+        raw = storage.bucket(bucket_type).read_bytes(href)
+        with MemoryFile(raw) as memfile, memfile.open() as src:
+            data = src.read(1).astype("float32")
+            if src.nodata is not None:
+                data = np.where(data == src.nodata, np.nan, data)
+            bounds = list(src.bounds)
+            crs = src.crs.to_string() if src.crs else "EPSG:4326"
+            return data, bounds, crs, src.width, src.height
 
     # ---- helpers ------------------------------------------------------------
 

--- a/georiva/src/georiva/processing/tests/test_engine.py
+++ b/georiva/src/georiva/processing/tests/test_engine.py
@@ -31,6 +31,7 @@ def _mock_writer():
     w = MagicMock()
     w.bucket.save.side_effect = lambda path, data: path
     w.write_cog.side_effect = lambda arr, path, *a, **k: path
+    w.write_png.side_effect = lambda rgba, path, *a, **k: path
     return w
 
 
@@ -64,14 +65,21 @@ class _PromotionFixture(TestCase):
         return {"staging_item_id": self.sitem.pk}
 
     def _run_promotion(self):
+        import numpy as np
+
         recipe = PromotionRecipe()
-        with patch("georiva.core.storage.storage") as st:
-            st.bucket.return_value.read_bytes.return_value = b"GEOTIFFBYTES"
+        data = np.full((10, 10), 5.0, dtype="float32")
+        with patch.object(
+            PromotionRecipe, "read_raster",
+            return_value=(data, [0, 0, 1, 1], "EPSG:4326", 10, 10),
+        ):
             return run_unit(recipe, self._unit(), writer=_mock_writer())
 
 
 class PromotionThroughEngineTests(_PromotionFixture):
-    def test_promotion_produces_item_asset_and_link(self):
+    def test_promotion_produces_cog_and_png_assets_and_link(self):
+        from georiva.core.models import Asset
+
         result = self._run_promotion()
 
         self.assertEqual(result.status, "completed")
@@ -79,15 +87,18 @@ class PromotionThroughEngineTests(_PromotionFixture):
         self.assertEqual(item.collection, self.pub_col)
         self.assertEqual(item.time, datetime(2020, 1, 1, tzinfo=timezone.utc))
 
-        asset = item.assets.get()
-        self.assertEqual(asset.variable, self.variable)
-        self.assertIn("data", asset.roles)
+        # A served COG (data role) + a visual PNG — the pair the catalog needs.
+        cog = item.assets.get(format=Asset.Format.COG)
+        self.assertEqual(cog.variable, self.variable)
+        self.assertEqual(cog.roles, ["data"])
+        png = item.assets.get(format=Asset.Format.PNG)
+        self.assertEqual(png.roles, ["visual"])
 
         link = DerivationLink.objects.get(derived_item=item)
         self.assertEqual(link.source_staging_item, self.sitem)
         self.assertIsNone(link.source_published_item)
         self.assertEqual(link.recipe_id, "promotion")
-        self.assertEqual(link.recipe_version, "1")
+        self.assertEqual(link.recipe_version, "2")
         self.assertEqual(link.input_hash, result.input_hash)
 
     def test_derivation_run_records_lifecycle(self):
@@ -241,3 +252,39 @@ class EngineIsRecipeAgnosticTests(_PromotionFixture):
             DerivationRun.objects.get(recipe_type="fake").status,
             DerivationRun.Status.COMPLETED,
         )
+
+
+class RegisterPngAssetTests(_PromotionFixture):
+    """The engine writes a PNG (encoded RGBA) for an array OutputAsset declared
+    with format='png', alongside the COG path for format='cog' (ADR: derived
+    products emit COG + PNG like ingestion)."""
+
+    def test_png_output_asset_is_encoded_and_written_as_png(self):
+        import numpy as np
+
+        from georiva.core.models import Asset
+        from georiva.processing.engine import _register_asset
+        from georiva.processing.recipe import OutputAsset
+
+        writer = _mock_writer()
+        item = Item.objects.create(
+            collection=self.pub_col,
+            time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+        data = np.full((3, 2), 12.0, dtype="float32")
+
+        asset = _register_asset(
+            item,
+            OutputAsset(variable=self.variable, roles=["visual"], format="png",
+                        array=data, bounds=[0, 0, 1, 1], crs="EPSG:4326",
+                        width=2, height=3),
+            writer,
+        )
+
+        writer.write_png.assert_called_once()
+        # The encoder turned the 2D data into an (H, W, 4) RGBA array.
+        rgba = writer.write_png.call_args.args[0]
+        self.assertEqual(rgba.shape, (3, 2, 4))
+        self.assertEqual(asset.format, Asset.Format.PNG)
+        self.assertEqual(asset.roles, ["visual"])
+        writer.write_cog.assert_not_called()

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -34,6 +34,7 @@ def _mock_writer():
     w = MagicMock()
     w.bucket.save.side_effect = lambda path, data: path
     w.write_cog.side_effect = lambda arr, path, *a, **k: path
+    w.write_png.side_effect = lambda rgba, path, *a, **k: path
     return w
 
 
@@ -254,15 +255,26 @@ class EndToEndPromotionTests(TestCase):
             "collection_slug": "rainfall",
         }
 
+        import numpy as np
+
+        from georiva.processing.recipes.promotion import PromotionRecipe
+
+        data = np.full((10, 10), 5.0, dtype="float32")
         with (
-            patch("georiva.core.storage.storage") as st,
+            patch("georiva.core.storage.storage"),
             patch("georiva.ingestion.asset_writer.AssetWriter", return_value=_mock_writer()),
+            patch.object(
+                PromotionRecipe, "read_raster",
+                return_value=(data, [0, 0, 1, 1], "EPSG:4326", 10, 10),
+            ),
         ):
-            st.bucket.return_value.read_bytes.return_value = b"GEOTIFFBYTES"
             dispatch_for_input(trigger, dispatch=False)
 
         item = Item.objects.get(collection=self.pub_col)
         self.assertEqual(item.time, datetime(2020, 1, 1, tzinfo=timezone.utc))
+        # Promotion now emits a served COG + a visual PNG.
+        self.assertTrue(item.assets.filter(format="cog").exists())
+        self.assertTrue(item.assets.filter(format="png").exists())
 
         run_rec = DerivationRun.objects.get(recipe_type="promotion")
         self.assertEqual(run_rec.status, DerivationRun.Status.COMPLETED)


### PR DESCRIPTION
## Problem

`/datasets/<catalog>/<collection>/` was empty for a collection served via **promotion** (e.g. `chirps-monthly`), even though the items existed. The datasets page (and Titiler tiling) is **COG-gated** — it only lists items that have a `format=cog` asset — but the promotion recipe was a **1:1 passthrough** that copied the raw GeoTIFF through unchanged (`format=geotiff`). So a promoted collection had items with only a plain-GeoTIFF asset → no COG coverage → blank page.

## Fix

Promotion now materialises the **same asset pair as the ingestion pipeline** — a served **COG** (`data` role) plus an encoded **PNG** (`visual` role):

- **`engine._register_asset`** — an array `OutputAsset` with `format="png"` is encoded to RGBA via `VariableEncoder` and written with `AssetWriter.write_png`; `format="cog"` still writes a COG. Passthrough mode is untouched.
- **`PromotionRecipe.transform`** — reads the staged single-band raster (new `read_raster` I/O seam) and emits a COG + a PNG `OutputAsset` per source asset, with stats.
- **`version` bumped 1 → 2** so already-promoted items are re-derived (stale) on the next sweep/backfill.

## Tests

TDD: engine PNG-asset path, promotion produces both COG + PNG, end-to-end promotion through dispatch. **571 tests pass** across processing / sources / ingestion / CHIRPS.

## Operational follow-up (not automatic)

Existing promoted items still carry their old `geotiff` asset; they need a **re-run of the promotion** to gain COG+PNG. Promotion is `trigger_mode="event"`, so it has no "Run now" button — regenerate via a backfill (`run_product_now` on the promotion product, or re-staging the raw files). The stale `geotiff` asset row lingers harmlessly alongside the new COG/PNG.

## Scope note

`read_raster` reads **band 1** — correct for the platform's per-variable single-band COG model (and for CHIRPS). Multi-band 1:1 passthrough is not preserved by the COG path; out of scope here.