### PR TITLE
fix: exclude machine-generated data models from Wagtail's reference index

### DIFF
--- a/georiva/src/georiva/core/models/item.py
+++ b/georiva/src/georiva/core/models/item.py
@@ -27,7 +27,14 @@ class Item(AbstractSpatialItem, TimescaleModel, TimeStampedModel, ClusterableMod
     Spatial/raster fields (source_file, bounds, geometry, width, height,
     resolution_x/y, crs, properties) are inherited from AbstractSpatialItem.
     """
-    
+
+    # Excluded from Wagtail's reference index: an Item is machine-generated data
+    # written on every ingestion/derivation, not editorial content whose usage or
+    # delete-protection matters. Snippet registration would otherwise enrol it,
+    # making every save run update_reference_index_task inline in the pipeline
+    # workers. See core/test_reference_index_exclusion.py.
+    wagtail_reference_index_ignore = True
+
     collection = models.ForeignKey(
         'georivacore.Collection',
         on_delete=models.CASCADE,

--- a/georiva/src/georiva/core/test_reference_index_exclusion.py
+++ b/georiva/src/georiva/core/test_reference_index_exclusion.py
@@ -1,0 +1,32 @@
+"""Machine-generated data-plane models are excluded from Wagtail's reference
+index (``wagtail_reference_index_ignore = True``).
+
+These models are registered as snippets for their admin list views, but that
+registration otherwise enrols them in the reference index — so every save (of
+which the pipelines do thousands) would synchronously run Wagtail's
+``update_reference_index_task`` in-process. They are machine data, not editorial
+content whose "usage" or delete-protection matters, so they opt out.
+"""
+from django.test import SimpleTestCase
+from wagtail.models import ReferenceIndex
+
+from georiva.core.models import Item
+from georiva.ingestion.models import FileIngestionJob
+from georiva.staging.models import StagingCollection, StagingItem
+
+
+class ReferenceIndexExclusionTests(SimpleTestCase):
+    def test_data_plane_models_are_not_reference_indexed(self):
+        for model in (Item, StagingItem, StagingCollection, FileIngestionJob):
+            with self.subTest(model=model.__name__):
+                self.assertFalse(
+                    ReferenceIndex.is_indexed(model),
+                    f"{model.__name__} should be excluded from the reference index",
+                )
+
+    def test_the_flag_is_declared_on_each_model(self):
+        # A guard against the exclusion silently regressing to the Wagtail
+        # default (indexed) if the attribute is removed.
+        for model in (Item, StagingItem, StagingCollection, FileIngestionJob):
+            with self.subTest(model=model.__name__):
+                self.assertTrue(getattr(model, "wagtail_reference_index_ignore", False))

--- a/georiva/src/georiva/ingestion/models.py
+++ b/georiva/src/georiva/ingestion/models.py
@@ -580,6 +580,10 @@ class FileIngestionJob(Job):
     invocation; when the run succeeds the FileIngestion FK is populated.
     """
 
+    # Machine-written job/telemetry record — kept out of Wagtail's reference
+    # index (see core/test_reference_index_exclusion.py).
+    wagtail_reference_index_ignore = True
+
     file_path = models.CharField(
         max_length=500,
         help_text="Path relative to bucket root.",

--- a/georiva/src/georiva/staging/models.py
+++ b/georiva/src/georiva/staging/models.py
@@ -27,7 +27,11 @@ from georiva.core.models.base import (
 @register_snippet
 class StagingCollection(AbstractCollection, TimeStampedModel, ClusterableModel):
     """A source-grained grouping of staged raw artifacts."""
-    
+
+    # Machine-generated data, not editorial content — kept out of Wagtail's
+    # reference index (see core/test_reference_index_exclusion.py).
+    wagtail_reference_index_ignore = True
+
     catalog = models.ForeignKey(
         'georivacore.Catalog',
         on_delete=models.CASCADE,
@@ -69,7 +73,11 @@ class StagingItem(AbstractSpatialItem, TimeStampedModel, ClusterableModel):
     Gregorian index bounds for selection only — the authoritative time and
     calendar are read from file content at derivation time.
     """
-    
+
+    # Machine-generated data written on every staged file — kept out of Wagtail's
+    # reference index (see core/test_reference_index_exclusion.py).
+    wagtail_reference_index_ignore = True
+
     collection = models.ForeignKey(
         StagingCollection,
         on_delete=models.CASCADE,


### PR DESCRIPTION
## Problem

`Item`, `StagingItem`, `StagingCollection`, and `FileIngestionJob` are registered as Wagtail **snippets** (for their admin list views), which also enrols them in the **reference index**. Every save then fires Wagtail's `update_reference_index_task` — and since Django's default task backend is `ImmediateBackend`, that task runs **inline, synchronously, in whatever process saved the row**. Because ingestion and derivation write these models in tight loops, that inline work was competing for the processing/ingestion Celery worker slots (seen as `update_reference_index_task` interleaved with `run_unit_task` during the promotion backfill).

It's not a Celery routing issue — the task isn't queued at all; it executes in-process on save. And it's not "every model" — only registered snippets/Pages with outbound FKs get indexed.

## Fix

Set `wagtail_reference_index_ignore = True` on the four data-plane models. It's a runtime class attribute (**no migration**) that removes them from the index, so `ReferenceIndex.is_indexed()` is `False` and the `post_save` handler never enqueues the task for them. These are machine-generated data, not editorial content whose "usage" or delete-protection matters, so nothing is lost — and their **snippet admin listings are unaffected**.

Verified nothing in the codebase reads the reference index for these models.

## Test

`ReferenceIndex.is_indexed()` is `False` for all four, plus a guard that the flag is declared (so it can't silently regress to the indexed default). **350 tests pass** across core / staging / ingestion.

## Note

`Item` and `StagingItem` are the performance-critical ones (tight-loop saves); the other two are lower-volume but excluded for consistency, since none of them belong in the reference index conceptually.