### PR TITLE
feat(processing): sweep reclaims stale RUNNING derivation units

### DIFF
--- a/georiva/src/georiva/processing/invocation.py
+++ b/georiva/src/georiva/processing/invocation.py
@@ -100,6 +100,50 @@ def sweep_stale_units(*, dispatch: bool = True) -> int:
     return stale
 
 
+def reclaim_stale_running(*, dispatch: bool = True) -> int:
+    """
+    Re-dispatch units stuck in RUNNING past the lock timeout.
+
+    A worker that dies mid-unit (crash, OOM, hard time-limit kill, or a dev
+    auto-reload) leaves its ``DerivationRun`` in RUNNING with no live task to
+    finish it. ``sweep_stale_units`` only inspects *terminal*
+    (completed/skipped) runs, so without this pass such a unit is reclaimed only
+    when that exact unit happens to be re-triggered by hand or a new input — it
+    otherwise sits stuck indefinitely.
+
+    Reclaiming just re-dispatches through the same per-unit primitive: when the
+    new task runs, ``run_unit`` → ``DerivationRun.acquire`` atomically steals the
+    stale lock (its claim query re-checks the timeout, so a still-live lock is
+    never stolen) and recomputes. No ``origin`` is passed, so ``acquire`` keeps
+    the run's existing product-origin stamp. Returns the number re-dispatched.
+    """
+    from django.utils import timezone
+
+    from .models import DerivationRun
+
+    cutoff = timezone.now() - DerivationRun.LOCK_TIMEOUT
+    stale_runs = DerivationRun.objects.filter(
+        status=DerivationRun.Status.RUNNING, locked_at__lt=cutoff,
+    )
+    reclaimed = 0
+    for run_rec in stale_runs:
+        if _recipe_for(run_rec.recipe_type) is None:
+            logger.warning(
+                "Sweep: stale RUNNING unit %s names unknown recipe '%s' — leaving as-is",
+                run_rec, run_rec.recipe_type,
+            )
+            continue
+        logger.warning(
+            "Sweep: reclaiming stale RUNNING unit %s (locked_by=%s at %s, past %s) — re-dispatching",
+            run_rec, run_rec.locked_by or "-", run_rec.locked_at, DerivationRun.LOCK_TIMEOUT,
+        )
+        _dispatch_unit(run_rec.recipe_type, run_rec.unit_key, dispatch=dispatch)
+        reclaimed += 1
+    if reclaimed:
+        logger.info("Sweep: reclaimed %d stale RUNNING unit(s)", reclaimed)
+    return reclaimed
+
+
 def _recipe_for(recipe_type: str):
     from .registry import recipe_registry
 

--- a/georiva/src/georiva/processing/tasks.py
+++ b/georiva/src/georiva/processing/tasks.py
@@ -86,12 +86,24 @@ def sweep_derivations():
     """
     Periodic backfill sweep — the write-side mirror of ``sweep_unprocessed``.
 
-    Recomputes units whose inputs changed since they were last derived
-    (recorded ``input_hash`` ≠ current), without depending on an event.
+    Two independent recovery passes, neither depending on an event:
+      1. ``sweep_stale_units`` — recomputes units whose inputs changed since they
+         were last derived (recorded ``input_hash`` ≠ current).
+      2. ``reclaim_stale_running`` — re-dispatches units stuck in RUNNING past the
+         lock timeout (a worker died mid-unit), which pass 1 never inspects.
     """
-    from georiva.processing.invocation import sweep_stale_units
+    from georiva.processing.invocation import (
+        reclaim_stale_running,
+        sweep_stale_units,
+    )
 
-    return sweep_stale_units()
+    input_stale = sweep_stale_units()
+    reclaimed = reclaim_stale_running()
+    logger.info(
+        "sweep_derivations: %d input-stale re-dispatched, %d stale-RUNNING reclaimed",
+        input_stale, reclaimed,
+    )
+    return {"input_stale": input_stale, "reclaimed": reclaimed}
 
 
 @app.task(

--- a/georiva/src/georiva/processing/tests/test_invocation.py
+++ b/georiva/src/georiva/processing/tests/test_invocation.py
@@ -414,6 +414,59 @@ class SweepStalenessTests(_RegistryIsolationMixin, TestCase):
         self.assertIn(("recipe_c", (("id", "C"),)), dispatched)  # propagated downstream
 
 
+class ReclaimStaleRunningTests(_RegistryIsolationMixin, TestCase):
+    """A worker that dies mid-unit leaves a RUNNING DerivationRun with no live
+    task; the sweep's second pass re-dispatches it once the lock has timed out,
+    while a still-fresh RUNNING lock is left alone."""
+
+    fake_recipes = [_SweepRecipe]
+
+    def _running_run(self, *, unit, age):
+        from django.utils import timezone
+
+        from georiva.processing.models import DerivationRun
+        from georiva.processing.recipe import unit_hash
+
+        return DerivationRun.objects.create(
+            recipe_type="sweep_fake", recipe_version="1",
+            unit_key=unit, unit_hash=unit_hash(unit),
+            status=DerivationRun.Status.RUNNING,
+            locked_by="dead-worker", locked_at=timezone.now() - age,
+        )
+
+    def test_stale_running_unit_is_reclaimed(self):
+        from datetime import timedelta
+
+        from georiva.processing.models import DerivationRun
+        from georiva.processing.tasks import sweep_derivations
+
+        self._running_run(
+            unit={"n": 1}, age=DerivationRun.LOCK_TIMEOUT + timedelta(minutes=1),
+        )
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            result = sweep_derivations.apply().get()
+
+        task.delay.assert_called_once()
+        self.assertEqual(task.delay.call_args.kwargs["recipe_type"], "sweep_fake")
+        self.assertEqual(task.delay.call_args.kwargs["unit"], {"n": 1})
+        self.assertEqual(result["reclaimed"], 1)
+
+    def test_fresh_running_unit_is_not_reclaimed(self):
+        from datetime import timedelta
+
+        from georiva.processing.tasks import sweep_derivations
+
+        # Locked a minute ago — well within the 20-min timeout, so a live task
+        # may still own it. Must not be stolen.
+        self._running_run(unit={"n": 2}, age=timedelta(minutes=1))
+
+        with patch("georiva.processing.tasks.run_unit_task") as task:
+            sweep_derivations.apply()
+
+        task.delay.assert_not_called()
+
+
 class ForwardInvalidationTests(TestCase):
     """A changed input invalidates its derived items transitively — walking
     DerivationLink forward through internal intermediates (A → B → C)."""


### PR DESCRIPTION
## Problem
A worker that dies mid-unit (crash, OOM, hard time-limit kill, dev auto-reload) leaves its `DerivationRun` in `RUNNING` with no live task. The existing sweep only inspects **terminal** (completed/skipped) runs, so the unit stays stuck indefinitely until that exact unit is re-triggered by hand. (This is what left 3 climatology slots wedged.)

## Fix
Add `reclaim_stale_running()`: re-dispatch units in `RUNNING` past `LOCK_TIMEOUT`. When the new task runs, `run_unit` → `acquire()` steals the stale lock **atomically** (its claim query re-checks the timeout, so a genuinely live lock is never stolen) and recomputes. No `origin` is passed, so the run keeps its product-origin stamp.

`sweep_derivations` now runs both passes every 5 min → a dead-worker unit self-heals within ~25 min.

## Tests
`ReclaimStaleRunningTests`: a past-timeout RUNNING unit is reclaimed; a fresh one (locked 1 min ago) is left alone. Verified live — reclaimed the actual stuck climatology slot, which then completed (12/12).