### PR TITLE
feat(ingestion): reingest actions for failed FileIngestions + snapshot fix (#224, #220)

### DIFF
--- a/georiva/src/georiva/ingestion/acquisition_snapshot.py
+++ b/georiva/src/georiva/ingestion/acquisition_snapshot.py
@@ -8,7 +8,7 @@ def _build_fetch_run_dict(run) -> dict:
     files = [
         {
             "id": ff.pk,
-            "filename": ff.filename,
+            "file_path": ff.file_path,
             "status": ff.status,
             "bytes_transferred": ff.bytes_transferred,
             "error": ff.error or "",

--- a/georiva/src/georiva/ingestion/tests/test_acquisition_snapshot.py
+++ b/georiva/src/georiva/ingestion/tests/test_acquisition_snapshot.py
@@ -1,0 +1,35 @@
+"""
+Acquisition Feed snapshot (issue #220): FetchedFile entries serialize via
+file_path — the model has no `filename` attribute, and reading one crashed
+the snapshot whenever a run had per-file records.
+"""
+from asgiref.sync import async_to_sync
+
+from django.test import TestCase
+
+from georiva.core.models import Catalog
+from georiva.ingestion.acquisition_snapshot import build_acquisition_snapshot
+from georiva.sources.models import DataFeed, FetchedFile, FetchRun
+
+
+class AcquisitionSnapshotTests(TestCase):
+    def test_snapshot_serializes_fetched_files_by_path(self):
+        catalog = Catalog.objects.create(
+            name="CHIRPS", slug="chirps", file_format="geotiff"
+        )
+        feed = DataFeed.objects.create(name="Feed", catalog=catalog)
+        run = FetchRun.objects.create(
+            data_feed=feed, status=FetchRun.Status.COMPLETED,
+        )
+        FetchedFile.objects.create(
+            fetch_run=run,
+            file_path="chirps/rainfall/rain.tif",
+            status=FetchedFile.Status.STORED,
+        )
+
+        snapshot = async_to_sync(build_acquisition_snapshot)()
+
+        run_entry = next(i for i in snapshot if i["type"] == "fetch_run")
+        self.assertEqual(
+            run_entry["files"][0]["file_path"], "chirps/rainfall/rain.tif"
+        )

--- a/georiva/src/georiva/ingestion/unprocessed.py
+++ b/georiva/src/georiva/ingestion/unprocessed.py
@@ -60,6 +60,28 @@ def ingest_unprocessed(found: list[UnprocessedFile]) -> int:
     return len(found)
 
 
+def reingest_records(records) -> int:
+    """Queue reingestion for FileIngestion records: reset each (state,
+    retries, results) and dispatch one processing task per file — the same
+    plumbing the MinIO consumer and upload views use (PRD #217, #224)."""
+    from georiva.ingestion import tasks
+    from georiva.ingestion.models import FileIngestion
+
+    count = 0
+    for record in records:
+        FileIngestion.reset_for_reingest(record.bucket, record.file_path)
+        tasks.process_incoming_file.delay(
+            file_path=record.file_path,
+            origin_bucket=record.bucket,
+            reference_time=(
+                record.reference_time.isoformat()
+                if record.reference_time else None
+            ),
+        )
+        count += 1
+    return count
+
+
 def find_unprocessed(prefix: str | None = None) -> list[UnprocessedFile]:
     """Scan the incoming and sources buckets (optionally under a path
     prefix) and classify files needing Ingestion. Read-only: registers

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_ingestions.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_ingestions.html
@@ -146,6 +146,14 @@
             padding: 0.25em 0;
         }
 
+        .ging-select {
+            width: 2em;
+        }
+
+        .ging-bulk {
+            margin-top: 1em;
+        }
+
         .ging-pagination {
             margin-top: 1.2em;
             font-size: 0.85em;
@@ -211,48 +219,75 @@
         </div>
 
         {% if records %}
-            <table class="ging-table">
-                <thead>
-                    <tr>
-                        <th>{% trans "Status" %}</th>
-                        <th>{% trans "File" %}</th>
-                        <th>{% trans "Collections" %}</th>
-                        <th class="ging-num">{% trans "Retries" %}</th>
-                        <th class="ging-num">{% trans "Items" %}</th>
-                        <th class="ging-num">{% trans "Assets" %}</th>
-                        <th>{% trans "Updated" %}</th>
-                        <th>{% trans "Error" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for record in records %}
+            <form method="post" action="{% url 'data_feed_ingestions' feed_pk=feed.pk %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}">
+                {% csrf_token %}
+                <table class="ging-table">
+                    <thead>
                         <tr>
-                            <td>
-                                <span class="ging-badge ging-badge--{{ record.status }}">{{ record.get_status_display }}</span>
-                            </td>
-                            <td><span class="ging-mono">{{ record.file_path }}</span></td>
-                            <td>
-                                {% for collection in record.collections.all %}
-                                    {{ collection.name }}{% if not forloop.last %}, {% endif %}
-                                {% empty %}
-                                    <span class="ging-meta">—</span>
-                                {% endfor %}
-                            </td>
-                            <td class="ging-num">{{ record.retry_count }}</td>
-                            <td class="ging-num">{{ record.items_created }}</td>
-                            <td class="ging-num">{{ record.assets_created }}</td>
-                            <td class="ging-meta">{{ record.updated_at|default:"—" }}</td>
-                            <td>
-                                {% if record.error %}
-                                    <div class="ging-error">{{ record.error|truncatechars:200 }}</div>
-                                {% else %}
-                                    <span class="ging-meta">—</span>
-                                {% endif %}
-                            </td>
+                            <th class="ging-select">
+                                <input type="checkbox" id="ging-select-all"
+                                       aria-label="{% trans 'Select all failed records' %}">
+                            </th>
+                            <th>{% trans "Status" %}</th>
+                            <th>{% trans "File" %}</th>
+                            <th>{% trans "Collections" %}</th>
+                            <th class="ging-num">{% trans "Retries" %}</th>
+                            <th class="ging-num">{% trans "Items" %}</th>
+                            <th class="ging-num">{% trans "Assets" %}</th>
+                            <th>{% trans "Updated" %}</th>
+                            <th>{% trans "Error" %}</th>
+                            <th></th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for record in records %}
+                            <tr>
+                                <td class="ging-select">
+                                    {% if record.status == "failed" %}
+                                        <input type="checkbox" name="record_ids"
+                                               value="{{ record.pk }}"
+                                               aria-label="{% trans 'Select record for reingestion' %}">
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <span class="ging-badge ging-badge--{{ record.status }}">{{ record.get_status_display }}</span>
+                                </td>
+                                <td><span class="ging-mono">{{ record.file_path }}</span></td>
+                                <td>
+                                    {% for collection in record.collections.all %}
+                                        {{ collection.name }}{% if not forloop.last %}, {% endif %}
+                                    {% empty %}
+                                        <span class="ging-meta">—</span>
+                                    {% endfor %}
+                                </td>
+                                <td class="ging-num">{{ record.retry_count }}</td>
+                                <td class="ging-num">{{ record.items_created }}</td>
+                                <td class="ging-num">{{ record.assets_created }}</td>
+                                <td class="ging-meta">{{ record.updated_at|default:"—" }}</td>
+                                <td>
+                                    {% if record.error %}
+                                        <div class="ging-error">{{ record.error|truncatechars:200 }}</div>
+                                    {% else %}
+                                        <span class="ging-meta">—</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if record.status == "failed" %}
+                                        <button class="button button-small button-secondary"
+                                                type="submit" name="reingest_id"
+                                                value="{{ record.pk }}">{% trans "Reingest" %}</button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="ging-bulk">
+                    <button class="button" type="submit" name="action" value="reingest_selected">
+                        {% trans "Reingest selected" %}
+                    </button>
+                </div>
+            </form>
 
             {% if page.paginator.num_pages > 1 %}
                 <div class="ging-pagination">
@@ -269,4 +304,22 @@
             <p class="ging-empty">{% trans "No ingestion records yet for this feed." %}</p>
         {% endif %}
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const selectAll = document.getElementById('ging-select-all');
+            if (!selectAll) {
+                return;
+            }
+            const boxes = document.querySelectorAll('input[name="record_ids"]');
+            selectAll.addEventListener('change', function () {
+                for (const box of boxes) {
+                    box.checked = selectAll.checked;
+                }
+            });
+        });
+    </script>
 {% endblock %}

--- a/georiva/src/georiva/sources/tests/test_ingestion_activity.py
+++ b/georiva/src/georiva/sources/tests/test_ingestion_activity.py
@@ -264,6 +264,114 @@ class CheckUnprocessedViewTests(TestCase):
         self.assertContains(response, "No unprocessed files")
 
 
+class ReingestUITests(TestCase):
+    """Reingest affordances on the Ingestion Activity page (issue #224):
+    per-row buttons and bulk checkboxes on failed rows only."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("admin_rei", "re@test.com", "pw")
+        self.client.force_login(self.user)
+        self.feed = _feed()
+
+    def _url(self):
+        return reverse("data_feed_ingestions", kwargs={"feed_pk": self.feed.pk})
+
+    def test_only_failed_rows_offer_reingest(self):
+        failed = _ingestion(
+            self.feed, "bad.grib", status=FileIngestion.Status.FAILED,
+        )
+        _ingestion(self.feed, "good.grib")  # completed
+        _ingestion(self.feed, "busy.grib", status=FileIngestion.Status.PROCESSING)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, 'name="reingest_id"', count=1)
+        self.assertContains(response, 'type="checkbox" name="record_ids"', count=1)
+        self.assertContains(response, f'value="{failed.pk}"', count=2)  # button + box
+
+    def test_single_reingest_resets_the_record_and_queues_processing(self):
+        from unittest.mock import patch
+
+        failed = _ingestion(
+            self.feed, "bad.grib",
+            status=FileIngestion.Status.FAILED,
+            error="boom", retry_count=3,
+        )
+
+        with patch("georiva.ingestion.tasks.process_incoming_file") as task:
+            response = self.client.post(
+                self._url(), {"reingest_id": failed.pk}, follow=True
+            )
+
+        failed.refresh_from_db()
+        self.assertEqual(failed.status, FileIngestion.Status.PENDING)
+        self.assertEqual(failed.error, "")
+        task.delay.assert_called_once()
+        self.assertEqual(
+            task.delay.call_args.kwargs["file_path"], failed.file_path
+        )
+        self.assertRedirects(response, self._url())
+        self.assertContains(response, "Reingestion queued for 1 file(s)")
+
+    def test_bulk_reingest_queues_each_selected_failed_record(self):
+        from unittest.mock import patch
+
+        first = _ingestion(
+            self.feed, "one.grib", status=FileIngestion.Status.FAILED,
+        )
+        second = _ingestion(
+            self.feed, "two.grib", status=FileIngestion.Status.FAILED,
+        )
+        completed = _ingestion(self.feed, "fine.grib")
+
+        with patch("georiva.ingestion.tasks.process_incoming_file") as task:
+            response = self.client.post(
+                self._url(),
+                {"action": "reingest_selected",
+                 "record_ids": [first.pk, second.pk, completed.pk, "junk"]},
+                follow=True,
+            )
+
+        dispatched = {c.kwargs["file_path"] for c in task.delay.call_args_list}
+        self.assertEqual(
+            dispatched, {first.file_path, second.file_path}
+        )
+        completed.refresh_from_db()
+        self.assertEqual(completed.status, FileIngestion.Status.COMPLETED)
+        self.assertContains(response, "Reingestion queued for 2 file(s)")
+
+    def test_crafted_reingest_outside_the_feed_or_unselected_queues_nothing(self):
+        from unittest.mock import patch
+
+        other_feed = _feed(name="Other", slug="other")
+        foreign = _ingestion(
+            other_feed, "foreign.grib", status=FileIngestion.Status.FAILED,
+        )
+
+        with patch("georiva.ingestion.tasks.process_incoming_file") as task:
+            crafted = self.client.post(
+                self._url(), {"reingest_id": foreign.pk}, follow=True
+            )
+            empty = self.client.post(
+                self._url(), {"action": "reingest_selected"}, follow=True
+            )
+
+        task.delay.assert_not_called()
+        foreign.refresh_from_db()
+        self.assertEqual(foreign.status, FileIngestion.Status.FAILED)
+        self.assertContains(crafted, "cannot be reingested")
+        self.assertContains(empty, "No files selected")
+
+    def test_page_wires_a_select_all_checkbox(self):
+        _ingestion(self.feed, "bad.grib", status=FileIngestion.Status.FAILED)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, 'id="ging-select-all"')
+        self.assertContains(response, "getElementById('ging-select-all')")
+        self.assertContains(response, "DOMContentLoaded")
+
+
 class DataFeedDetailIngestionPanelTests(TestCase):
     """The compact ingestion panel on the feed detail page: recent records +
     a "View all" link to the Ingestion Activity page."""

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -1635,6 +1635,38 @@ def data_feed_ingestions(request, feed_pk):
             messages.info(request, _("No unprocessed files under this feed's catalog."))
         return redirect("data_feed_ingestions", feed_pk=feed.pk)
 
+    is_bulk_reingest = request.POST.get("action") == "reingest_selected"
+    if request.method == "POST" and (request.POST.get("reingest_id") or is_bulk_reingest):
+        from georiva.ingestion import unprocessed
+        from georiva.ingestion.models import FileIngestion as FI
+
+        if is_bulk_reingest:
+            raw_pks = request.POST.getlist("record_ids")
+        else:
+            raw_pks = [request.POST["reingest_id"]]
+        pks = [pk for pk in raw_pks if str(pk).isdigit()]
+
+        if not pks:
+            messages.info(request, _("No files selected."))
+        else:
+            # Only failed records of THIS feed's catalog may be reingested —
+            # crafted POSTs for anything else select nothing.
+            targets = FI.objects.filter(
+                pk__in=pks,
+                status=FI.Status.FAILED,
+                file_path__startswith=f"{feed.catalog.slug}/",
+            )
+            queued = unprocessed.reingest_records(targets)
+            if queued:
+                messages.success(
+                    request, _("Reingestion queued for %d file(s).") % queued
+                )
+            else:
+                messages.warning(
+                    request, _("Selected record(s) cannot be reingested.")
+                )
+        return redirect("data_feed_ingestions", feed_pk=feed.pk)
+
     status = request.GET.get("status") or None
 
     collections = Collection.objects.filter(catalog=feed.catalog).order_by("name")


### PR DESCRIPTION
Closes #224. Closes #220. Completes PRD #217 (last slice, after #226–#231).

**#224 — reingest UI** on the Ingestion Activity page:
- Per-row Reingest button on failed rows only; checkbox multi-select with select-all header checkbox (vanilla JS in `extra_js`); "Reingest selected" bulk action
- Both paths use new `unprocessed.reingest_records`: `reset_for_reingest` + one `process_incoming_file` dispatch per record (the consumer/upload-views plumbing), flash with the queued count
- Guards: only failed records under the feed's catalog prefix are selectable server-side — crafted POSTs (non-failed rows, foreign-catalog records, garbage ids) queue nothing; empty selection explains itself

**#220 — Acquisition Feed snapshot fix:**
- `_build_fetch_run_dict` read `ff.filename`, which doesn't exist on `FetchedFile` — the snapshot raised AttributeError whenever a run had per-file records. Now serializes `file_path`; the feed page's JS already falls back to it and the live signal payload already used it. Regression test reproduces the crash first.

Tests: 6 new. Full `sources` + `ingestion` suites pass (542 tests).