### PR TITLE
feat(sources): enrich dashboard row with live unit counts (#210)

### DIFF
--- a/georiva/src/georiva/sources/derivation_tracking.py
+++ b/georiva/src/georiva/sources/derivation_tracking.py
@@ -58,6 +58,12 @@ class ProductStatus:
     counts: dict = field(default_factory=dict)
     last_completed_at: datetime | None = None
 
+    @property
+    def done(self) -> int:
+        """Terminal successes, mirroring the engine's [progress] line (#205):
+        completed units plus idempotent skips."""
+        return self.counts.get("completed", 0) + self.counts.get("skipped", 0)
+
 
 def product_runs(product, *, status=None):
     """The product's DerivationRuns for the run-list drill-down (#211).

--- a/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
+++ b/georiva/src/georiva/sources/templates/georivasources/derived_product_tracking.html
@@ -149,9 +149,19 @@
                                 </span>
                             </td>
                             <td class="gdp-counts">
-                                {% blocktrans with n=row.status.total %}{{ n }} total{% endblocktrans %}
-                                {% if row.status.counts.failed %}
-                                    · {% blocktrans with n=row.status.counts.failed %}{{ n }} failed{% endblocktrans %}
+                                {% if row.status.total %}
+                                    {% blocktrans with done=row.status.done total=row.status.total %}{{ done }}/{{ total }} done{% endblocktrans %}
+                                    {% if row.status.counts.failed %}
+                                        · {% blocktrans with n=row.status.counts.failed %}{{ n }} failed{% endblocktrans %}
+                                    {% endif %}
+                                    {% if row.status.counts.running %}
+                                        · {% blocktrans with n=row.status.counts.running %}{{ n }} running{% endblocktrans %}
+                                    {% endif %}
+                                    {% if row.status.counts.not_ready %}
+                                        · {% blocktrans with n=row.status.counts.not_ready %}{{ n }} not ready{% endblocktrans %}
+                                    {% endif %}
+                                {% else %}
+                                    {% trans "No runs yet" %}
                                 {% endif %}
                             </td>
                             <td>

--- a/georiva/src/georiva/sources/tests/test_derivation_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_derivation_tracking.py
@@ -103,6 +103,19 @@ class ProductStatusTests(TestCase):
         self.assertEqual(status.counts.get("completed"), 2)
         self.assertEqual(status.counts.get("failed"), 1)
 
+    def test_done_tallies_completed_plus_skipped(self):
+        # "Done" mirrors the engine's [progress] line (#205): terminal successes
+        # are completed + idempotent skips.
+        _run(self._origin(), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(self._origin(), DerivationRun.Status.SKIPPED, unit={"n": 2})
+        _run(self._origin(), DerivationRun.Status.FAILED, unit={"n": 3})
+        _run(self._origin(), DerivationRun.Status.RUNNING, unit={"n": 4})
+
+        status = product_status(self.product)
+
+        self.assertEqual(status.done, 2)
+        self.assertEqual(status.total, 4)
+
     def test_another_products_runs_do_not_bleed_in(self):
         other = DerivedProduct.objects.create(
             data_feed=self.feed, definition_key="normals", recipe_type="climatology",
@@ -134,6 +147,26 @@ class TrackingViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "anomaly")   # the product is listed
         self.assertContains(response, "idle")      # no runs yet
+
+    def test_row_shows_enriched_done_failed_running_counts(self):
+        _run(product_origin(self.product), DerivationRun.Status.COMPLETED, unit={"n": 1})
+        _run(product_origin(self.product), DerivationRun.Status.COMPLETED, unit={"n": 2})
+        _run(product_origin(self.product), DerivationRun.Status.FAILED, unit={"n": 3})
+        _run(product_origin(self.product), DerivationRun.Status.RUNNING, unit={"n": 4})
+
+        response = self.client.get(reverse("derived_product_tracking"))
+
+        self.assertContains(response, "2/4 done")
+        self.assertContains(response, "1 failed")
+        self.assertContains(response, "1 running")
+
+    def test_row_with_no_runs_shows_a_clear_empty_state(self):
+        # The setUp product has no runs — it must read as "nothing has happened",
+        # not as an ambiguous "0/0 done".
+        response = self.client.get(reverse("derived_product_tracking"))
+
+        self.assertContains(response, "No runs yet")
+        self.assertNotContains(response, "0/0 done")
 
     def test_orphaned_product_shows_an_orphan_badge_linking_to_the_feed(self):
         # The base feed declares no products, so this row is an orphan.


### PR DESCRIPTION
Closes #210 (part of #208 — the final slice).

## What this does

Enriches each product row on the **Derived Products** dashboard so an operator can triage at a glance — the coarse `idle/running/failed/completed` badge becomes a live breakdown, without opening the product. It surfaces the same information as the engine's `[progress]` log line (#205), on screen instead of stdout.

## Changes

- **`ProductStatus.done`** = completed + skipped, mirroring the engine's `[progress]` "done" semantics (#205). A pure read-side property over the `counts` dict `product_status()` already builds — **no new query**.
- Each dashboard row now renders `{done}/{total} done · {n} failed · {n} running · {n} not ready` next to (not replacing) the existing status badge.
- A product with no runs reads **"No runs yet"**, distinct from an ambiguous `0/0 done`.
- Run-now / Enable-Disable actions unchanged; template follows conventions (no inline styles, `--w-color-*` tokens).

Pure read/template — **the engine is not touched** (zero `processing/` files).

## Testing (TDD)

- [x] `ProductStatus.done` tallies completed + skipped (function seam)
- [x] Row renders `2/4 done · 1 failed · 1 running` for a mixed set (template)
- [x] No-runs product shows "No runs yet", not `0/0 done`

**208 sources tests pass; no regressions.**

---

This completes the derived-product visibility epic (#208): dashboard counts → run-list → run-detail, backed by the persisted retry story.
