### PR TITLE
feat(sources): run-list drill-down for derived products (#211)

### DIFF
--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -59,6 +59,22 @@ class ProductStatus:
     last_completed_at: datetime | None = None
 
 
+def product_runs(product, *, status=None):
+    """The product's DerivationRuns for the run-list drill-down (#211).
+
+    Joined by the opaque `origin` key (like `product_status`), ordered most-
+    recently-modified first so in-flight and just-failed units surface on top.
+    An optional `status` narrows to a single run status. Query logic lives here,
+    keeping the view dumb; the engine is not involved (ADR-0005).
+    """
+    from georiva.processing.models import DerivationRun
+
+    runs = DerivationRun.objects.filter(origin=product_origin(product))
+    if status:
+        runs = runs.filter(status=status)
+    return runs.order_by("-modified")
+
+
 def product_status(product) -> ProductStatus:
     """Aggregate a product's DerivationRuns (joined by origin) into one status."""
     from georiva.processing.models import DerivationRun

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_runs.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_runs.html
@@ -1,0 +1,186 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% blocktrans with label=product.display_label %}Runs — {{ label }}{% endblocktrans %}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .gdr-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1em;
+        }
+
+        .gdr-table th,
+        .gdr-table td {
+            text-align: left;
+            padding: 0.6em 0.8em;
+            border-bottom: 1px solid var(--w-color-border-furniture);
+            vertical-align: top;
+        }
+
+        .gdr-table th {
+            font-size: 0.75em;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdr-badge {
+            display: inline-block;
+            padding: 0.15em 0.6em;
+            border-radius: 999px;
+            font-size: 0.78em;
+            font-weight: 600;
+            border: 1px solid;
+        }
+
+        .gdr-badge--running {
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+            border-color: var(--w-color-info-100);
+        }
+
+        .gdr-badge--completed {
+            background: color-mix(in srgb, var(--w-color-positive-100) 12%, transparent);
+            color: var(--w-color-positive-100);
+            border-color: color-mix(in srgb, var(--w-color-positive-100) 35%, transparent);
+        }
+
+        .gdr-badge--failed {
+            background: var(--w-color-critical-200);
+            color: var(--w-color-white);
+            border-color: var(--w-color-critical-200);
+        }
+
+        .gdr-badge--skipped,
+        .gdr-badge--not_ready,
+        .gdr-badge--pending {
+            background: transparent;
+            color: var(--w-color-grey-400);
+            border-color: var(--w-color-border-furniture);
+        }
+
+        .gdr-unit {
+            font-family: monospace;
+            font-size: 0.85em;
+        }
+
+        .gdr-meta {
+            font-size: 0.8em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdr-error {
+            font-size: 0.82em;
+            color: var(--w-color-critical-200);
+            max-width: 32em;
+        }
+
+        .gdr-filters {
+            margin-top: 1em;
+            display: flex;
+            gap: 0.4em;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .gdr-filter {
+            font-size: 0.8em;
+            padding: 0.2em 0.7em;
+            border-radius: 999px;
+            border: 1px solid var(--w-color-border-furniture);
+            color: var(--w-color-text-label);
+            text-decoration: none;
+        }
+
+        .gdr-filter--active {
+            background: var(--w-color-surface-menus);
+            color: var(--w-color-white);
+            border-color: var(--w-color-surface-menus);
+        }
+
+        .gdr-empty {
+            margin-top: 1.5em;
+            color: var(--w-color-grey-400);
+        }
+
+        .gdr-pagination {
+            margin-top: 1.2em;
+            font-size: 0.85em;
+            color: var(--w-color-grey-400);
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=product.display_label subtitle=_("Derivation runs") icon="cogs" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        <div class="gdr-filters">
+            <span class="gdr-meta">{% trans "Filter" %}:</span>
+            <a class="gdr-filter {% if not current_status %}gdr-filter--active{% endif %}"
+               href="{% url 'derived_product_runs' product_pk=product.pk %}">{% trans "All" %}</a>
+            {% for value, label in statuses %}
+                <a class="gdr-filter {% if current_status == value %}gdr-filter--active{% endif %}"
+                   href="{% url 'derived_product_runs' product_pk=product.pk %}?status={{ value }}">{{ label }}</a>
+            {% endfor %}
+        </div>
+
+        {% if rows %}
+            <table class="gdr-table">
+                <thead>
+                    <tr>
+                        <th>{% trans "Status" %}</th>
+                        <th>{% trans "Unit" %}</th>
+                        <th>{% trans "Started" %}</th>
+                        <th>{% trans "Completed" %}</th>
+                        <th>{% trans "Duration" %}</th>
+                        <th>{% trans "Attempts" %}</th>
+                        <th>{% trans "Error" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                        <tr>
+                            <td>
+                                <span class="gdr-badge gdr-badge--{{ row.run.status }}">{{ row.run.status }}</span>
+                            </td>
+                            <td>
+                                <span class="gdr-unit">{{ row.run.recipe_type }}[{{ row.run.unit_hash|slice:":8" }}]</span>
+                            </td>
+                            <td class="gdr-meta">{{ row.run.started_at|default:"—" }}</td>
+                            <td class="gdr-meta">{{ row.run.completed_at|default:"—" }}</td>
+                            <td class="gdr-meta">
+                                {% if row.duration is not None %}{{ row.duration|floatformat:1 }}s{% else %}—{% endif %}
+                            </td>
+                            <td>{{ row.run.attempts }}</td>
+                            <td>
+                                {% if row.run.error %}
+                                    <div class="gdr-error">{{ row.run.error|truncatechars:200 }}</div>
+                                {% else %}
+                                    <span class="gdr-meta">—</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            {% if page.paginator.num_pages > 1 %}
+                <div class="gdr-pagination">
+                    {% if page.has_previous %}
+                        <a href="?{% if current_status %}status={{ current_status }}&amp;{% endif %}page={{ page.previous_page_number }}">{% trans "Previous" %}</a>
+                    {% endif %}
+                    {% blocktrans with n=page.number total=page.paginator.num_pages %}Page {{ n }} of {{ total }}{% endblocktrans %}
+                    {% if page.has_next %}
+                        <a href="?{% if current_status %}status={{ current_status }}&amp;{% endif %}page={{ page.next_page_number }}">{% trans "Next" %}</a>
+                    {% endif %}
+                </div>
+            {% endif %}
+        {% else %}
+            <p class="gdr-empty">{% trans "No runs yet for this product." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
@@ -133,7 +133,7 @@
                         <tr class="{% if not row.product.is_enabled %}gdp-disabled{% endif %}">
                             <td>
                                 <div class="gdp-product__label">
-                                    {{ row.label }}
+                                    <a href="{% url 'derived_product_runs' product_pk=row.product.pk %}">{{ row.label }}</a>
                                     {% if row.orphaned %}
                                         <a class="gdp-orphan-badge" href="{{ row.feed_url }}">{% trans "Orphaned" %}</a>
                                     {% endif %}

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -20,7 +20,7 @@ from georiva.core.derived_products import (
 from georiva.core.models import Catalog, Collection
 from georiva.processing.models import DerivationRun
 from georiva.sources.derivation_invocation import product_origin
-from georiva.sources.derivation_tracking import product_status
+from georiva.sources.derivation_tracking import product_runs, product_status
 from georiva.sources.models import DataFeed, DerivedProduct, DerivedProductInput
 from georiva.staging.models import StagingAsset, StagingCollection, StagingItem
 
@@ -215,3 +215,130 @@ class TrackingViewTests(TestCase):
 
         run_now.assert_not_called()
         self.assertContains(response, "value empty")
+
+
+def _touch_modified(run, when):
+    """Pin a run's `modified` (auto_now) deterministically for ordering tests."""
+    DerivationRun.objects.filter(pk=run.pk).update(modified=when)
+
+
+class ProductRunsTests(TestCase):
+    """product_runs is the per-product run list the drill-down renders (issue
+    #211): the product's DerivationRuns joined by origin, most-recent first."""
+
+    def setUp(self):
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def _origin(self):
+        return product_origin(self.product)
+
+    def test_returns_the_products_runs_most_recently_modified_first(self):
+        older = _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        newer = _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 2})
+        _touch_modified(older, datetime(2026, 1, 1, tzinfo=timezone.utc))
+        _touch_modified(newer, datetime(2026, 6, 1, tzinfo=timezone.utc))
+
+        runs = list(product_runs(self.product))
+
+        self.assertEqual([r.pk for r in runs], [newer.pk, older.pk])
+
+    def test_excludes_runs_belonging_to_another_product(self):
+        other = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="normals", recipe_type="climatology",
+        )
+        mine = _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(product_origin(other), DerivationRun.Status.FAILED, unit={"n": 9})
+
+        runs = list(product_runs(self.product))
+
+        self.assertEqual([r.pk for r in runs], [mine.pk])
+
+    def test_status_filter_narrows_to_a_single_status(self):
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        failed = _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 2})
+
+        runs = list(product_runs(self.product, status=DerivationRun.Status.FAILED))
+
+        self.assertEqual([r.pk for r in runs], [failed.pk])
+
+
+class RunListViewTests(TestCase):
+    """The run-list drill-down page (issue #211): a thin view over product_runs,
+    reached from the Derived Products dashboard."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_runs", "r@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def _url(self):
+        return reverse("derived_product_runs", kwargs={"product_pk": self.product.pk})
+
+    def _failed_run(self):
+        run = _run(product_origin(self.product), DerivationRun.Status.FAILED, unit={"n": 1})
+        DerivationRun.objects.filter(pk=run.pk).update(
+            error="boom: the transform blew up", attempts=3,
+        )
+        return run
+
+    def test_lists_a_products_runs_with_status_unit_attempts_and_error(self):
+        self._failed_run()
+
+        response = self.client.get(self._url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "failed")                     # status
+        self.assertContains(response, "climatology")                # unit recipe type
+        self.assertContains(response, "boom: the transform blew up")  # error snippet
+        self.assertContains(response, "3")                          # attempts
+
+    def test_status_filter_querystring_narrows_the_list(self):
+        from georiva.processing.recipe import unit_hash
+
+        completed = _run(product_origin(self.product), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        failed = _run(product_origin(self.product), DerivationRun.Status.FAILED, unit={"n": 2})
+        completed_tag = unit_hash({"n": 1})[:8]
+        failed_tag = unit_hash({"n": 2})[:8]
+
+        # Default (no filter) shows both.
+        both = self.client.get(self._url())
+        self.assertContains(both, completed_tag)
+        self.assertContains(both, failed_tag)
+
+        # ?status=failed shows only the failed run.
+        only_failed = self.client.get(self._url(), {"status": DerivationRun.Status.FAILED})
+        self.assertContains(only_failed, failed_tag)
+        self.assertNotContains(only_failed, completed_tag)
+
+    def test_run_list_is_paginated(self):
+        for i in range(26):
+            _run(product_origin(self.product), DerivationRun.Status.COMPLETED, unit={"n": i})
+
+        first = self.client.get(self._url())
+        self.assertEqual(first.context["page"].paginator.num_pages, 2)
+        self.assertEqual(len(first.context["rows"]), 25)
+
+        second = self.client.get(self._url(), {"page": 2})
+        self.assertEqual(len(second.context["rows"]), 1)
+
+    def test_dashboard_row_links_to_the_run_list(self):
+        response = self.client.get(reverse("derived_product_tracking"))
+
+        self.assertContains(response, self._url())
+
+    def test_run_list_breadcrumbs_back_to_the_dashboard(self):
+        response = self.client.get(self._url())
+
+        self.assertContains(response, reverse("derived_product_tracking"))

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1496,6 +1496,49 @@ def derived_product_tracking(request):
     return render(request, "georivasources/derived_product_tracking.html", context)
 
 
+def derived_product_runs(request, product_pk):
+    """
+    Run-list drill-down (ADR-0008, issue #211): one DerivedProduct's individual
+    DerivationRuns, joined by origin, most-recent first, with a status filter and
+    pagination. The read-side query lives in product_runs(); this view only
+    paginates and shapes rows (unit label, duration, error snippet) for display —
+    the engine is not involved.
+    """
+    from django.core.paginator import Paginator
+
+    from georiva.processing.models import DerivationRun
+    from georiva.sources.derivation_tracking import product_runs
+    from georiva.sources.models import DerivedProduct
+
+    product = get_object_or_404(DerivedProduct, pk=product_pk)
+    status = request.GET.get("status") or None
+
+    paginator = Paginator(product_runs(product, status=status), 25)
+    page = paginator.get_page(request.GET.get("page"))
+
+    rows = []
+    for run in page:
+        duration = None
+        if run.started_at and run.completed_at:
+            duration = (run.completed_at - run.started_at).total_seconds()
+        rows.append({"run": run, "duration": duration})
+
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+            {"url": reverse("derived_product_tracking"), "label": _("Derived Products")},
+            {"url": "", "label": product.display_label},
+        ],
+        "product": product,
+        "rows": rows,
+        "page": page,
+        "statuses": DerivationRun.Status.choices,
+        "current_status": status or "",
+    }
+    return render(request, "georivasources/derived_product_runs.html", context)
+
+
 def derived_product_chain(request, feed_pk):
     """
     Server-rendered chain diagram (ADR-0008): the planned DAG of a feed's

--- a/georiva/src/georiva/sources/wagtail_hooks.py
+++ b/georiva/src/georiva/sources/wagtail_hooks.py
@@ -29,6 +29,7 @@ from .views import (
     wizard_step4_products,
     wizard_provision,
     derived_product_tracking,
+    derived_product_runs,
     derived_product_chain,
     item_lineage,
 )
@@ -45,6 +46,8 @@ def urlconf_georivasources():
     return [
         path('data-feeds/', data_feed_list, name="data_feed_list"),
         path('data-feeds/derived-products/', derived_product_tracking, name="derived_product_tracking"),
+        path('data-feeds/derived-products/<int:product_pk>/runs/', derived_product_runs,
+             name="derived_product_runs"),
         path('data-feeds/<int:feed_pk>/chain/', derived_product_chain, name="derived_product_chain"),
         path('items/<int:item_pk>/lineage/', item_lineage, name="item_lineage"),
         path('data-feeds/select/', data_feed_add_select, name="data_feed_add_select"),


### PR DESCRIPTION
Closes #211 (part of #208). Builds on #209 (merged).

## What this does

Lets an operator click a product on the **Derived Products** dashboard and drill into its individual `DerivationRun`s — the first level of the debugging drill-down.

## Changes

- **`product_runs(product, *, status=None)`** (sources read-side) — joins a product's runs by the opaque `origin` key, orders `-modified` (in-flight / just-failed on top), optionally narrows to one status. Pure query; mirrors `product_status` / `product_readiness`. **The engine is not touched** — zero files under `processing/`.
- **`derived_product_runs` view** — thin: paginates `product_runs` (25/page) and shapes each row (unit label, duration, error snippet) for display. Status filter via querystring (default = all), breadcrumbs back to the dashboard, behind the existing admin URL gating.
- **Dashboard link** — each product row's label links to its run list.
- **Template** `derived_product_runs.html` — follows project conventions (no inline styles, `--w-color-*` tokens, extracted CSS).

The `attempts` column renders the field added in #209.

## Testing (TDD, one behavior at a time)

Extends `test_derivation_tracking.py`:

**`product_runs` (function seam):**
- [x] Returns the product's runs, `-modified` first
- [x] Excludes other products' runs (origin isolation)
- [x] `status=` narrows to one status

**Run-list view (smoke, `reverse()` + client):**
- [x] 200 and lists status / unit / attempts / error snippet
- [x] Status-filter querystring narrows; default shows all
- [x] Paginated (25/page)
- [x] Dashboard row links to the run list; run list breadcrumbs back

**199 sources tests pass; no regressions.**
