### PR TITLE
feat(sources): check-for-new-files dry run + fetch-now action (#222)

### DIFF
--- a/georiva/src/georiva/sources/loader.py
+++ b/georiva/src/georiva/sources/loader.py
@@ -22,6 +22,15 @@ from django.conf import settings
 
 
 @dataclass
+class CandidateFile:
+    """One file the source offers right now, classified against storage —
+    the unit of the read-only "check for new files" dry run (PRD #217)."""
+    filename: str
+    storage_path: str
+    exists: bool
+
+
+@dataclass
 class LoaderRunResult:
     """Result of a complete loader run."""
     started_at: datetime = field(default_factory=timezone.now)
@@ -169,7 +178,24 @@ class Loader:
     # =========================================================================
     # Main Run Method
     # =========================================================================
-    
+
+    def check_new_files(self) -> list[CandidateFile]:
+        """
+        Read-only dry run (PRD #217): ask the source what it would fetch for
+        this collection and classify each candidate against storage. Persists
+        nothing — no FetchRun/FetchedFile, no counters — and never connects
+        the fetch strategy.
+        """
+        requests = self.data_source.generate_requests_for_collection(self.collection)
+        return [
+            CandidateFile(
+                filename=request.filename,
+                storage_path=self._get_storage_path(request),
+                exists=self._already_exists(request),
+            )
+            for request in requests
+        ]
+
     def run(
             self,
             *,

--- a/georiva/src/georiva/sources/models.py
+++ b/georiva/src/georiva/sources/models.py
@@ -257,6 +257,27 @@ class DataFeed(PolymorphicModel, TimeStampedModel, ClusterableModel):
         next_run = self.last_run_at + timedelta(minutes=self.interval_minutes)
         return timezone.now() >= next_run
     
+    def check_new_files(self):
+        """
+        Synchronous "check for new files" dry run (PRD #217): ask the source
+        what it would fetch for each linked collection, classified against
+        storage. Purely informational — persists nothing and touches no feed
+        stats; fetching stays run_now's job.
+
+        Returns one dict per collection link:
+        {"collection", "candidates" (list of CandidateFile), "error"}.
+        """
+        results = []
+        for link in self.collection_links.select_related('collection'):
+            entry = {"collection": link.collection, "candidates": [], "error": None}
+            try:
+                loader = self.get_loader(link.collection)
+                entry["candidates"] = loader.check_new_files()
+            except Exception as exc:
+                entry["error"] = str(exc)
+            results.append(entry)
+        return results
+
     def run_now(self, collection=None, *, user=None, async_run: bool = True):
         """
         Dispatch a loader run.

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
@@ -440,6 +440,16 @@
                 <h3 class="gfeed-card__title">{% trans "Acquisition Activity" %}</h3>
                 <div class="gfeed-card__actions">
                     {% if feed.collection_links.exists %}
+                        <form class="gfeed-runs-form" method="post"
+                              action="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="check_new_files">
+                            <button class="button button-small button-secondary" type="submit">
+                                {% trans "Check for new files" %}
+                            </button>
+                        </form>
+                    {% endif %}
+                    {% if feed.collection_links.exists %}
                         <form class="gfeed-runs-form" method="post" action="{% url 'data_feed_detail' pk=feed.pk %}">
                             {% csrf_token %}
                             <input type="hidden" name="action" value="run_now">

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_fetch_runs.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_fetch_runs.html
@@ -103,6 +103,54 @@
             color: var(--w-color-grey-400);
         }
 
+        .gaq-actions {
+            display: flex;
+            gap: 0.6em;
+            align-items: center;
+        }
+
+        .gaq-actions form {
+            margin: 0;
+        }
+
+        .gaq-mono {
+            font-family: monospace;
+            font-size: 0.85em;
+            word-break: break-all;
+        }
+
+        .gaq-check {
+            margin-top: 1.2em;
+            padding: 1em 1.25em;
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+            background: var(--w-color-grey-50);
+        }
+
+        .gaq-check__title {
+            font-size: 0.85em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--w-color-grey-400);
+            margin: 0;
+        }
+
+        .gaq-check__collection {
+            font-size: 0.95em;
+            margin: 1em 0 0.3em;
+        }
+
+        .gaq-check__files {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .gaq-check__files li {
+            padding: 0.25em 0;
+        }
+
         .gaq-pagination {
             margin-top: 1.2em;
             font-size: 0.85em;
@@ -115,6 +163,53 @@
     {% include "wagtailadmin/shared/header.html" with title=feed.name subtitle=_("Acquisition Activity") icon="download" breadcrumbs=breadcrumbs_items %}
 
     <div class="nice-padding">
+        <div class="gaq-actions">
+            <form method="post" action="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="check_new_files">
+                <button class="button button-secondary" type="submit">{% trans "Check for new files" %}</button>
+            </form>
+            <form method="post" action="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="fetch_now">
+                <button class="button" type="submit">{% trans "Fetch now" %}</button>
+            </form>
+        </div>
+
+        {% if check_results is not None %}
+            <div class="gaq-check">
+                <h2 class="gaq-check__title">{% trans "Check results" %}</h2>
+                {% for entry in check_results %}
+                    <div class="gaq-check__group">
+                        <h3 class="gaq-check__collection">
+                            {{ entry.collection.name }}
+                            <span class="gaq-meta">
+                                — {% blocktrans with new=entry.new_count existing=entry.existing_count %}{{ new }} new · {{ existing }} existing{% endblocktrans %}
+                            </span>
+                        </h3>
+                        {% if entry.error %}
+                            <div class="gaq-error">{{ entry.error }}</div>
+                        {% elif entry.candidates %}
+                            <ul class="gaq-check__files">
+                                {% for candidate in entry.candidates %}
+                                    <li>
+                                        <span class="gaq-mono">{{ candidate.filename }}</span>
+                                        {% if candidate.exists %}
+                                            <span class="gaq-badge gaq-badge--cancelled">{% trans "already exists" %}</span>
+                                        {% else %}
+                                            <span class="gaq-badge gaq-badge--completed">{% trans "new" %}</span>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="gaq-meta">{% trans "Source offered no files." %}</p>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+
         <div class="gaq-filters">
             <span class="gaq-meta">{% trans "Filter" %}:</span>
             <a class="gaq-filter {% if not current_status %}gaq-filter--active{% endif %}"

--- a/georiva/src/georiva/sources/tests/test_acquisition_check.py
+++ b/georiva/src/georiva/sources/tests/test_acquisition_check.py
@@ -1,0 +1,226 @@
+"""
+"Check for new files" dry run + "Fetch now" (PRD #217, issue #222).
+
+The check is synchronous and ephemeral: it asks the source what it would
+fetch, classifies each candidate against storage, and persists nothing —
+no FetchRun/FetchedFile, no feed counter changes. "Fetch now" is the
+existing asynchronous run_now, unchanged.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from georiva.core.models import Catalog, Collection
+from georiva.sources.loader import Loader
+from georiva.sources.models import (
+    DataFeed,
+    DataFeedCollectionLink,
+    FetchedFile,
+    FetchRun,
+)
+
+
+User = get_user_model()
+
+
+def _feed_and_collection(name="CHIRPS", slug="chirps"):
+    catalog = Catalog.objects.create(name=name, slug=slug, file_format="geotiff")
+    collection = Collection.objects.create(
+        name="Rainfall", slug="rainfall", catalog=catalog
+    )
+    feed = DataFeed.objects.create(name=f"{name} Feed", catalog=catalog)
+    return feed, collection
+
+
+def _request(filename):
+    req = MagicMock()
+    req.filename = filename
+    req.reference_time = None
+    return req
+
+
+class LoaderCheckNewFilesTests(TestCase):
+    """Loader.check_new_files: the read-only dry run behind the check action."""
+
+    def setUp(self):
+        self.feed, self.collection = _feed_and_collection()
+
+    def _check(self, requests, exists_by_filename):
+        loader = Loader(
+            data_source=MagicMock(),
+            collection=self.collection,
+            data_feed=self.feed,
+        )
+        loader.data_source.generate_requests_for_collection.return_value = requests
+
+        with patch.object(
+            loader, "_already_exists",
+            side_effect=lambda req: exists_by_filename[req.filename],
+        ):
+            return loader.check_new_files()
+
+    def test_classifies_candidates_as_new_or_already_existing(self):
+        candidates = self._check(
+            [_request("new.tif"), _request("old.tif")],
+            {"new.tif": False, "old.tif": True},
+        )
+
+        by_name = {c.filename: c for c in candidates}
+        self.assertEqual(len(candidates), 2)
+        self.assertFalse(by_name["new.tif"].exists)
+        self.assertTrue(by_name["old.tif"].exists)
+        self.assertEqual(
+            by_name["new.tif"].storage_path, "chirps/rainfall/new.tif"
+        )
+
+    def test_persists_no_acquisition_records(self):
+        self._check([_request("new.tif")], {"new.tif": False})
+
+        self.assertEqual(FetchRun.objects.count(), 0)
+        self.assertEqual(FetchedFile.objects.count(), 0)
+
+
+class DataFeedCheckNewFilesTests(TestCase):
+    """DataFeed.check_new_files: the feed-level check the view action runs —
+    one result group per linked collection."""
+
+    def setUp(self):
+        self.feed, self.rainfall = _feed_and_collection()
+        self.wind = Collection.objects.create(
+            name="Wind", slug="wind", catalog=self.feed.catalog
+        )
+        DataFeedCollectionLink.objects.create(
+            data_feed=self.feed, collection=self.rainfall
+        )
+        DataFeedCollectionLink.objects.create(
+            data_feed=self.feed, collection=self.wind
+        )
+
+    def test_groups_candidates_per_linked_collection(self):
+        from georiva.sources.loader import CandidateFile
+
+        def loader_for(collection=None):
+            loader = MagicMock()
+            loader.check_new_files.return_value = [
+                CandidateFile(
+                    filename=f"{collection.slug}.tif",
+                    storage_path=f"chirps/{collection.slug}/{collection.slug}.tif",
+                    exists=(collection == self.wind),
+                )
+            ]
+            return loader
+
+        with patch.object(DataFeed, "get_loader", side_effect=loader_for):
+            results = self.feed.get_real_instance().check_new_files()
+
+        by_collection = {r["collection"]: r for r in results}
+        self.assertEqual(len(results), 2)
+        self.assertEqual(
+            [c.filename for c in by_collection[self.rainfall]["candidates"]],
+            ["rainfall.tif"],
+        )
+        self.assertEqual(
+            [c.filename for c in by_collection[self.wind]["candidates"]],
+            ["wind.tif"],
+        )
+
+    def test_check_leaves_feed_stats_untouched(self):
+        from georiva.sources.loader import CandidateFile
+
+        def loader_for(collection=None):
+            loader = MagicMock()
+            loader.check_new_files.return_value = [
+                CandidateFile("a.tif", "chirps/x/a.tif", exists=False)
+            ]
+            return loader
+
+        with patch.object(DataFeed, "get_loader", side_effect=loader_for):
+            self.feed.get_real_instance().check_new_files()
+
+        self.feed.refresh_from_db()
+        self.assertEqual(self.feed.total_runs, 0)
+        self.assertEqual(self.feed.total_files_fetched, 0)
+        self.assertIsNone(self.feed.last_run_at)
+
+    def test_a_failing_source_reports_per_collection_instead_of_raising(self):
+        def loader_for(collection=None):
+            loader = MagicMock()
+            if collection == self.rainfall:
+                loader.check_new_files.side_effect = ConnectionError("host down")
+            else:
+                loader.check_new_files.return_value = []
+            return loader
+
+        with patch.object(DataFeed, "get_loader", side_effect=loader_for):
+            results = self.feed.get_real_instance().check_new_files()
+
+        by_collection = {r["collection"]: r for r in results}
+        self.assertIn("host down", by_collection[self.rainfall]["error"])
+        self.assertIsNone(by_collection[self.wind]["error"])
+
+
+class CheckNewFilesViewTests(TestCase):
+    """The check/fetch actions on the Acquisition Activity page."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_check", "c@test.com", "pw")
+        self.client.force_login(self.user)
+        self.feed, self.rainfall = _feed_and_collection()
+        DataFeedCollectionLink.objects.create(
+            data_feed=self.feed, collection=self.rainfall
+        )
+
+    def _url(self):
+        return reverse("data_feed_fetch_runs", kwargs={"feed_pk": self.feed.pk})
+
+    def test_check_renders_results_grouped_per_collection(self):
+        from georiva.sources.loader import CandidateFile
+
+        canned = [{
+            "collection": self.rainfall,
+            "candidates": [
+                CandidateFile("fresh.tif", "chirps/rainfall/fresh.tif", exists=False),
+                CandidateFile("stale.tif", "chirps/rainfall/stale.tif", exists=True),
+            ],
+            "error": None,
+        }]
+
+        with patch.object(DataFeed, "check_new_files", return_value=canned):
+            response = self.client.post(self._url(), {"action": "check_new_files"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Rainfall")
+        self.assertContains(response, "fresh.tif")
+        self.assertContains(response, "stale.tif")
+
+    def test_check_with_nothing_on_offer_shows_a_clear_empty_state(self):
+        canned = [{"collection": self.rainfall, "candidates": [], "error": None}]
+
+        with patch.object(DataFeed, "check_new_files", return_value=canned):
+            response = self.client.post(self._url(), {"action": "check_new_files"})
+
+        self.assertContains(response, "Source offered no files")
+
+    def test_check_shows_a_source_error_instead_of_crashing(self):
+        canned = [{
+            "collection": self.rainfall, "candidates": [], "error": "host down",
+        }]
+
+        with patch.object(DataFeed, "check_new_files", return_value=canned):
+            response = self.client.post(self._url(), {"action": "check_new_files"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "host down")
+
+    def test_fetch_now_dispatches_the_feeds_async_run_and_confirms(self):
+        with patch.object(DataFeed, "run_now") as run_now:
+            response = self.client.post(
+                self._url(), {"action": "fetch_now"}, follow=True
+            )
+
+        run_now.assert_called_once()
+        self.assertEqual(run_now.call_args.kwargs.get("user"), self.user)
+        self.assertRedirects(response, self._url())
+        self.assertContains(response, "Fetch started")

--- a/georiva/src/georiva/sources/tests/test_acquisition_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_acquisition_tracking.py
@@ -274,3 +274,19 @@ class DataFeedDetailAcquisitionPanelTests(TestCase):
 
         self.assertContains(response, "90210")
         self.assertContains(response, "48151")
+
+    def test_panel_offers_the_check_for_new_files_action(self):
+        from georiva.core.models import Collection
+        from georiva.sources.models import DataFeedCollectionLink
+
+        collection = Collection.objects.create(
+            name="Rainfall", slug="rainfall", catalog=self.feed.catalog
+        )
+        DataFeedCollectionLink.objects.create(
+            data_feed=self.feed, collection=collection
+        )
+
+        response = self.client.get(self._detail_url())
+
+        self.assertContains(response, 'value="check_new_files"')
+        self.assertContains(response, "Check for new files")

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1549,6 +1549,26 @@ def data_feed_fetch_runs(request, feed_pk):
     from georiva.sources.models import FetchRun
 
     feed = get_object_or_404(DataFeed, pk=feed_pk)
+
+    # Synchronous, ephemeral dry run (PRD #217): results render on this POST
+    # response and are never persisted. Re-POSTing on refresh is harmless —
+    # the check is read-only.
+    if request.method == "POST" and request.POST.get("action") == "fetch_now":
+        feed.run_now(user=request.user)
+        messages.success(request, _("Fetch started for '%s'.") % feed.name)
+        return redirect("data_feed_fetch_runs", feed_pk=feed.pk)
+
+    check_results = None
+    if request.method == "POST" and request.POST.get("action") == "check_new_files":
+        check_results = [
+            {
+                **entry,
+                "new_count": sum(1 for c in entry["candidates"] if not c.exists),
+                "existing_count": sum(1 for c in entry["candidates"] if c.exists),
+            }
+            for entry in feed.get_real_instance().check_new_files()
+        ]
+
     status = request.GET.get("status") or None
 
     paginator = Paginator(feed_fetch_runs(feed, status=status), 25)
@@ -1571,6 +1591,7 @@ def data_feed_fetch_runs(request, feed_pk):
         "page": page,
         "statuses": FetchRun.Status.choices,
         "current_status": status or "",
+        "check_results": check_results,
     }
     return render(request, "georivasources/data_feed_fetch_runs.html", context)
 


### PR DESCRIPTION
Closes #222 (PRD #217).

The two acquisition actions (follow-up to #226/#227):

- `Loader.check_new_files()` — read-only dry run returning `CandidateFile` (filename, storage path, exists) per source candidate; never connects the fetch strategy, persists nothing
- `DataFeed.check_new_files()` — iterates collection links, groups candidates per collection, captures per-collection source errors instead of raising
- Acquisition Activity page: POST `check_new_files` renders grouped results synchronously on the response (new/existing badges, counts, empty state, error state); POST `fetch_now` dispatches the existing async `run_now` and redirects with a flash message
- Feed-detail panel gains the "Check for new files" button (gated on collection links, like Run Now)
- Feed stats (total_runs, last_run_at, counters) proven untouched by checks

Tests: 10 new across loader/model/view seams. Full `sources` + `ingestion` suites pass (505 tests).