### PR TITLE
fix(processing): derived assets use the shared ingestion path scheme

### DIFF
--- a/georiva/src/georiva/processing/engine.py
+++ b/georiva/src/georiva/processing/engine.py
@@ -32,11 +32,28 @@ class UnitResult:
 
 
 def _asset_output_path(item, variable, fmt: str) -> str:
+    """The stored path for a derived asset — the *same* scheme ingestion writes
+    (``ingestion.handlers.asset_handler``): a time-partitioned directory from the
+    shared ``storage.build_asset_path`` plus a ``{variable}_{HHMMSS}`` filename
+    (the date lives in the path), suffixed ``__ref{reftime}`` for a forecast item.
+    Reusing the shared builder keeps derived and ingested assets resolvable by the
+    same href-agnostic consumers (map layers, Titiler), instead of the divergent
+    ``{variable}_{YYYYMMDDTHHMMSS}`` this used to emit."""
+    from georiva.core.storage import storage
+
     ext = {"cog": "tif", "geotiff": "tif", "png": "png"}.get(fmt, "tif")
     t = item.time
-    return (
-        f"{item.collection.catalog.slug}/{item.collection.slug}/{variable.slug}/"
-        f"{t:%Y/%m/%d}/{variable.slug}_{t:%Y%m%dT%H%M%S}.{ext}"
+    if item.reference_time:
+        ref_str = item.reference_time.strftime("%Y%m%dT%H%M%S")
+        name = f"{variable.slug}_{t:%H%M%S}__ref{ref_str}.{ext}"
+    else:
+        name = f"{variable.slug}_{t:%H%M%S}.{ext}"
+    return storage.build_asset_path(
+        catalog=item.collection.catalog.slug,
+        collection=item.collection.slug,
+        variable=variable.slug,
+        timestamp=t,
+        filename=name,
     )
 
 

--- a/georiva/src/georiva/processing/recipes/promotion.py
+++ b/georiva/src/georiva/processing/recipes/promotion.py
@@ -42,10 +42,13 @@ def _array_stats(data) -> dict:
 @RecipeRegistry.register
 class PromotionRecipe(BaseRecipe):
     type = "promotion"
-    # v2: promotion now materialises a COG + a visual PNG (was a raw-GeoTIFF
-    # passthrough), so the served item is tile-servable and shows in the catalog.
+    # v2: promotion materialises a COG + a visual PNG (was a raw-GeoTIFF
+    #     passthrough), so the served item is tile-servable and shows in the catalog.
+    # v3: those assets now use the shared ingestion path scheme
+    #     ({variable}_{HHMMSS}) instead of the divergent {variable}_{YYYYMMDDTHHMMSS},
+    #     so href-agnostic consumers resolve them.
     # Bumping the version re-derives already-promoted items on the next sweep.
-    version = "2"
+    version = "3"
 
     # ---- declarative surface ------------------------------------------------
 

--- a/georiva/src/georiva/processing/tests/test_engine.py
+++ b/georiva/src/georiva/processing/tests/test_engine.py
@@ -98,7 +98,7 @@ class PromotionThroughEngineTests(_PromotionFixture):
         self.assertEqual(link.source_staging_item, self.sitem)
         self.assertIsNone(link.source_published_item)
         self.assertEqual(link.recipe_id, "promotion")
-        self.assertEqual(link.recipe_version, "2")
+        self.assertEqual(link.recipe_version, "3")
         self.assertEqual(link.input_hash, result.input_hash)
 
     def test_derivation_run_records_lifecycle(self):
@@ -288,3 +288,43 @@ class RegisterPngAssetTests(_PromotionFixture):
         self.assertEqual(asset.format, Asset.Format.PNG)
         self.assertEqual(asset.roles, ["visual"])
         writer.write_cog.assert_not_called()
+
+
+class AssetOutputPathTests(_PromotionFixture):
+    """Derived assets use the SAME path scheme as ingestion (ADR follow-up):
+    {cat}/{coll}/{var}/{Y}/{MM}/{DD}/{var}_{HHMMSS}[__ref{...}].{ext} — the date
+    lives in the path, the filename carries only the time (plus a forecast ref).
+    Previously the engine wrote {var}_{YYYYMMDDTHHMMSS}, which no href-agnostic
+    consumer (built for the ingestion scheme) could resolve."""
+
+    def test_non_forecast_asset_path_matches_the_ingestion_scheme(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Item
+        from georiva.processing.engine import _asset_output_path
+
+        item = Item.objects.create(
+            collection=self.pub_col,
+            time=datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        path = _asset_output_path(item, self.variable, "cog")
+        self.assertEqual(path, "cmip6/tas/tas/2026/05/01/tas_000000.tif")
+
+        png = _asset_output_path(item, self.variable, "png")
+        self.assertEqual(png, "cmip6/tas/tas/2026/05/01/tas_000000.png")
+
+    def test_forecast_asset_path_carries_the_reference_time(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Item
+        from georiva.processing.engine import _asset_output_path
+
+        item = Item.objects.create(
+            collection=self.pub_col,
+            time=datetime(2026, 5, 1, 6, 0, 0, tzinfo=timezone.utc),
+            reference_time=datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        path = _asset_output_path(item, self.variable, "cog")
+        self.assertEqual(
+            path, "cmip6/tas/tas/2026/05/01/tas_060000__ref20260501T000000.tif"
+        )

--- a/georiva/src/georiva/sources/tests/test_derivation_invocation.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_invocation.py
@@ -261,7 +261,6 @@ class EndToEndPromotionTests(TestCase):
 
         data = np.full((10, 10), 5.0, dtype="float32")
         with (
-            patch("georiva.core.storage.storage"),
             patch("georiva.ingestion.asset_writer.AssetWriter", return_value=_mock_writer()),
             patch.object(
                 PromotionRecipe, "read_raster",
@@ -272,9 +271,12 @@ class EndToEndPromotionTests(TestCase):
 
         item = Item.objects.get(collection=self.pub_col)
         self.assertEqual(item.time, datetime(2020, 1, 1, tzinfo=timezone.utc))
-        # Promotion now emits a served COG + a visual PNG.
-        self.assertTrue(item.assets.filter(format="cog").exists())
-        self.assertTrue(item.assets.filter(format="png").exists())
+        # Promotion emits a served COG + a visual PNG under the shared ingestion
+        # path scheme ({variable}_{HHMMSS}).
+        cog = item.assets.get(format="cog")
+        self.assertTrue(cog.href.endswith("/precip_000000.tif"), cog.href)
+        png = item.assets.get(format="png")
+        self.assertTrue(png.href.endswith("/precip_000000.png"), png.href)
 
         run_rec = DerivationRun.objects.get(recipe_type="promotion")
         self.assertEqual(run_rec.status, DerivationRun.Status.COMPLETED)

--- a/titiler-app/app/dependencies.py
+++ b/titiler-app/app/dependencies.py
@@ -28,7 +28,10 @@ redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
 # Django fallback
 # ---------------------------------------------------------------------------
 
-def _fetch_config_from_django(catalog: str, collection: str, variable: str) -> Optional[dict]:
+
+def _fetch_config_from_django(
+    catalog: str, collection: str, variable: str
+) -> Optional[dict]:
     """Fetch rendering config from Django internal API on Redis miss."""
     url = f"{DJANGO_BASE_URL}/api/tile-config/{catalog}/{collection}/{variable}/"
     try:
@@ -37,12 +40,18 @@ def _fetch_config_from_django(catalog: str, collection: str, variable: str) -> O
             return resp.json()
         logger.warning(
             "Django tile-config returned %d for %s/%s/%s",
-            resp.status_code, catalog, collection, variable,
+            resp.status_code,
+            catalog,
+            collection,
+            variable,
         )
     except Exception as e:
         logger.warning(
             "Django tile-config fallback failed for %s/%s/%s: %s",
-            catalog, collection, variable, e,
+            catalog,
+            collection,
+            variable,
+            e,
         )
     return None
 
@@ -51,12 +60,13 @@ def _fetch_config_from_django(catalog: str, collection: str, variable: str) -> O
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def build_cog_url(
-        catalog: str,
-        collection: str,
-        variable: str,
-        time_dt: datetime,
-        reftime_dt: Optional[datetime],
+    catalog: str,
+    collection: str,
+    variable: str,
+    time_dt: datetime,
+    reftime_dt: Optional[datetime],
 ) -> str:
     """
     Construct the MinIO COG URL from path components.
@@ -66,20 +76,24 @@ def build_cog_url(
       {catalog}/{collection}/{variable}/{YYYY}/{MM}/{DD}/{variable}_{HHMMSS}__ref{YYYYMMDDTHHmmss}.tif
     """
     date_path = time_dt.strftime("%Y/%m/%d")
-    time_str = time_dt.strftime("%H%M%S")
-    
+    time_str = time_dt.strftime("%Y%m%dT%H%M%S")
+
     if reftime_dt is not None:
         ref_str = reftime_dt.strftime("%Y%m%dT%H%M%S")
         filename = f"{variable}_{time_str}__ref{ref_str}.tif"
     else:
         filename = f"{variable}_{time_str}.tif"
-    
+
     dataset_path = f"{catalog}/{collection}/{variable}/{date_path}/{filename}"
-    
+
     if not PATH_RE.match(dataset_path):
-        raise HTTPException(status_code=400, detail=f"Invalid constructed path: {dataset_path}")
-    
-    return f"{MINIO_HOST}/{MINIO_BUCKET_NAME}/{dataset_path}"
+        raise HTTPException(
+            status_code=400, detail=f"Invalid constructed path: {dataset_path}"
+        )
+
+    url = f"{MINIO_HOST}/{MINIO_BUCKET_NAME}/{dataset_path}"
+
+    return url
 
 
 def parse_iso_datetime(value: str, param_name: str) -> datetime:
@@ -98,10 +112,11 @@ def parse_iso_datetime(value: str, param_name: str) -> datetime:
 # FastAPI dependencies
 # ---------------------------------------------------------------------------
 
+
 def SemanticTileConfig(
-        catalog_slug: Annotated[str, Path(...)],
-        collection_slug: Annotated[str, Path(...)],
-        variable_slug: Annotated[str, Path(...)],
+    catalog_slug: Annotated[str, Path(...)],
+    collection_slug: Annotated[str, Path(...)],
+    variable_slug: Annotated[str, Path(...)],
 ) -> dict:
     """Resolve rendering config for a variable.
 
@@ -109,17 +124,31 @@ def SemanticTileConfig(
     FastAPI caches this result per request so colormap and rescale
     dependencies share a single Redis call.
     """
-    raw = redis_client.get(f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}")
+    raw = redis_client.get(
+        f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}"
+    )
     if raw:
-        logger.debug("Redis cache hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
+        logger.debug(
+            "Redis cache hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug
+        )
         return json.loads(raw)
-    
+
     config = _fetch_config_from_django(catalog_slug, collection_slug, variable_slug)
     if config is not None:
-        logger.debug("Django fallback hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
+        logger.debug(
+            "Django fallback hit: %s/%s/%s",
+            catalog_slug,
+            collection_slug,
+            variable_slug,
+        )
         return config
-    
-    logger.warning("Tile config unavailable: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
+
+    logger.warning(
+        "Tile config unavailable: %s/%s/%s",
+        catalog_slug,
+        collection_slug,
+        variable_slug,
+    )
     raise HTTPException(
         status_code=503,
         detail="Tile config unavailable — Redis cold and Django fallback failed",
@@ -127,22 +156,28 @@ def SemanticTileConfig(
 
 
 def SemanticPathParams(
-        catalog_slug: Annotated[str, Path(...)],
-        collection_slug: Annotated[str, Path(...)],
-        variable_slug: Annotated[str, Path(...)],
-        time: str = Query(..., description="Valid time in ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)"),
-        reftime: Optional[str] = Query(None, description="Forecast reference time in ISO 8601 UTC"),
+    catalog_slug: Annotated[str, Path(...)],
+    collection_slug: Annotated[str, Path(...)],
+    variable_slug: Annotated[str, Path(...)],
+    time: str = Query(
+        ..., description="Valid time in ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)"
+    ),
+    reftime: Optional[str] = Query(
+        None, description="Forecast reference time in ISO 8601 UTC"
+    ),
 ) -> str:
     """Resolve the COG URL from semantic path params and time query params."""
     time_dt = parse_iso_datetime(time, "time")
     reftime_dt = parse_iso_datetime(reftime, "reftime") if reftime else None
-    url = build_cog_url(catalog_slug, collection_slug, variable_slug, time_dt, reftime_dt)
+    url = build_cog_url(
+        catalog_slug, collection_slug, variable_slug, time_dt, reftime_dt
+    )
     logger.debug("Resolved COG URL: %s", url)
     return url
 
 
 def SemanticColorMap(
-        tile_config: dict = Depends(SemanticTileConfig),
+    tile_config: dict = Depends(SemanticTileConfig),
 ) -> Optional[ColorMapType]:
     """Return the 256-entry colormap from Redis config, or grayscale fallback."""
     raw = tile_config.get("colormap")
@@ -153,17 +188,17 @@ def SemanticColorMap(
 
 class RescaleAlgorithm(BaseAlgorithm):
     """Rescale raw float COG data to 0-255 before colormap lookup."""
-    
+
     vmin: float
     vmax: float
-    
+
     def __call__(self, img: ImageData) -> ImageData:
         img.rescale(in_range=[(self.vmin, self.vmax)], out_range=[(0, 255)])
         return img
 
 
 def SemanticRescale(
-        tile_config: dict = Depends(SemanticTileConfig),
+    tile_config: dict = Depends(SemanticTileConfig),
 ) -> Optional[BaseAlgorithm]:
     """Return a rescale algorithm using vmin/vmax from the tile config."""
     return RescaleAlgorithm(vmin=tile_config["vmin"], vmax=tile_config["vmax"])


### PR DESCRIPTION
## Problem

The derivation engine's `_asset_output_path` reimplemented its own path with a **divergent filename** — `{variable}_{YYYYMMDDTHHMMSS}` — and no reference-time handling, while ingestion writes `{variable}_{HHMMSS}[__ref{...}]` via the shared `storage.build_asset_path`. So every derived-product asset (promotion COG/PNG, climatology, anomaly) landed at a different filename than ingestion. Href-agnostic consumers that reconstruct the ingestion filename (map/weather layers, Titiler) requested `precip_000000.png` and 404'd on the stored `precip_20260501T000000.png`.

## Fix

- `_asset_output_path` reuses `storage.build_asset_path` for the time-partitioned directory and ingestion's exact filename convention (`{variable}_{HHMMSS}`, `__ref{reftime}` for forecasts). Derived and ingested assets are now path-identical.
- Promotion `version` 2 → 3 so already-promoted items re-materialise under the corrected path on the next backfill.

## Tests

TDD: non-forecast + forecast path scheme, promotion e2e asserts the shared scheme. **573 tests pass** across processing / sources / ingestion / CHIRPS.

## Follow-up

Re-run the promotion backfill so all 542 `chirps-monthly` items land at `precip_000000.{tif,png}`. Orphaned `precip_YYYYMMDDTHHMMSS.*` objects from the interrupted first backfill can be swept from MinIO separately.