### PR TITLE
feat(processing): bound derivation units with time limits, align lock timeout

### DIFF
--- a/georiva/src/georiva/processing/constants.py
+++ b/georiva/src/georiva/processing/constants.py
@@ -1,0 +1,33 @@
+"""
+Timeouts for a single derivation unit, in one place so the Celery task time
+limit and the ``DerivationRun`` lock timeout can't drift apart.
+
+A unit (``run_unit_task``) is bounded by a soft then hard Celery time limit; the
+``DerivationRun`` lock timeout sits strictly above the hard limit. Because Celery
+guarantees no task outlives the hard limit, a live task can never have its lock
+stolen mid-run — while a worker that dies *without* releasing recovers a short
+margin after the hard kill instead of after hours.
+"""
+# Soft limit: Celery raises ``SoftTimeLimitExceeded`` inside the task, which
+# ``engine.run_unit`` catches (``except Exception``) → ``mark_failed`` → the lock
+# is released immediately. This is the graceful recovery path for a task that has
+# simply run too long (e.g. a pathologically large raster, or contention).
+RUN_UNIT_SOFT_TIME_LIMIT_SECONDS = 13 * 60   # 780s
+
+# Hard limit: the worker force-kills the task's process. No chance to release the
+# lock, so the lock timeout below is the backstop. Only reached when the soft
+# exception can't unwind — e.g. stuck in a native GDAL/rasterio call that ignores
+# Python signals.
+RUN_UNIT_HARD_TIME_LIMIT_SECONDS = 15 * 60   # 900s
+
+# Grace after the hard kill before another worker may reclaim the lock, letting
+# the killed task's DB state and broker redelivery settle.
+LOCK_TIMEOUT_MARGIN_SECONDS = 5 * 60         # 300s
+
+# The DerivationRun stale-lock timeout. Strictly greater than the hard task limit
+# (so a live, time-limited task's lock is never stolen) plus the settle margin —
+# 20 min total, versus the old fixed 2h that left a dead unit unrecoverable for
+# hours.
+DERIVATION_LOCK_TIMEOUT_SECONDS = (
+    RUN_UNIT_HARD_TIME_LIMIT_SECONDS + LOCK_TIMEOUT_MARGIN_SECONDS
+)  # 1200s = 20 min

--- a/georiva/src/georiva/processing/models.py
+++ b/georiva/src/georiva/processing/models.py
@@ -16,9 +16,15 @@ from django.db import models
 from django.utils import timezone as dj_timezone
 from django_extensions.db.models import TimeStampedModel
 
+from georiva.processing.constants import DERIVATION_LOCK_TIMEOUT_SECONDS
+
 
 class DerivationRun(TimeStampedModel):
-    LOCK_TIMEOUT = timedelta(hours=2)
+    # Aligned with the run_unit_task hard time limit (see processing/constants):
+    # the lock only becomes stealable strictly after Celery would have killed a
+    # runaway task, so a live task's lock is never stolen, and a dead worker's
+    # unit recovers in ~20 min rather than the old fixed 2h.
+    LOCK_TIMEOUT = timedelta(seconds=DERIVATION_LOCK_TIMEOUT_SECONDS)
 
     class Status(models.TextChoices):
         PENDING = 'pending', 'Pending'

--- a/georiva/src/georiva/processing/tasks.py
+++ b/georiva/src/georiva/processing/tasks.py
@@ -8,6 +8,10 @@ backfill cannot starve live ingestion. Recovery is via the backfill sweep
 import logging
 
 from georiva.config.celery import app
+from georiva.processing.constants import (
+    RUN_UNIT_HARD_TIME_LIMIT_SECONDS,
+    RUN_UNIT_SOFT_TIME_LIMIT_SECONDS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +43,12 @@ def setup_periodic_tasks(sender, **kwargs):
     max_retries=2,
     acks_late=True,
     queue="georiva-processing",
+    # Bound a single unit so a hung/thrashing task can't run indefinitely: the
+    # soft limit raises inside the task (run_unit catches it → mark_failed →
+    # releases the lock immediately); the hard limit force-kills as a backstop.
+    # DerivationRun.LOCK_TIMEOUT is aligned just above the hard limit.
+    soft_time_limit=RUN_UNIT_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=RUN_UNIT_HARD_TIME_LIMIT_SECONDS,
 )
 def run_unit_task(self, recipe_type: str, unit: dict, origin: str = None):
     """Run a single ProductionUnit for a recipe (one DerivationRun)."""

--- a/georiva/src/georiva/processing/tests/test_engine.py
+++ b/georiva/src/georiva/processing/tests/test_engine.py
@@ -328,3 +328,31 @@ class AssetOutputPathTests(_PromotionFixture):
         self.assertEqual(
             path, "cmip6/tas/tas/2026/05/01/tas_060000__ref20260501T000000.tif"
         )
+
+
+class SoftTimeLimitReleasesLockTests(_PromotionFixture):
+    """When a unit hits the Celery soft time limit, SoftTimeLimitExceeded is
+    raised inside run_unit; it's caught, the run is marked FAILED, and the lock
+    is released immediately — so a slow/hung unit recovers at once rather than
+    holding its lock until LOCK_TIMEOUT."""
+
+    def test_soft_time_limit_marks_the_run_failed_and_frees_the_lock(self):
+        from celery.exceptions import SoftTimeLimitExceeded
+
+        from georiva.processing.engine import run_unit
+        from georiva.processing.models import DerivationRun
+
+        recipe = PromotionRecipe()
+        # The soft limit fires mid-read; run_unit's `except Exception` catches it.
+        with patch.object(
+            PromotionRecipe, "read_raster", side_effect=SoftTimeLimitExceeded()
+        ):
+            with self.assertRaises(SoftTimeLimitExceeded):
+                run_unit(recipe, self._unit(), writer=_mock_writer())
+
+        run = DerivationRun.objects.get(recipe_type="promotion")
+        self.assertEqual(run.status, DerivationRun.Status.FAILED)
+        # FAILED is immediately reclaimable — the lock isn't held to LOCK_TIMEOUT
+        # (it's not RUNNING; is_stale is a property, False for a non-RUNNING run).
+        self.assertNotEqual(run.status, DerivationRun.Status.RUNNING)
+        self.assertFalse(run.is_stale)

--- a/georiva/src/georiva/processing/tests/test_task_time_limits.py
+++ b/georiva/src/georiva/processing/tests/test_task_time_limits.py
@@ -1,0 +1,49 @@
+"""Bounded derivation units + an aligned lock timeout (Option 1).
+
+A single derivation unit (``run_unit_task``) is bounded by a soft then hard
+Celery time limit, and ``DerivationRun.LOCK_TIMEOUT`` sits just above the hard
+limit. So a live, time-limited task can never have its lock stolen mid-run, while
+a worker that dies without releasing recovers minutes after the hard kill instead
+of after hours (the old fixed 2h). The soft limit is the graceful path: it raises
+inside the task, ``run_unit`` catches it and marks the run failed, freeing the
+lock immediately.
+"""
+from datetime import timedelta
+
+from django.test import SimpleTestCase
+
+from georiva.processing.constants import (
+    DERIVATION_LOCK_TIMEOUT_SECONDS,
+    RUN_UNIT_HARD_TIME_LIMIT_SECONDS,
+    RUN_UNIT_SOFT_TIME_LIMIT_SECONDS,
+)
+from georiva.processing.models import DerivationRun
+from georiva.processing.tasks import run_unit_task
+
+
+class TaskTimeLimitInvariantTests(SimpleTestCase):
+    def test_soft_below_hard_below_lock_timeout(self):
+        # The correctness invariant: soft fires first (graceful cleanup), and the
+        # lock only becomes stealable strictly *after* the hard kill — so Celery's
+        # guarantee that no task outlives the hard limit means a live task's lock
+        # can never be stolen.
+        self.assertLess(
+            RUN_UNIT_SOFT_TIME_LIMIT_SECONDS, RUN_UNIT_HARD_TIME_LIMIT_SECONDS
+        )
+        self.assertLess(
+            RUN_UNIT_HARD_TIME_LIMIT_SECONDS, DERIVATION_LOCK_TIMEOUT_SECONDS
+        )
+
+    def test_run_unit_task_declares_both_time_limits(self):
+        self.assertEqual(
+            run_unit_task.soft_time_limit, RUN_UNIT_SOFT_TIME_LIMIT_SECONDS
+        )
+        self.assertEqual(run_unit_task.time_limit, RUN_UNIT_HARD_TIME_LIMIT_SECONDS)
+
+    def test_lock_timeout_tracks_the_constant_and_is_far_below_the_old_2h(self):
+        self.assertEqual(
+            DerivationRun.LOCK_TIMEOUT,
+            timedelta(seconds=DERIVATION_LOCK_TIMEOUT_SECONDS),
+        )
+        # Recovery in well under an hour (was 2h).
+        self.assertLess(DerivationRun.LOCK_TIMEOUT, timedelta(hours=1))


### PR DESCRIPTION
Option 1 from the lock-timeout discussion. Fixes the failure mode that wedged the promotion backfill: a hung/thrashing unit could run indefinitely (no Celery time limit), and `DerivationRun.LOCK_TIMEOUT` was a flat **2h**, so a dead unit was unrecoverable for hours.

## Change

Bound the unit, then align the lock just above it:

- **`run_unit_task`** gains `soft_time_limit=13m` and `time_limit=15m`. The **soft** limit raises `SoftTimeLimitExceeded` inside the task; `run_unit`'s existing `except Exception` catches it → `mark_failed` → **the lock is released immediately** (the graceful path). The **hard** limit force-kills the process as a backstop.
- **`LOCK_TIMEOUT` 2h → 20m**, defined as `hard_limit + 5m margin`. Because Celery guarantees no task outlives the hard limit, the lock only becomes stealable *strictly after* it — so a **live task's lock is never stolen**, while a **dead worker's unit recovers in ~20m** instead of 2h.
- All three values live in `processing/constants.py` so the task limit and the lock timeout **can't drift apart**.

## Why this is the right lever

The old 2h wasn't wrong so much as overloaded: one fixed value had to both bound legitimate task duration *and* detect dead workers, so it had to be conservative (long), making recovery slow. Adding the hard time limit lets the lock be short *and* safe — Celery enforces the ceiling the lock relies on. It's exactly the piece that would have made the backfill hang self-heal instead of needing a manual row reset.

## Tests

- Invariant: `soft < hard < lock_timeout`.
- `run_unit_task` declares both limits; `LOCK_TIMEOUT` tracks the constant and is `< 1h`.
- **Behavioural:** a `SoftTimeLimitExceeded` mid-unit marks the run `FAILED` and frees the lock (proves the graceful path).

304 tests pass across processing / sources / CHIRPS.

## Note

This is the safety net; the first-order fix for that incident was sane worker concurrency (I'd over-grown the pool to 19 on 10 cores). Making a sane processing-worker concurrency the default in the dev entrypoint is still a worthwhile follow-up — happy to PR it.