### PR TITLE
feat(sources): run-detail page for derived-product runs (#212)

### DIFF
--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -75,6 +75,14 @@ def product_runs(product, *, status=None):
     return runs.order_by("-modified")
 
 
+def run_duration_seconds(run):
+    """A run's wall-clock duration in seconds, or None if it never finished —
+    the display helper the run-list and run-detail views share."""
+    if run.started_at and run.completed_at:
+        return (run.completed_at - run.started_at).total_seconds()
+    return None
+
+
 def product_status(product) -> ProductStatus:
     """Aggregate a product's DerivationRuns (joined by origin) into one status."""
     from georiva.processing.models import DerivationRun

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_run_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_run_detail.html
@@ -1,0 +1,164 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% blocktrans with label=product.display_label %}Run — {{ label }}{% endblocktrans %}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .grd-grid {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1em;
+            max-width: 60em;
+        }
+
+        .grd-grid th,
+        .grd-grid td {
+            text-align: left;
+            padding: 0.6em 0.8em;
+            border-bottom: 1px solid var(--w-color-border-furniture);
+            vertical-align: top;
+        }
+
+        .grd-grid th {
+            width: 12em;
+            font-size: 0.78em;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--w-color-grey-400);
+            font-weight: 600;
+        }
+
+        .grd-badge {
+            display: inline-block;
+            padding: 0.15em 0.6em;
+            border-radius: 999px;
+            font-size: 0.78em;
+            font-weight: 600;
+            border: 1px solid;
+        }
+
+        .grd-badge--running {
+            background: var(--w-color-info-100);
+            color: var(--w-color-white);
+            border-color: var(--w-color-info-100);
+        }
+
+        .grd-badge--completed {
+            background: color-mix(in srgb, var(--w-color-positive-100) 12%, transparent);
+            color: var(--w-color-positive-100);
+            border-color: color-mix(in srgb, var(--w-color-positive-100) 35%, transparent);
+        }
+
+        .grd-badge--failed {
+            background: var(--w-color-critical-200);
+            color: var(--w-color-white);
+            border-color: var(--w-color-critical-200);
+        }
+
+        .grd-badge--skipped,
+        .grd-badge--not_ready,
+        .grd-badge--pending {
+            background: transparent;
+            color: var(--w-color-grey-400);
+            border-color: var(--w-color-border-furniture);
+        }
+
+        .grd-mono {
+            font-family: monospace;
+            font-size: 0.9em;
+        }
+
+        .grd-error {
+            font-family: monospace;
+            font-size: 0.85em;
+            white-space: pre-wrap;
+            word-break: break-word;
+            color: var(--w-color-critical-200);
+            background: color-mix(in srgb, var(--w-color-critical-200) 6%, transparent);
+            padding: 0.8em;
+            border-radius: 4px;
+            margin: 0;
+        }
+
+        .grd-muted {
+            color: var(--w-color-grey-400);
+        }
+
+        .grd-links a {
+            margin-right: 1em;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=product.display_label subtitle=_("Run detail") icon="cogs" breadcrumbs=breadcrumbs_items %}
+
+    <div class="nice-padding">
+        <table class="grd-grid">
+            <tbody>
+                <tr>
+                    <th>{% trans "Status" %}</th>
+                    <td><span class="grd-badge grd-badge--{{ run.status }}">{{ run.get_status_display }}</span></td>
+                </tr>
+                <tr>
+                    <th>{% trans "Unit" %}</th>
+                    <td>
+                        <span class="grd-mono">{{ run.recipe_type }} v{{ run.recipe_version }}</span>
+                        <div class="grd-mono grd-muted">{{ run.unit_hash }}</div>
+                        <div class="grd-mono grd-muted">{{ run.unit_key }}</div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Started" %}</th>
+                    <td class="grd-muted">{{ run.started_at|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Completed" %}</th>
+                    <td class="grd-muted">{{ run.completed_at|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Duration" %}</th>
+                    <td class="grd-muted">{% if duration is not None %}{{ duration|floatformat:1 }}s{% else %}—{% endif %}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Attempts" %}</th>
+                    <td>{{ run.attempts }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Last retry reason" %}</th>
+                    <td>
+                        {{ run.get_last_retry_reason_display }}
+                        {% if run.last_retry_at %}
+                            <span class="grd-muted">· {{ run.last_retry_at }}</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Output" %}</th>
+                    <td class="grd-links">
+                        {% if run.produced_item_id %}
+                            <a href="{% url 'item_preview' item_id=run.produced_item_id %}">{% trans "Produced item" %}</a>
+                            <a href="{% url 'item_lineage' item_pk=run.produced_item_id %}">{% trans "Lineage" %}</a>
+                        {% else %}
+                            <span class="grd-muted">{% trans "No output yet" %}</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Error" %}</th>
+                    <td>
+                        {% if run.error %}
+                            <pre class="grd-error">{{ run.error }}</pre>
+                        {% else %}
+                            <span class="grd-muted">—</span>
+                        {% endif %}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p><a href="{{ runs_url }}">← {% trans "Back to runs" %}</a></p>
+    </div>
+{% endblock %}

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_runs.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_runs.html
@@ -148,7 +148,8 @@
                                 <span class="gdr-badge gdr-badge--{{ row.run.status }}">{{ row.run.status }}</span>
                             </td>
                             <td>
-                                <span class="gdr-unit">{{ row.run.recipe_type }}[{{ row.run.unit_hash|slice:":8" }}]</span>
+                                <a class="gdr-unit"
+                                   href="{% url 'derived_product_run_detail' product_pk=product.pk run_pk=row.run.pk %}">{{ row.run.recipe_type }}[{{ row.run.unit_hash|slice:":8" }}]</a>
                             </td>
                             <td class="gdr-meta">{{ row.run.started_at|default:"—" }}</td>
                             <td class="gdr-meta">{{ row.run.completed_at|default:"—" }}</td>

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -342,3 +342,96 @@ class RunListViewTests(TestCase):
         response = self.client.get(self._url())
 
         self.assertContains(response, reverse("derived_product_tracking"))
+
+    def test_each_run_row_links_to_its_detail_page(self):
+        run = self._failed_run()
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, reverse(
+            "derived_product_run_detail",
+            kwargs={"product_pk": self.product.pk, "run_pk": run.pk},
+        ))
+
+
+class RunDetailViewTests(TestCase):
+    """The run-detail leaf (issue #212): exactly what happened for one run —
+    the screen that answers 'why did this fail'."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_rd", "d@test.com", "pw")
+        self.client.force_login(self.user)
+        self.catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        self.feed = DataFeed.objects.create(name="Rain Feed", catalog=self.catalog)
+        self.product = DerivedProduct.objects.create(
+            data_feed=self.feed, definition_key="anomaly", recipe_type="climatology",
+        )
+
+    def _run_rec(self, **overrides):
+        run = _run(product_origin(self.product), DerivationRun.Status.FAILED, unit={"n": 1})
+        if overrides:
+            DerivationRun.objects.filter(pk=run.pk).update(**overrides)
+            run.refresh_from_db()
+        return run
+
+    def _url(self, run):
+        return reverse(
+            "derived_product_run_detail",
+            kwargs={"product_pk": self.product.pk, "run_pk": run.pk},
+        )
+
+    def test_shows_full_error_and_status(self):
+        run = self._run_rec(error="Traceback: ValueError deep in the transform, full text")
+
+        response = self.client.get(self._url(run))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Traceback: ValueError deep in the transform, full text")
+        self.assertContains(response, "failed")
+
+    def test_shows_unit_identity(self):
+        from georiva.processing.recipe import unit_hash
+
+        run = self._run_rec()
+
+        response = self.client.get(self._url(run))
+
+        self.assertContains(response, "climatology")            # recipe type
+        self.assertContains(response, unit_hash({"n": 1}))      # full unit hash
+
+    def test_shows_attempts_and_retry_reason(self):
+        run = self._run_rec(
+            attempts=4,
+            last_retry_reason=DerivationRun.RetryReason.STALE_RUNNING_RECLAIM,
+        )
+
+        response = self.client.get(self._url(run))
+
+        self.assertContains(response, "4")                       # attempts
+        self.assertContains(response, "Stale RUNNING reclaimed")  # reason label
+
+    def test_completed_run_links_to_produced_item_and_lineage(self):
+        from datetime import datetime, timezone
+
+        from georiva.core.models import Item
+
+        col = Collection.objects.create(catalog=self.catalog, slug="out", name="out")
+        item = Item.objects.create(
+            collection=col, time=datetime(2020, 1, 1, tzinfo=timezone.utc)
+        )
+        run = self._run_rec(status=DerivationRun.Status.COMPLETED, produced_item=item)
+
+        response = self.client.get(self._url(run))
+
+        self.assertContains(response, reverse("item_preview", kwargs={"item_id": item.pk}))
+        self.assertContains(response, reverse("item_lineage", kwargs={"item_pk": item.pk}))
+
+    def test_run_without_output_shows_no_output_state_not_a_broken_link(self):
+        run = self._run_rec()  # failed, no produced_item
+
+        response = self.client.get(self._url(run))
+
+        self.assertContains(response, "No output yet")
+        self.assertNotContains(response, "/lineage/")

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1507,7 +1507,7 @@ def derived_product_runs(request, product_pk):
     from django.core.paginator import Paginator
 
     from georiva.processing.models import DerivationRun
-    from georiva.sources.derivation_tracking import product_runs
+    from georiva.sources.derivation_tracking import product_runs, run_duration_seconds
     from georiva.sources.models import DerivedProduct
 
     product = get_object_or_404(DerivedProduct, pk=product_pk)
@@ -1516,12 +1516,10 @@ def derived_product_runs(request, product_pk):
     paginator = Paginator(product_runs(product, status=status), 25)
     page = paginator.get_page(request.GET.get("page"))
 
-    rows = []
-    for run in page:
-        duration = None
-        if run.started_at and run.completed_at:
-            duration = (run.completed_at - run.started_at).total_seconds()
-        rows.append({"run": run, "duration": duration})
+    rows = [
+        {"run": run, "duration": run_duration_seconds(run)}
+        for run in page
+    ]
 
     context = {
         "breadcrumbs_items": [
@@ -1537,6 +1535,42 @@ def derived_product_runs(request, product_pk):
         "current_status": status or "",
     }
     return render(request, "georivasources/derived_product_runs.html", context)
+
+
+def derived_product_run_detail(request, product_pk, run_pk):
+    """
+    Run-detail leaf (ADR-0008, issue #212): exactly what happened for one
+    DerivationRun — full error, status, timings, unit identity, the retry story
+    (attempts + last_retry_reason), and links to the produced Item and its
+    lineage. Static (reflects current DB state on load); the engine is not
+    touched. The run is scoped to the product by its origin key.
+    """
+    from georiva.processing.models import DerivationRun
+    from georiva.sources.derivation_invocation import product_origin
+    from georiva.sources.derivation_tracking import run_duration_seconds
+    from georiva.sources.models import DerivedProduct
+
+    product = get_object_or_404(DerivedProduct, pk=product_pk)
+    run = get_object_or_404(
+        DerivationRun, pk=run_pk, origin=product_origin(product),
+    )
+
+    duration = run_duration_seconds(run)
+    runs_url = reverse("derived_product_runs", kwargs={"product_pk": product.pk})
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("data_feed_list"), "label": _("Data Feeds")},
+            {"url": reverse("derived_product_tracking"), "label": _("Derived Products")},
+            {"url": runs_url, "label": product.display_label},
+            {"url": "", "label": _("Run")},
+        ],
+        "product": product,
+        "run": run,
+        "duration": duration,
+        "runs_url": runs_url,
+    }
+    return render(request, "georivasources/derived_product_run_detail.html", context)
 
 
 def derived_product_chain(request, feed_pk):

--- a/georiva/src/georiva/sources/wagtail_hooks.py
+++ b/georiva/src/georiva/sources/wagtail_hooks.py
@@ -30,6 +30,7 @@ from .views import (
     wizard_provision,
     derived_product_tracking,
     derived_product_runs,
+    derived_product_run_detail,
     derived_product_chain,
     item_lineage,
 )
@@ -48,6 +49,8 @@ def urlconf_georivasources():
         path('data-feeds/derived-products/', derived_product_tracking, name="derived_product_tracking"),
         path('data-feeds/derived-products/<int:product_pk>/runs/', derived_product_runs,
              name="derived_product_runs"),
+        path('data-feeds/derived-products/<int:product_pk>/runs/<int:run_pk>/',
+             derived_product_run_detail, name="derived_product_run_detail"),
         path('data-feeds/<int:feed_pk>/chain/', derived_product_chain, name="derived_product_chain"),
         path('items/<int:item_pk>/lineage/', item_lineage, name="item_lineage"),
         path('data-feeds/select/', data_feed_add_select, name="data_feed_add_select"),


### PR DESCRIPTION
Closes #212 (part of #208). Builds on #209 + #211 (both merged).

## What this does

The **leaf** of the debugging drill-down: click a run in the run list to see exactly what happened — the screen that answers "why did this fail".

## Changes

- **`derived_product_run_detail` view** (sources) — renders one `DerivationRun`, scoped to the product by its `origin` key:
  - full `error` text (not a snippet), status, started/completed timestamps + duration;
  - unit identity (recipe type + version, full `unit_hash`, `unit_key`) to correlate with engine logs and reproduce the unit;
  - `attempts` + `last_retry_reason` / `last_retry_at` (from #209) — a code failure reads differently from an infrastructure reclaim;
  - a completed run links to its produced **Item** (`item_preview`) and that item's **lineage** (`item_lineage`);
  - a run with no `produced_item` shows a clear **"No output yet"** state, not a broken link.
- **Run-list rows now link** to the detail page.
- Static/read-only, breadcrumbs back to the run list + dashboard, behind the existing admin gating.
- Extracted a shared `run_duration_seconds()` helper so both the run-list and run-detail views stay dumb.

**The engine is not touched** — zero files under `processing/`.

## Testing (TDD)

Extends `test_derivation_tracking.py` (`RunDetailViewTests`), smoke-tested via `reverse()` + client:

- [x] 200 + full error text + status
- [x] Unit identity (recipe type + full hash)
- [x] `attempts` + retry-reason label
- [x] Completed run links to produced item + lineage
- [x] No `produced_item` → "No output yet", no broken lineage link
- [x] Each run-list row links to its detail page (red→green)

**205 sources tests pass; no regressions.**
