### PR TITLE
feat(ingestion): check-unprocessed dry run + ingest-now action (#223)

### DIFF
--- a/georiva/src/georiva/ingestion/tasks.py
+++ b/georiva/src/georiva/ingestion/tasks.py
@@ -126,72 +126,45 @@ def sweep_unprocessed(sync: bool = False):
     # -----------------------------------------------------------------
     
     new_files = 0
-    
-    dispatch = process_incoming_file.delay if not sync else process_incoming_file.run
-    
-    for bucket_type in [BucketType.INCOMING, BucketType.SOURCES]:
-        bucket = storage.bucket(bucket_type)
-        files = bucket.list_files(recursive=True)
-        
-        logger.info("Found %d untracked files", len(files))
-        
-        for f in files:
-            path = f['path']
-            filename = Path(path).name
-            
-            # Skip placeholder and hidden files
-            if filename.startswith('.') or filename == '.keep':
-                continue
-            
-            # Skip if path doesn't match convention
-            try:
-                meta = validate_path(path)
-            except ValueError:
-                logger.debug("Skipping non-conforming path: %s", path)
-                continue
-            
-            # Skip if already tracked
-            if FileIngestion.is_known(bucket_type, path):
-                log = FileIngestion.objects.filter(
-                    bucket=bucket_type, file_path=path
-                ).first()
-                if log and (
-                        log.force_reingest or
-                        (log.status == FileIngestion.Status.COMPLETED and not log.has_live_data)
-                ):
-                    logger.warning(
-                        "Re-ingesting %s/%s (force=%s, live_data=%s)",
-                        bucket_type, path, log.force_reingest, log.has_live_data,
-                    )
-                    FileIngestion.reset_for_reingest(bucket_type, path)
-                    dispatch(
-                        file_path=path,
-                        origin_bucket=bucket_type,
-                        reference_time=(
-                            meta['reference_time'].isoformat()
-                            if meta.get('reference_time') else None
-                        ),
-                    )
-                continue
-            
-            logger.info("Found untracked file: %s/%s", bucket_type, path)
 
-            FileIngestion.register(
-                bucket=bucket_type,
-                file_path=path,
-                reference_time=meta.get('reference_time'),
+    dispatch = process_incoming_file.delay if not sync else process_incoming_file.run
+
+    from georiva.ingestion.unprocessed import find_unprocessed
+
+    for unprocessed in find_unprocessed():
+        reference_time_iso = (
+            unprocessed.reference_time.isoformat()
+            if unprocessed.reference_time else None
+        )
+
+        if unprocessed.reason == "reingest":
+            logger.warning(
+                "Re-ingesting %s/%s", unprocessed.bucket, unprocessed.file_path,
             )
-            
-            # Queue for processing
+            FileIngestion.reset_for_reingest(unprocessed.bucket, unprocessed.file_path)
             dispatch(
-                file_path=path,
-                origin_bucket=bucket_type,
-                reference_time=(
-                    meta['reference_time'].isoformat()
-                    if meta.get('reference_time') else None
-                ),
+                file_path=unprocessed.file_path,
+                origin_bucket=unprocessed.bucket,
+                reference_time=reference_time_iso,
+            )
+        elif unprocessed.reason == "untracked":
+            logger.info(
+                "Found untracked file: %s/%s",
+                unprocessed.bucket, unprocessed.file_path,
+            )
+            FileIngestion.register(
+                bucket=unprocessed.bucket,
+                file_path=unprocessed.file_path,
+                reference_time=unprocessed.reference_time,
+            )
+            dispatch(
+                file_path=unprocessed.file_path,
+                origin_bucket=unprocessed.bucket,
+                reference_time=reference_time_iso,
             )
             new_files += 1
+        # 'pending' records already await a dispatched task — the sweep
+        # leaves them alone (unchanged behavior).
     
     if new_files:
         logger.info("Queued %d untracked files", new_files)

--- a/georiva/src/georiva/ingestion/tests/test_consumer.py
+++ b/georiva/src/georiva/ingestion/tests/test_consumer.py
@@ -75,9 +75,11 @@ class SweepDirectFileIngestionTests(TestCase):
         def _bucket_side_effect(bucket_type):
             return sources_bucket if bucket_type == BT.SOURCES else incoming_bucket
 
+        # The bucket scan lives in ingestion.unprocessed (issue #223); the
+        # storage boundary is mocked there.
         with (
-            patch("georiva.ingestion.tasks.storage") as mock_storage,
-            patch("georiva.ingestion.tasks.validate_path") as mock_vp,
+            patch("georiva.ingestion.unprocessed.storage") as mock_storage,
+            patch("georiva.ingestion.unprocessed.validate_path") as mock_vp,
             patch("georiva.ingestion.tasks.process_incoming_file") as mock_task,
         ):
             mock_storage.bucket.side_effect = _bucket_side_effect

--- a/georiva/src/georiva/ingestion/tests/test_unprocessed.py
+++ b/georiva/src/georiva/ingestion/tests/test_unprocessed.py
@@ -1,0 +1,103 @@
+"""
+find_unprocessed (PRD #217, issue #223): the bucket-scan behind both the
+periodic Sweep and the feed page's "Check unprocessed files" action.
+
+Storage listing is mocked (like the sweep tests) — the behavior under test
+is classification and prefix scoping, not MinIO I/O.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from georiva.core.storage import BucketType
+from georiva.ingestion.models import FileIngestion
+from georiva.ingestion.unprocessed import find_unprocessed
+
+
+def _scan(listing_by_bucket, prefix=None):
+    """Run find_unprocessed against a mocked storage layout:
+    {BucketType.X: [path, ...]}."""
+    def bucket_for(bucket_type):
+        bucket = MagicMock()
+        bucket.list_files.return_value = [
+            {"path": p} for p in listing_by_bucket.get(bucket_type, [])
+        ]
+        return bucket
+
+    with patch("georiva.ingestion.unprocessed.storage") as mock_storage:
+        mock_storage.bucket.side_effect = bucket_for
+        return find_unprocessed(prefix=prefix)
+
+
+class FindUnprocessedClassificationTests(TestCase):
+    def test_classifies_untracked_pending_and_reingest_and_skips_in_flight(self):
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES, file_path="cat/col/pending.tif",
+            status=FileIngestion.Status.PENDING,
+        )
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES, file_path="cat/col/reingest.tif",
+            status=FileIngestion.Status.COMPLETED, force_reingest=True,
+        )
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES, file_path="cat/col/busy.tif",
+            status=FileIngestion.Status.PROCESSING,
+        )
+
+        found = _scan({
+            BucketType.SOURCES: [
+                "cat/col/untracked.tif",
+                "cat/col/pending.tif",
+                "cat/col/reingest.tif",
+                "cat/col/busy.tif",
+                ".keep",
+            ],
+        })
+
+        by_path = {f.file_path: f.reason for f in found}
+        self.assertEqual(by_path, {
+            "cat/col/untracked.tif": "untracked",
+            "cat/col/pending.tif": "pending",
+            "cat/col/reingest.tif": "reingest",
+        })
+        self.assertEqual({f.bucket for f in found}, {BucketType.SOURCES})
+
+    def test_force_reingest_wins_regardless_of_status(self):
+        # The pre-refactor sweep re-ingested any force_reingest record, not
+        # only completed ones — the refactor must not lose that.
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES, file_path="cat/col/forced-failed.tif",
+            status=FileIngestion.Status.FAILED, force_reingest=True,
+        )
+        FileIngestion.objects.create(
+            bucket=BucketType.SOURCES, file_path="cat/col/forced-pending.tif",
+            status=FileIngestion.Status.PENDING, force_reingest=True,
+        )
+
+        found = _scan({
+            BucketType.SOURCES: [
+                "cat/col/forced-failed.tif", "cat/col/forced-pending.tif",
+            ],
+        })
+
+        self.assertEqual(
+            {f.file_path: f.reason for f in found},
+            {
+                "cat/col/forced-failed.tif": "reingest",
+                "cat/col/forced-pending.tif": "reingest",
+            },
+        )
+
+    def test_prefix_scopes_the_scan_to_one_catalog(self):
+        found = _scan(
+            {
+                BucketType.INCOMING: ["chirps/col/a.tif", "other/col/b.tif"],
+                BucketType.SOURCES: ["chirps/col/c.tif"],
+            },
+            prefix="chirps/",
+        )
+
+        self.assertCountEqual(
+            [f.file_path for f in found],
+            ["chirps/col/a.tif", "chirps/col/c.tif"],
+        )

--- a/georiva/src/georiva/ingestion/unprocessed.py
+++ b/georiva/src/georiva/ingestion/unprocessed.py
@@ -1,0 +1,109 @@
+"""
+Unprocessed-file scan (PRD #217, issue #223).
+
+The bucket-scan phase of the periodic Sweep, extracted so the feed-scoped
+"Check unprocessed files" action can run it read-only under a catalog
+prefix. Classifies every conforming file in the incoming/sources buckets:
+
+- ``untracked`` — no FileIngestion record at all (the webhook missed it)
+- ``pending``   — registered but never processed (a lost dispatch)
+- ``reingest``  — completed-but-dead data or an operator-forced re-ingest
+
+In-flight (processing) and failed records are not the scan's business —
+failures are the Sweep's bounded-retry phase.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from georiva.core.filename import validate_path
+from georiva.core.storage import BucketType, storage
+
+
+@dataclass
+class UnprocessedFile:
+    bucket: str
+    file_path: str
+    reason: str  # 'untracked' | 'pending' | 'reingest'
+    reference_time: Optional[datetime] = None
+
+
+def ingest_unprocessed(found: list[UnprocessedFile]) -> int:
+    """Queue Ingestion for a find_unprocessed() result: register untracked
+    files, reset reingest candidates, and dispatch one processing task per
+    file (pending files just get their lost dispatch re-sent)."""
+    from georiva.ingestion import tasks
+    from georiva.ingestion.models import FileIngestion
+
+    for unprocessed_file in found:
+        if unprocessed_file.reason == "untracked":
+            FileIngestion.register(
+                bucket=unprocessed_file.bucket,
+                file_path=unprocessed_file.file_path,
+                reference_time=unprocessed_file.reference_time,
+            )
+        elif unprocessed_file.reason == "reingest":
+            FileIngestion.reset_for_reingest(
+                unprocessed_file.bucket, unprocessed_file.file_path
+            )
+        tasks.process_incoming_file.delay(
+            file_path=unprocessed_file.file_path,
+            origin_bucket=unprocessed_file.bucket,
+            reference_time=(
+                unprocessed_file.reference_time.isoformat()
+                if unprocessed_file.reference_time else None
+            ),
+        )
+    return len(found)
+
+
+def find_unprocessed(prefix: str | None = None) -> list[UnprocessedFile]:
+    """Scan the incoming and sources buckets (optionally under a path
+    prefix) and classify files needing Ingestion. Read-only: registers
+    nothing, dispatches nothing."""
+    from georiva.ingestion.models import FileIngestion
+
+    found = []
+    for bucket_type in [BucketType.INCOMING, BucketType.SOURCES]:
+        bucket = storage.bucket(bucket_type)
+        for f in bucket.list_files(recursive=True):
+            path = f["path"]
+            filename = Path(path).name
+
+            if filename.startswith(".") or filename == ".keep":
+                continue
+            if prefix and not path.startswith(prefix):
+                continue
+            try:
+                meta = validate_path(path)
+            except ValueError:
+                continue
+
+            record = FileIngestion.objects.filter(
+                bucket=bucket_type, file_path=path
+            ).first()
+
+            if record is None:
+                reason = "untracked"
+            elif record.force_reingest or (
+                record.status == FileIngestion.Status.COMPLETED
+                and not record.has_live_data
+            ):
+                # force_reingest wins regardless of status — matches the
+                # pre-extraction sweep.
+                reason = "reingest"
+            elif record.status == FileIngestion.Status.PENDING:
+                reason = "pending"
+            else:
+                continue
+
+            found.append(UnprocessedFile(
+                bucket=bucket_type,
+                file_path=path,
+                reason=reason,
+                reference_time=meta.get("reference_time"),
+            ))
+    return found

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
@@ -567,6 +567,14 @@
             <div class="gfeed-card__header">
                 <h3 class="gfeed-card__title">{% trans "Ingestion Activity" %}</h3>
                 <div class="gfeed-card__actions">
+                    <form class="gfeed-runs-form" method="post"
+                          action="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="check_unprocessed">
+                        <button class="button button-small button-secondary" type="submit">
+                            {% trans "Check unprocessed files" %}
+                        </button>
+                    </form>
                     <a class="button button-small button-secondary"
                        href="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">{% trans "View all" %}</a>
                 </div>

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_ingestions.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_ingestions.html
@@ -109,6 +109,43 @@
             color: var(--w-color-grey-400);
         }
 
+        .ging-actions {
+            display: flex;
+            gap: 0.6em;
+            align-items: center;
+        }
+
+        .ging-actions form {
+            margin: 0;
+        }
+
+        .ging-check {
+            margin-top: 1.2em;
+            padding: 1em 1.25em;
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+            background: var(--w-color-grey-50);
+        }
+
+        .ging-check__title {
+            font-size: 0.85em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--w-color-grey-400);
+            margin: 0 0 0.6em;
+        }
+
+        .ging-check__files {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .ging-check__files li {
+            padding: 0.25em 0;
+        }
+
         .ging-pagination {
             margin-top: 1.2em;
             font-size: 0.85em;
@@ -121,6 +158,37 @@
     {% include "wagtailadmin/shared/header.html" with title=feed.name subtitle=_("Ingestion Activity") icon="cogs" breadcrumbs=breadcrumbs_items %}
 
     <div class="nice-padding">
+        <div class="ging-actions">
+            <form method="post" action="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="check_unprocessed">
+                <button class="button button-secondary" type="submit">{% trans "Check unprocessed files" %}</button>
+            </form>
+            <form method="post" action="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="ingest_now">
+                <button class="button" type="submit">{% trans "Ingest now" %}</button>
+            </form>
+        </div>
+
+        {% if check_results is not None %}
+            <div class="ging-check">
+                <h2 class="ging-check__title">{% trans "Unprocessed files in MinIO" %}</h2>
+                {% if check_results %}
+                    <ul class="ging-check__files">
+                        {% for found in check_results %}
+                            <li>
+                                <span class="ging-mono">{{ found.bucket }}/{{ found.file_path }}</span>
+                                <span class="ging-badge ging-badge--pending">{{ found.reason }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="ging-meta">{% trans "No unprocessed files under this feed's catalog." %}</p>
+                {% endif %}
+            </div>
+        {% endif %}
+
         <div class="ging-filters">
             <span class="ging-meta">{% trans "Status" %}:</span>
             <a class="ging-filter {% if not current_status %}ging-filter--active{% endif %}"

--- a/georiva/src/georiva/sources/tests/test_ingestion_activity.py
+++ b/georiva/src/georiva/sources/tests/test_ingestion_activity.py
@@ -164,6 +164,106 @@ class IngestionActivityViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
 
 
+class CheckUnprocessedViewTests(TestCase):
+    """The check/ingest actions on the Ingestion Activity page (issue #223)."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_chk", "k@test.com", "pw")
+        self.client.force_login(self.user)
+        self.feed = _feed()
+
+    def _url(self):
+        return reverse("data_feed_ingestions", kwargs={"feed_pk": self.feed.pk})
+
+    def _found(self, *paths, reason="untracked"):
+        from georiva.ingestion.unprocessed import UnprocessedFile
+        return [
+            UnprocessedFile(bucket="sources", file_path=p, reason=reason)
+            for p in paths
+        ]
+
+    def test_check_renders_the_scoped_scan_results(self):
+        from unittest.mock import patch
+
+        with patch(
+            "georiva.ingestion.unprocessed.find_unprocessed",
+            return_value=self._found("chirps/rainfall/stuck.grib"),
+        ) as find:
+            response = self.client.post(self._url(), {"action": "check_unprocessed"})
+
+        find.assert_called_once_with(prefix="chirps/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "chirps/rainfall/stuck.grib")
+        self.assertContains(response, "untracked")
+
+    def test_check_with_a_clean_bucket_shows_a_clear_empty_state(self):
+        from unittest.mock import patch
+
+        with patch(
+            "georiva.ingestion.unprocessed.find_unprocessed", return_value=[]
+        ):
+            response = self.client.post(self._url(), {"action": "check_unprocessed"})
+
+        self.assertContains(response, "No unprocessed files")
+
+    def test_ingest_now_registers_resets_and_dispatches_per_file(self):
+        from unittest.mock import patch
+
+        FileIngestion.objects.create(
+            bucket="sources", file_path="chirps/rainfall/pending.grib",
+            status=FileIngestion.Status.PENDING,
+        )
+        FileIngestion.objects.create(
+            bucket="sources", file_path="chirps/rainfall/dead.grib",
+            status=FileIngestion.Status.COMPLETED, force_reingest=True,
+        )
+        found = (
+            self._found("chirps/rainfall/new.grib", reason="untracked")
+            + self._found("chirps/rainfall/pending.grib", reason="pending")
+            + self._found("chirps/rainfall/dead.grib", reason="reingest")
+        )
+
+        with (
+            patch("georiva.ingestion.unprocessed.find_unprocessed",
+                  return_value=found),
+            patch("georiva.ingestion.tasks.process_incoming_file") as task,
+        ):
+            response = self.client.post(
+                self._url(), {"action": "ingest_now"}, follow=True
+            )
+
+        dispatched = {c.kwargs["file_path"] for c in task.delay.call_args_list}
+        self.assertEqual(dispatched, {
+            "chirps/rainfall/new.grib",
+            "chirps/rainfall/pending.grib",
+            "chirps/rainfall/dead.grib",
+        })
+        # The untracked file now has a FileIngestion; the dead one was reset.
+        self.assertTrue(FileIngestion.objects.filter(
+            file_path="chirps/rainfall/new.grib").exists())
+        self.assertEqual(
+            FileIngestion.objects.get(file_path="chirps/rainfall/dead.grib").status,
+            FileIngestion.Status.PENDING,
+        )
+        self.assertRedirects(response, self._url())
+        self.assertContains(response, "3 file(s) queued for ingestion")
+
+    def test_ingest_now_with_nothing_found_explains_itself(self):
+        from unittest.mock import patch
+
+        with (
+            patch("georiva.ingestion.unprocessed.find_unprocessed",
+                  return_value=[]),
+            patch("georiva.ingestion.tasks.process_incoming_file") as task,
+        ):
+            response = self.client.post(
+                self._url(), {"action": "ingest_now"}, follow=True
+            )
+
+        task.delay.assert_not_called()
+        self.assertContains(response, "No unprocessed files")
+
+
 class DataFeedDetailIngestionPanelTests(TestCase):
     """The compact ingestion panel on the feed detail page: recent records +
     a "View all" link to the Ingestion Activity page."""
@@ -193,3 +293,11 @@ class DataFeedDetailIngestionPanelTests(TestCase):
             reverse("data_feed_ingestions", kwargs={"feed_pk": self.feed.pk}),
         )
         self.assertContains(response, "recent-orphan.grib")
+
+    def test_panel_offers_the_check_unprocessed_action(self):
+        response = self.client.get(
+            reverse("data_feed_detail", kwargs={"pk": self.feed.pk})
+        )
+
+        self.assertContains(response, 'value="check_unprocessed"')
+        self.assertContains(response, "Check unprocessed files")

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1617,6 +1617,24 @@ def data_feed_ingestions(request, feed_pk):
     from georiva.ingestion.models import FileIngestion
 
     feed = get_object_or_404(DataFeed, pk=feed_pk)
+
+    # Synchronous, ephemeral dry run (PRD #217): scan MinIO under the feed's
+    # catalog prefix; results render on this POST response, nothing persists.
+    check_results = None
+    if request.method == "POST" and request.POST.get("action") == "check_unprocessed":
+        from georiva.ingestion import unprocessed
+        check_results = unprocessed.find_unprocessed(prefix=f"{feed.catalog.slug}/")
+
+    if request.method == "POST" and request.POST.get("action") == "ingest_now":
+        from georiva.ingestion import unprocessed
+        found = unprocessed.find_unprocessed(prefix=f"{feed.catalog.slug}/")
+        if found:
+            queued = unprocessed.ingest_unprocessed(found)
+            messages.success(request, _("%d file(s) queued for ingestion.") % queued)
+        else:
+            messages.info(request, _("No unprocessed files under this feed's catalog."))
+        return redirect("data_feed_ingestions", feed_pk=feed.pk)
+
     status = request.GET.get("status") or None
 
     collections = Collection.objects.filter(catalog=feed.catalog).order_by("name")
@@ -1646,6 +1664,7 @@ def data_feed_ingestions(request, feed_pk):
         "collections": collections,
         "current_collection": raw_collection or "",
         "no_collection_value": NO_COLLECTION,
+        "check_results": check_results,
     }
     return render(request, "georivasources/data_feed_ingestions.html", context)
 


### PR DESCRIPTION
Closes #223 (PRD #217).

- New `ingestion/unprocessed.py`:
  - `find_unprocessed(prefix=None)` — the Sweep's bucket-scan phase, extracted and prefix-scopable; read-only. Classifies `untracked` (no record), `pending` (lost dispatch), `reingest` (force_reingest — any status, matching pre-extraction behavior — or completed without live data). In-flight/failed records are not its business.
  - `ingest_unprocessed(found)` — registers untracked files, resets reingest candidates, dispatches one `process_incoming_file` per file
- `sweep_unprocessed` phase 2 now delegates to `find_unprocessed()`; behavior unchanged (pending still left alone; guarded by the existing sweep test, whose storage mocks moved to the new boundary)
- Ingestion Activity page: POST `check_unprocessed` renders the scoped scan synchronously (nothing persisted, empty state included); POST `ingest_now` re-runs it non-dry, redirects, and flashes the queued count
- Feed-detail ingestion panel gains the "Check unprocessed files" button

Tests: 8 new (scan classification/prefix seam + view seam). One subtle catch during the refactor: the old sweep re-ingested `force_reingest` records of ANY status — a test now pins that. Full `sources` + `ingestion` suites pass (536 tests).