### PR TITLE
feat(core): cleanup_asset_orphans management command

### DIFF
--- a/georiva/src/georiva/core/asset_cleanup.py
+++ b/georiva/src/georiva/core/asset_cleanup.py
@@ -1,0 +1,45 @@
+"""
+Orphaned-asset-object selection — the pure core of the ``cleanup_asset_orphans``
+management command.
+
+An **orphan** is a raster/visual object in the assets bucket that no live
+``Asset.href`` references. These accumulate when a re-derivation rewrites an
+asset's ``href`` in place (e.g. a filename-scheme change) while the old object
+lingers in the bucket, or when items/assets are deleted without a storage sweep.
+
+Only object types that correspond to an ``Asset`` (COG/GeoTIFF, PNG, WebP, JPEG)
+are ever selected — a non-asset sidecar such as the ``.json`` metadata ingestion
+writes alongside each asset is deliberately left alone, so a sweep can never
+remove a legitimate file that simply isn't modelled as an ``Asset`` row.
+
+Kept dependency-free so it is unit-testable without a live bucket; the command
+supplies the object listing and the live-href set.
+"""
+from __future__ import annotations
+
+import os
+
+# Extensions of objects that ARE registered as Assets (mirrors the format→ext
+# mapping the engine/ingestion writers use). Anything else in the bucket — most
+# notably the ``.json`` metadata sidecar — is never a deletion candidate.
+DELETABLE_EXTENSIONS = (".tif", ".tiff", ".png", ".webp", ".jpeg", ".jpg")
+
+
+def select_orphan_objects(object_paths, live_hrefs, deletable_extensions):
+    """Return the object paths that are safe to delete: those whose extension is
+    a known asset type **and** which no live ``href`` references.
+
+    ``object_paths`` — the keys currently in the (scoped) bucket.
+    ``live_hrefs`` — the set of ``Asset.href`` values still in the database.
+    ``deletable_extensions`` — lowercase extensions eligible for deletion.
+    """
+    live = set(live_hrefs)
+    exts = tuple(e.lower() for e in deletable_extensions)
+    orphans = []
+    for path in object_paths:
+        if path in live:
+            continue
+        if os.path.splitext(path)[1].lower() not in exts:
+            continue
+        orphans.append(path)
+    return orphans

--- a/georiva/src/georiva/core/management/commands/cleanup_asset_orphans.py
+++ b/georiva/src/georiva/core/management/commands/cleanup_asset_orphans.py
@@ -1,0 +1,118 @@
+"""
+Delete orphaned raster/visual objects from the assets bucket — files no live
+``Asset.href`` references (see ``core.asset_cleanup``). The usual cause is a
+re-derivation that rewrote an asset's href in place (e.g. a filename-scheme
+change) and left the old object behind.
+
+Safe by default:
+  * previews only — pass ``--apply`` to actually delete;
+  * a scope is required — ``--catalog`` (optionally with ``--collection``) or the
+    explicit ``--all``, so an accidental bare run can't sweep the whole bucket;
+  * only known asset object types are ever removed — ``.json`` metadata sidecars
+    and any other non-asset files are left untouched.
+
+Examples::
+
+    georiva cleanup_asset_orphans --catalog chirps --collection chirps-monthly
+    georiva cleanup_asset_orphans --catalog chirps --apply
+    georiva cleanup_asset_orphans --all --apply
+"""
+from django.core.management.base import BaseCommand, CommandError
+
+from georiva.core.asset_cleanup import DELETABLE_EXTENSIONS, select_orphan_objects
+from georiva.core.models import Asset, Collection
+from georiva.core.storage import storage
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete orphaned raster/visual objects from the assets bucket "
+        "(files no Asset.href references). Previews unless --apply is given."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--catalog", metavar="SLUG",
+            help="Scope to one catalog (by slug).",
+        )
+        parser.add_argument(
+            "--collection", metavar="SLUG",
+            help="Scope to one collection slug (within --catalog).",
+        )
+        parser.add_argument(
+            "--all", action="store_true", dest="all_catalogs",
+            help="Sweep every catalog. Required to run without --catalog.",
+        )
+        parser.add_argument(
+            "--apply", action="store_true",
+            help="Actually delete. Without it, orphans are only listed.",
+        )
+
+    def handle(self, *args, **options):
+        catalog = options["catalog"]
+        collection = options["collection"]
+        apply = options["apply"]
+
+        if not catalog and not options["all_catalogs"]:
+            raise CommandError(
+                "Refusing to scan the whole bucket without a scope. "
+                "Pass --catalog SLUG (optionally --collection SLUG), or --all."
+            )
+
+        collections = Collection.objects.select_related("catalog")
+        if catalog:
+            collections = collections.filter(catalog__slug=catalog)
+        if collection:
+            collections = collections.filter(slug=collection)
+        collections = list(collections)
+        if not collections:
+            raise CommandError("No collections matched the given scope.")
+
+        total_orphans = 0
+        total_bytes = 0
+        for coll in collections:
+            prefix = f"{coll.catalog.slug}/{coll.slug}"
+            objects = [
+                f["path"]
+                for f in storage.assets.list_files(prefix, recursive=True)
+            ]
+            live = set(
+                Asset.objects
+                .filter(href__startswith=f"{prefix}/")
+                .values_list("href", flat=True)
+            )
+            orphans = select_orphan_objects(objects, live, DELETABLE_EXTENSIONS)
+            if not orphans:
+                continue
+
+            self.stdout.write(
+                f"{coll.catalog.slug}/{coll.slug}: "
+                f"{len(objects)} objects, {len(live)} live, "
+                f"{len(orphans)} orphan(s)"
+            )
+            for path in orphans:
+                size = _safe_size(path)
+                total_bytes += size
+                total_orphans += 1
+                if apply:
+                    storage.assets.delete(path)
+                    self.stdout.write(f"  deleted {path}")
+                else:
+                    self.stdout.write(f"  would delete {path} ({size} bytes)")
+
+        verb = "Deleted" if apply else "Would delete"
+        prefixnote = "" if apply else " [DRY RUN — pass --apply to delete]"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{verb} {total_orphans} orphan object(s), "
+                f"{total_bytes} bytes across {len(collections)} collection(s)."
+                f"{prefixnote}"
+            )
+        )
+
+
+def _safe_size(path: str) -> int:
+    try:
+        return storage.assets.size(path)
+    except Exception:
+        return 0

--- a/georiva/src/georiva/core/test_asset_cleanup.py
+++ b/georiva/src/georiva/core/test_asset_cleanup.py
@@ -1,0 +1,71 @@
+"""Pure orphaned-asset-object selection (used by the cleanup_asset_orphans
+management command). An orphan is a *raster/visual* object in the assets bucket
+that no live Asset.href references — e.g. a file left behind when a re-derivation
+rewrote an asset's href in place. Non-asset sidecars (.json metadata) are never
+selected, so legitimate files are safe."""
+from django.test import SimpleTestCase
+
+from georiva.core.asset_cleanup import DELETABLE_EXTENSIONS, select_orphan_objects
+
+
+class SelectOrphanObjectsTests(SimpleTestCase):
+    def test_selects_raster_objects_no_live_href_points_at(self):
+        objects = [
+            "chirps/chirps-monthly/precip/2026/05/01/precip_000000.tif",   # live
+            "chirps/chirps-monthly/precip/2026/05/01/precip_000000.png",   # live
+            "chirps/chirps-monthly/precip/2026/05/01/precip_20260501T000000.tif",  # orphan
+            "chirps/chirps-monthly/precip/2026/05/01/precip_20260501T000000.png",  # orphan
+        ]
+        live = {
+            "chirps/chirps-monthly/precip/2026/05/01/precip_000000.tif",
+            "chirps/chirps-monthly/precip/2026/05/01/precip_000000.png",
+        }
+
+        orphans = select_orphan_objects(objects, live, DELETABLE_EXTENSIONS)
+
+        self.assertEqual(sorted(orphans), [
+            "chirps/chirps-monthly/precip/2026/05/01/precip_20260501T000000.png",
+            "chirps/chirps-monthly/precip/2026/05/01/precip_20260501T000000.tif",
+        ])
+
+    def test_never_selects_non_asset_sidecars(self):
+        # A .json metadata sidecar (ingestion writes these; they are NOT Asset
+        # rows) must never be treated as an orphan, even though no href points at
+        # it.
+        objects = [
+            "cat/coll/v/2026/05/01/v_000000.tif",       # live
+            "cat/coll/v/2026/05/01/v_000000.json",      # sidecar — keep
+            "cat/coll/v/2026/05/01/v_stale.tif",        # orphan raster
+        ]
+        live = {"cat/coll/v/2026/05/01/v_000000.tif"}
+
+        orphans = select_orphan_objects(objects, live, DELETABLE_EXTENSIONS)
+
+        self.assertEqual(orphans, ["cat/coll/v/2026/05/01/v_stale.tif"])
+
+    def test_a_referenced_object_is_never_an_orphan(self):
+        objects = ["cat/coll/v/2026/05/01/v_000000.tif"]
+        live = {"cat/coll/v/2026/05/01/v_000000.tif"}
+
+        self.assertEqual(
+            select_orphan_objects(objects, live, DELETABLE_EXTENSIONS), []
+        )
+
+    def test_extension_match_is_case_insensitive(self):
+        objects = ["cat/coll/v/2026/05/01/v_stale.TIF"]
+        self.assertEqual(
+            select_orphan_objects(objects, set(), DELETABLE_EXTENSIONS),
+            ["cat/coll/v/2026/05/01/v_stale.TIF"],
+        )
+
+
+class CommandSafetyGuardTests(SimpleTestCase):
+    """The command refuses to scan the whole bucket without an explicit scope,
+    so a bare invocation can never sweep everything by accident."""
+
+    def test_no_scope_raises_rather_than_scanning_everything(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with self.assertRaises(CommandError):
+            call_command("cleanup_asset_orphans")

--- a/titiler-app/app/dependencies.py
+++ b/titiler-app/app/dependencies.py
@@ -28,10 +28,7 @@ redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
 # Django fallback
 # ---------------------------------------------------------------------------
 
-
-def _fetch_config_from_django(
-    catalog: str, collection: str, variable: str
-) -> Optional[dict]:
+def _fetch_config_from_django(catalog: str, collection: str, variable: str) -> Optional[dict]:
     """Fetch rendering config from Django internal API on Redis miss."""
     url = f"{DJANGO_BASE_URL}/api/tile-config/{catalog}/{collection}/{variable}/"
     try:
@@ -40,18 +37,12 @@ def _fetch_config_from_django(
             return resp.json()
         logger.warning(
             "Django tile-config returned %d for %s/%s/%s",
-            resp.status_code,
-            catalog,
-            collection,
-            variable,
+            resp.status_code, catalog, collection, variable,
         )
     except Exception as e:
         logger.warning(
             "Django tile-config fallback failed for %s/%s/%s: %s",
-            catalog,
-            collection,
-            variable,
-            e,
+            catalog, collection, variable, e,
         )
     return None
 
@@ -60,13 +51,12 @@ def _fetch_config_from_django(
 # Helpers
 # ---------------------------------------------------------------------------
 
-
 def build_cog_url(
-    catalog: str,
-    collection: str,
-    variable: str,
-    time_dt: datetime,
-    reftime_dt: Optional[datetime],
+        catalog: str,
+        collection: str,
+        variable: str,
+        time_dt: datetime,
+        reftime_dt: Optional[datetime],
 ) -> str:
     """
     Construct the MinIO COG URL from path components.
@@ -76,24 +66,20 @@ def build_cog_url(
       {catalog}/{collection}/{variable}/{YYYY}/{MM}/{DD}/{variable}_{HHMMSS}__ref{YYYYMMDDTHHmmss}.tif
     """
     date_path = time_dt.strftime("%Y/%m/%d")
-    time_str = time_dt.strftime("%Y%m%dT%H%M%S")
-
+    time_str = time_dt.strftime("%H%M%S")
+    
     if reftime_dt is not None:
         ref_str = reftime_dt.strftime("%Y%m%dT%H%M%S")
         filename = f"{variable}_{time_str}__ref{ref_str}.tif"
     else:
         filename = f"{variable}_{time_str}.tif"
-
+    
     dataset_path = f"{catalog}/{collection}/{variable}/{date_path}/{filename}"
-
+    
     if not PATH_RE.match(dataset_path):
-        raise HTTPException(
-            status_code=400, detail=f"Invalid constructed path: {dataset_path}"
-        )
-
-    url = f"{MINIO_HOST}/{MINIO_BUCKET_NAME}/{dataset_path}"
-
-    return url
+        raise HTTPException(status_code=400, detail=f"Invalid constructed path: {dataset_path}")
+    
+    return f"{MINIO_HOST}/{MINIO_BUCKET_NAME}/{dataset_path}"
 
 
 def parse_iso_datetime(value: str, param_name: str) -> datetime:
@@ -112,11 +98,10 @@ def parse_iso_datetime(value: str, param_name: str) -> datetime:
 # FastAPI dependencies
 # ---------------------------------------------------------------------------
 
-
 def SemanticTileConfig(
-    catalog_slug: Annotated[str, Path(...)],
-    collection_slug: Annotated[str, Path(...)],
-    variable_slug: Annotated[str, Path(...)],
+        catalog_slug: Annotated[str, Path(...)],
+        collection_slug: Annotated[str, Path(...)],
+        variable_slug: Annotated[str, Path(...)],
 ) -> dict:
     """Resolve rendering config for a variable.
 
@@ -124,31 +109,17 @@ def SemanticTileConfig(
     FastAPI caches this result per request so colormap and rescale
     dependencies share a single Redis call.
     """
-    raw = redis_client.get(
-        f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}"
-    )
+    raw = redis_client.get(f"{PALETTE_KEY_PREFIX}:{catalog_slug}:{collection_slug}:{variable_slug}")
     if raw:
-        logger.debug(
-            "Redis cache hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug
-        )
+        logger.debug("Redis cache hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
         return json.loads(raw)
-
+    
     config = _fetch_config_from_django(catalog_slug, collection_slug, variable_slug)
     if config is not None:
-        logger.debug(
-            "Django fallback hit: %s/%s/%s",
-            catalog_slug,
-            collection_slug,
-            variable_slug,
-        )
+        logger.debug("Django fallback hit: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
         return config
-
-    logger.warning(
-        "Tile config unavailable: %s/%s/%s",
-        catalog_slug,
-        collection_slug,
-        variable_slug,
-    )
+    
+    logger.warning("Tile config unavailable: %s/%s/%s", catalog_slug, collection_slug, variable_slug)
     raise HTTPException(
         status_code=503,
         detail="Tile config unavailable — Redis cold and Django fallback failed",
@@ -156,28 +127,22 @@ def SemanticTileConfig(
 
 
 def SemanticPathParams(
-    catalog_slug: Annotated[str, Path(...)],
-    collection_slug: Annotated[str, Path(...)],
-    variable_slug: Annotated[str, Path(...)],
-    time: str = Query(
-        ..., description="Valid time in ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)"
-    ),
-    reftime: Optional[str] = Query(
-        None, description="Forecast reference time in ISO 8601 UTC"
-    ),
+        catalog_slug: Annotated[str, Path(...)],
+        collection_slug: Annotated[str, Path(...)],
+        variable_slug: Annotated[str, Path(...)],
+        time: str = Query(..., description="Valid time in ISO 8601 UTC (e.g. 2026-03-23T12:00:00Z)"),
+        reftime: Optional[str] = Query(None, description="Forecast reference time in ISO 8601 UTC"),
 ) -> str:
     """Resolve the COG URL from semantic path params and time query params."""
     time_dt = parse_iso_datetime(time, "time")
     reftime_dt = parse_iso_datetime(reftime, "reftime") if reftime else None
-    url = build_cog_url(
-        catalog_slug, collection_slug, variable_slug, time_dt, reftime_dt
-    )
+    url = build_cog_url(catalog_slug, collection_slug, variable_slug, time_dt, reftime_dt)
     logger.debug("Resolved COG URL: %s", url)
     return url
 
 
 def SemanticColorMap(
-    tile_config: dict = Depends(SemanticTileConfig),
+        tile_config: dict = Depends(SemanticTileConfig),
 ) -> Optional[ColorMapType]:
     """Return the 256-entry colormap from Redis config, or grayscale fallback."""
     raw = tile_config.get("colormap")
@@ -188,17 +153,17 @@ def SemanticColorMap(
 
 class RescaleAlgorithm(BaseAlgorithm):
     """Rescale raw float COG data to 0-255 before colormap lookup."""
-
+    
     vmin: float
     vmax: float
-
+    
     def __call__(self, img: ImageData) -> ImageData:
         img.rescale(in_range=[(self.vmin, self.vmax)], out_range=[(0, 255)])
         return img
 
 
 def SemanticRescale(
-    tile_config: dict = Depends(SemanticTileConfig),
+        tile_config: dict = Depends(SemanticTileConfig),
 ) -> Optional[BaseAlgorithm]:
     """Return a rescale algorithm using vmin/vmax from the tile config."""
     return RescaleAlgorithm(vmin=tile_config["vmin"], vmax=tile_config["vmax"])


### PR DESCRIPTION
Sweeps orphaned raster/visual objects from the assets bucket — files no live `Asset.href` references. These accumulate when a re-derivation rewrites an asset's href in place (e.g. the derived-asset path-scheme fix in #199) and leaves the old object behind, or when items/assets are deleted without a storage sweep.

## Design

- **`core.asset_cleanup.select_orphan_objects`** — pure, unit-tested selection. An orphan is a **known asset object type** (`.tif/.tiff/.png/.webp/.jpeg/.jpg`) that no live href references. **Non-asset sidecars (`.json` metadata that ingestion writes but does not model as an `Asset`) are never selected**, so a sweep can't remove a legitimate file.
- **`cleanup_asset_orphans` command** — safe by default:
  - **dry-run** unless `--apply`;
  - a **scope is required** — `--catalog SLUG` (optionally `--collection SLUG`) or explicit `--all` — so a bare invocation can't sweep the whole bucket;
  - live hrefs are matched per collection prefix.

```
georiva cleanup_asset_orphans --catalog chirps --collection chirps-monthly
georiva cleanup_asset_orphans --catalog chirps --apply
```

## Tests

Pure selection (sidecar safety, referenced-is-kept, case-insensitive ext) + the no-scope safety guard. Dry-run validated on live `chirps-monthly`: correctly identified 76 `precip_YYYYMMDDTHHMMSS.png/.tif` orphans (the items already re-derived to the `_000000` scheme), leaving not-yet-flipped items' still-referenced objects untouched.

## Operational note

The right sequence for the current CHIRPS cleanup: let the promotion backfill (#199) **fully complete** first — until then, un-flipped items still reference their `T000000` object, so it's correctly protected. Once all items are on the `_000000` scheme, run `--apply` once to remove every orphaned `T000000` object in one pass.