### PR TITLE
fix(sources): resolve polymorphic DataFeed before reading product definitions

### DIFF
--- a/georiva/src/georiva/sources/derivation_invocation.py
+++ b/georiva/src/georiva/sources/derivation_invocation.py
@@ -30,8 +30,20 @@ def _trigger_tier(trigger: dict) -> str:
 
 
 def definition_for(product):
-    """The product's DerivedProductDefinition, looked up on its feed by key."""
-    for definition in product.data_feed.get_derived_products():
+    """The product's DerivedProductDefinition, looked up on its feed by key.
+
+    ``DataFeed`` is a django-polymorphic model. Resolve the *real* subclass
+    instance before calling ``get_derived_products()``: a caller that fetched the
+    product via ``select_related("data_feed")`` gets the **base** ``DataFeed``
+    back (select_related can't join the unknown child table), whose base
+    ``get_derived_products()`` returns ``[]`` — which would mislabel every product
+    as orphaned. ``get_real_instance()`` downcasts to e.g. ``CHIRPSDataFeed`` so
+    the declarations are found regardless of how the product was queried.
+    """
+    feed = product.data_feed
+    if hasattr(feed, "get_real_instance"):
+        feed = feed.get_real_instance()
+    for definition in feed.get_derived_products():
         if definition.key == product.definition_key:
             return definition
     return None


### PR DESCRIPTION
## Problem
Every derived product showed as **'orphaned' / 'Blocked: no product definition'** in the tracking UI.

`DataFeed` is a **django-polymorphic** model. The tracking view queries `DerivedProduct.objects.select_related('data_feed')`, and `select_related` on a polymorphic FK returns the **base** `DataFeed` (it can't join the unknown child table). Base `get_derived_products()` returns `[]`, so `definition_for()` matched nothing → every product mislabelled as orphaned.

Confirmed live: same product resolves fine without `select_related`, empty with it.

## Fix
Downcast via `get_real_instance()` inside `definition_for` — the single shared resolver behind tracking, chain UI, readiness, and scheduled dispatch — so definitions resolve regardless of how the product was queried.

Verified through the view's exact queryset: `orphaned=False, ready=True` for all products.