### PR TITLE
feat(sources): replace feed-detail activity tables with stat cards

### DIFF
--- a/georiva/src/georiva/ingestion/ingestion_tracking.py
+++ b/georiva/src/georiva/ingestion/ingestion_tracking.py
@@ -13,6 +13,22 @@ from __future__ import annotations
 NO_COLLECTION = "none"
 
 
+def feed_ingestion_status_counts(feed) -> dict:
+    """Status → count over the feed's FileIngestions (all four statuses
+    always present, zero-filled) — the Ingestion Activity stat card."""
+    from django.db.models import Count
+
+    from georiva.ingestion.models import FileIngestion
+
+    counted = dict(
+        feed_file_ingestions(feed)
+        .order_by()
+        .values_list("status")
+        .annotate(n=Count("id"))
+    )
+    return {value: counted.get(value, 0) for value, _ in FileIngestion.Status.choices}
+
+
 def feed_file_ingestions(feed, *, status=None, collection=None):
     """A feed's FileIngestions, newest activity first.
 

--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
@@ -54,13 +54,50 @@
 
         .gfeed-stats {
             display: grid;
-            grid-template-columns: repeat(3, 1fr);
+            grid-template-columns: repeat(2, 1fr);
             gap: 1em;
             margin-bottom: 1.5em;
         }
 
         .gfeed-stats .gfeed-card {
             margin-bottom: 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .gfeed-activity-card__body {
+            padding: 1em 1.25em;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5em;
+            flex: 1;
+        }
+
+        .gfeed-activity-card__row {
+            display: flex;
+            align-items: baseline;
+            gap: 0.5em;
+            flex-wrap: wrap;
+        }
+
+        .gfeed-activity-card__link {
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .gfeed-activity-counts {
+            display: flex;
+            gap: 1.25em;
+            flex-wrap: wrap;
+        }
+
+        .gfeed-activity-counts a {
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .gfeed-activity-count--failed .gfeed-stat__value {
+            color: var(--w-color-critical-200);
         }
 
         .gfeed-stat__value {
@@ -164,26 +201,11 @@
             flex-wrap: wrap;
         }
 
-        /* Runs table */
-        .gfeed-runs-form {
-            margin: 0;
-        }
-
-        .gfeed-card__actions {
-            display: flex;
-            align-items: center;
-            gap: 0.5em;
-        }
-
         .gfeed-empty-state {
             padding: 1.5em;
             color: var(--w-color-grey-400);
             font-size: 0.9em;
             text-align: center;
-        }
-
-        .gfeed-num {
-            text-align: right;
         }
 
         .gfeed-status {
@@ -205,10 +227,6 @@
             background: var(--w-color-positive-100);
         }
 
-        .gfeed-dot--partial {
-            background: var(--w-color-warning-100);
-        }
-
         .gfeed-dot--failed {
             background: var(--w-color-critical-200);
         }
@@ -217,18 +235,8 @@
             background: var(--w-color-info-100);
         }
 
-        .gfeed-dot--empty, .gfeed-dot--default {
+        .gfeed-dot--default {
             background: var(--w-color-grey-400);
-        }
-
-        .gfeed-failed-count {
-            color: var(--w-color-critical-200);
-        }
-
-        .gfeed-error-cell {
-            font-size: 0.8em;
-            color: var(--w-color-grey-400);
-            max-width: 300px;
         }
 
         .gfeed-status-active {
@@ -290,34 +298,70 @@
             </div>
         </div>
 
-        {# ── Stat cards #}
+        {# ── Activity stat cards (PRD #217 follow-up) #}
         <div class="gfeed-stats">
-            <div class="gfeed-card gfeed-card__body">
-                <div class="gfeed-stat__value">
-                    {{ feed.total_runs }}
+            <div class="gfeed-card">
+                <div class="gfeed-card__header">
+                    <h3 class="gfeed-card__title">{% trans "Acquisition Activity" %}</h3>
+                    <a class="button button-small button-secondary"
+                       href="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">{% trans "View all" %}</a>
                 </div>
-                <div class="gfeed-stat__label">
-                    {% trans "Total Runs" %}
+                <div class="gfeed-activity-card__body">
+                    <div class="gfeed-activity-card__row">
+                        <span class="gfeed-stat__value">{{ acquisition_summary.total_runs }}</span>
+                        <span class="gfeed-stat__label">{% trans "Total Runs" %}</span>
+                    </div>
+                    {% with last=acquisition_summary.last_run %}
+                        {% if last %}
+                            <a class="gfeed-activity-card__link"
+                               href="{% url 'data_feed_fetch_run_detail' feed_pk=feed.pk run_pk=last.pk %}">
+                                <span class="gfeed-activity-card__row">
+                                    <span class="gfeed-stat__label">{% trans "Last run" %}</span>
+                                    <span class="gfeed-status">
+                                        {% if last.status == "completed" %}
+                                            <span class="gfeed-dot gfeed-dot--success"></span>
+                                        {% elif last.status == "failed" %}
+                                            <span class="gfeed-dot gfeed-dot--failed"></span>
+                                        {% elif last.status == "running" %}
+                                            <span class="gfeed-dot gfeed-dot--running"></span>
+                                        {% else %}
+                                            <span class="gfeed-dot gfeed-dot--default"></span>
+                                        {% endif %}
+                                        {{ last.get_status_display }}
+                                    </span>
+                                    <span class="gfeed-meta">{{ last.started_at|timesince }} {% trans "ago" %}</span>
+                                </span>
+                                <span class="gfeed-activity-card__row">
+                                    <span class="gfeed-meta">
+                                        {% blocktrans with requested=last.files_requested failed=last.files_failed %}
+                                            {{ requested }} requested · {{ failed }} failed
+                                        {% endblocktrans %}
+                                    </span>
+                                </span>
+                            </a>
+                        {% else %}
+                            <span class="gfeed-meta">{% trans "No runs yet." %}</span>
+                        {% endif %}
+                    {% endwith %}
                 </div>
             </div>
-            <div class="gfeed-card gfeed-card__body">
-                <div class="gfeed-stat__value">
-                    {% if feed.last_run_at %}
-                        {{ feed.last_run_at|timesince }}
-                    {% else %}
-                        —
-                    {% endif %}
+
+            <div class="gfeed-card">
+                <div class="gfeed-card__header">
+                    <h3 class="gfeed-card__title">{% trans "Ingestion Activity" %}</h3>
+                    <a class="button button-small button-secondary"
+                       href="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">{% trans "View all" %}</a>
                 </div>
-                <div class="gfeed-stat__label">
-                    {% trans "Last Run" %}
-                </div>
-            </div>
-            <div class="gfeed-card gfeed-card__body">
-                <div class="gfeed-stat__value">
-                    {{ feed.total_files_fetched }}
-                </div>
-                <div class="gfeed-stat__label">
-                    {% trans "Files Fetched" %}
+                <div class="gfeed-activity-card__body">
+                    <div class="gfeed-activity-counts">
+                        {% for value, label, count in ingestion_count_rows %}
+                            <a class="gfeed-activity-count gfeed-activity-count--{{ value }}"
+                               href="{% url 'data_feed_ingestions' feed_pk=feed.pk %}?status={{ value }}">
+                                <span class="gfeed-stat__value">{{ count }}</span>
+                                <span class="gfeed-stat__label">{{ label }}</span>
+                            </a>
+                        {% endfor %}
+                    </div>
                 </div>
             </div>
         </div>
@@ -434,219 +478,5 @@
             </div>
         {% endif %}
 
-        {# ── Acquisition Activity card (PRD #217, issue #218) #}
-        <div class="gfeed-card">
-            <div class="gfeed-card__header">
-                <h3 class="gfeed-card__title">{% trans "Acquisition Activity" %}</h3>
-                <div class="gfeed-card__actions">
-                    {% if feed.collection_links.exists %}
-                        <form class="gfeed-runs-form" method="post"
-                              action="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="action" value="check_new_files">
-                            <button class="button button-small button-secondary" type="submit">
-                                {% trans "Check for new files" %}
-                            </button>
-                        </form>
-                    {% endif %}
-                    {% if feed.collection_links.exists %}
-                        <form class="gfeed-runs-form" method="post" action="{% url 'data_feed_detail' pk=feed.pk %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="action" value="run_now">
-                            <button class="button bicolor button--icon button-small" type="submit">
-                                <span class="icon-wrapper">
-                                    <svg class="icon icon-rotate icon" aria-hidden="true">
-                                        <use href="#icon-rotate"></use>
-                                    </svg>
-                                </span>
-                                {% trans "Run Now" %}
-                            </button>
-                        </form>
-                    {% endif %}
-                    <a class="button button-small button-secondary"
-                       href="{% url 'data_feed_fetch_runs' feed_pk=feed.pk %}">{% trans "View all" %}</a>
-                </div>
-            </div>
-            {% if recent_fetch_runs %}
-                <table class="listing">
-                    <thead>
-                    <tr>
-                        <th>
-                            {% trans "Status" %}
-                        </th>
-                        <th>
-                            {% trans "Started" %}
-                        </th>
-                        <th>
-                            {% trans "Duration" %}
-                        </th>
-                        <th class="gfeed-num">
-                            {% trans "Requested" %}
-                        </th>
-                        <th class="gfeed-num">
-                            {% trans "Fetched" %}
-                        </th>
-                        <th class="gfeed-num">
-                            {% trans "Skipped" %}
-                        </th>
-                        <th class="gfeed-num">
-                            {% trans "Failed" %}
-                        </th>
-                        <th>
-                            {% trans "Error" %}
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for row in recent_fetch_runs %}
-                        <tr>
-                            <td>
-                                <span class="gfeed-status">
-                                    {% if row.run.status == "completed" %}
-                                        <span class="gfeed-dot gfeed-dot--success"></span>
-                                        {% trans "Completed" %}
-                                    {% elif row.run.status == "failed" %}
-                                        <span class="gfeed-dot gfeed-dot--failed"></span>
-                                        {% trans "Failed" %}
-                                    {% elif row.run.status == "running" %}
-                                        <span class="gfeed-dot gfeed-dot--running"></span>
-                                        {% trans "Running" %}
-                                    {% else %}
-                                        <span class="gfeed-dot gfeed-dot--default"></span>
-                                        {{ row.run.get_status_display }}
-                                    {% endif %}
-                                </span>
-                            </td>
-                            <td>
-                                {{ row.run.started_at|timesince }} {% trans "ago" %}
-                            </td>
-                            <td>
-                                {% if row.duration is not None %}
-                                    {{ row.duration|floatformat:0 }}s
-                                {% else %}
-                                    —
-                                {% endif %}</td>
-                            <td class="gfeed-num">
-                                {{ row.run.files_requested }}
-                            </td>
-                            <td class="gfeed-num">
-                                {{ row.run.files_fetched }}
-                            </td>
-                            <td class="gfeed-num">
-                                {{ row.run.files_skipped }}
-                            </td>
-                            <td class="gfeed-num">
-                                {% if row.run.files_failed %}
-                                    <span class="gfeed-failed-count">
-                                        {{ row.run.files_failed }}
-                                    </span>
-                                {% else %}
-                                    0
-                                {% endif %}
-                            </td>
-                            <td class="gfeed-error-cell">
-                                {% if row.run.error_message %}
-                                    {{ row.run.error_message|truncatechars:120 }}
-                                {% else %}
-                                    —
-                                {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            {% else %}
-                <p class="gfeed-empty-state">
-                    {% trans "No fetch runs recorded yet." %}
-                </p>
-            {% endif %}
-        </div>
-
-        {# ── Ingestion Activity card (PRD #217, issue #219) #}
-        <div class="gfeed-card">
-            <div class="gfeed-card__header">
-                <h3 class="gfeed-card__title">{% trans "Ingestion Activity" %}</h3>
-                <div class="gfeed-card__actions">
-                    <form class="gfeed-runs-form" method="post"
-                          action="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">
-                        {% csrf_token %}
-                        <input type="hidden" name="action" value="check_unprocessed">
-                        <button class="button button-small button-secondary" type="submit">
-                            {% trans "Check unprocessed files" %}
-                        </button>
-                    </form>
-                    <a class="button button-small button-secondary"
-                       href="{% url 'data_feed_ingestions' feed_pk=feed.pk %}">{% trans "View all" %}</a>
-                </div>
-            </div>
-            {% if recent_ingestions %}
-                <table class="listing">
-                    <thead>
-                    <tr>
-                        <th>
-                            {% trans "Status" %}
-                        </th>
-                        <th>
-                            {% trans "File" %}
-                        </th>
-                        <th>
-                            {% trans "Collections" %}
-                        </th>
-                        <th>
-                            {% trans "Updated" %}
-                        </th>
-                        <th>
-                            {% trans "Error" %}
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for record in recent_ingestions %}
-                        <tr>
-                            <td>
-                                <span class="gfeed-status">
-                                    {% if record.status == "completed" %}
-                                        <span class="gfeed-dot gfeed-dot--success"></span>
-                                        {% trans "Completed" %}
-                                    {% elif record.status == "failed" %}
-                                        <span class="gfeed-dot gfeed-dot--failed"></span>
-                                        {% trans "Failed" %}
-                                    {% elif record.status == "processing" %}
-                                        <span class="gfeed-dot gfeed-dot--running"></span>
-                                        {% trans "Processing" %}
-                                    {% else %}
-                                        <span class="gfeed-dot gfeed-dot--default"></span>
-                                        {{ record.get_status_display }}
-                                    {% endif %}
-                                </span>
-                            </td>
-                            <td>{{ record.file_path }}</td>
-                            <td>
-                                {% for collection in record.collections.all %}
-                                    {{ collection.name }}{% if not forloop.last %}, {% endif %}
-                                {% empty %}
-                                    —
-                                {% endfor %}
-                            </td>
-                            <td>
-                                {{ record.updated_at|timesince }} {% trans "ago" %}
-                            </td>
-                            <td class="gfeed-error-cell">
-                                {% if record.error %}
-                                    {{ record.error|truncatechars:120 }}
-                                {% else %}
-                                    —
-                                {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            {% else %}
-                <p class="gfeed-empty-state">
-                    {% trans "No ingestion records yet." %}
-                </p>
-            {% endif %}
-        </div>
     </div>
 {% endblock %}

--- a/georiva/src/georiva/sources/tests/test_acquisition_tracking.py
+++ b/georiva/src/georiva/sources/tests/test_acquisition_tracking.py
@@ -226,10 +226,10 @@ class FetchRunDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
 
 
-class DataFeedDetailAcquisitionPanelTests(TestCase):
-    """The compact acquisition panel on the feed detail page (replacing the
-    stale Recent Runs panel): recent runs + a "View all" link to the
-    Acquisition Activity page."""
+class DataFeedDetailAcquisitionCardTests(TestCase):
+    """The Acquisition Activity stat card at the top of the feed detail page:
+    total runs, a last-run summary linking to that run, and a "View all"
+    link. Actions (Run Now, checks) live on the list pages, not here."""
 
     @classmethod
     def setUpClass(cls):
@@ -245,33 +245,43 @@ class DataFeedDetailAcquisitionPanelTests(TestCase):
     def _detail_url(self):
         return reverse("data_feed_detail", kwargs={"pk": self.feed.pk})
 
-    def test_links_to_the_acquisition_activity_page(self):
+    def test_card_shows_total_runs_and_last_run_summary(self):
+        _run(self.feed, started_ago=60)
+        _run(self.feed, started_ago=30)
+        last = _run(
+            self.feed, FetchRun.Status.FAILED, started_ago=1,
+            files_requested=90210, files_failed=48151,
+        )
+
         response = self.client.get(self._detail_url())
 
-        self.assertContains(
+        self.assertEqual(
+            response.context["acquisition_summary"]["total_runs"], 3
+        )
+        self.assertContains(response, "90210")  # last run requested
+        self.assertContains(response, "48151")  # last run failed
+        self.assertContains(response, "Failed")  # status badge
+        self.assertContains(  # summary links to the run's detail page
+            response,
+            reverse(
+                "data_feed_fetch_run_detail",
+                kwargs={"feed_pk": self.feed.pk, "run_pk": last.pk},
+            ),
+        )
+        self.assertContains(  # View all
             response, reverse("data_feed_fetch_runs", kwargs={"feed_pk": self.feed.pk})
         )
 
-    def test_shows_recent_run_counters(self):
-        _run(self.feed, files_requested=90210, files_fetched=48151)
+    def test_card_with_no_runs_shows_an_empty_state(self):
+        response = self.client.get(self._detail_url())
+
+        self.assertContains(response, "No runs yet")
+
+    def test_detail_page_carries_no_activity_actions_or_tables(self):
+        _run(self.feed, files_requested=7)
 
         response = self.client.get(self._detail_url())
 
-        self.assertContains(response, "90210")
-        self.assertContains(response, "48151")
-
-    def test_panel_offers_the_check_for_new_files_action(self):
-        from georiva.core.models import Collection
-        from georiva.sources.models import DataFeedCollectionLink
-
-        collection = Collection.objects.create(
-            name="Rainfall", slug="rainfall", catalog=self.feed.catalog
-        )
-        DataFeedCollectionLink.objects.create(
-            data_feed=self.feed, collection=collection
-        )
-
-        response = self.client.get(self._detail_url())
-
-        self.assertContains(response, 'value="check_new_files"')
-        self.assertContains(response, "Check for new files")
+        self.assertNotContains(response, 'value="run_now"')
+        self.assertNotContains(response, 'value="check_new_files"')
+        self.assertNotContains(response, 'value="check_unprocessed"')

--- a/georiva/src/georiva/sources/tests/test_ingestion_activity.py
+++ b/georiva/src/georiva/sources/tests/test_ingestion_activity.py
@@ -372,9 +372,10 @@ class ReingestUITests(TestCase):
         self.assertContains(response, "DOMContentLoaded")
 
 
-class DataFeedDetailIngestionPanelTests(TestCase):
-    """The compact ingestion panel on the feed detail page: recent records +
-    a "View all" link to the Ingestion Activity page."""
+class DataFeedDetailIngestionCardTests(TestCase):
+    """The Ingestion Activity stat card at the top of the feed detail page:
+    all-time status counts, each linking to the pre-filtered list, plus a
+    "View all" link. No actions here — those live on the list page."""
 
     @classmethod
     def setUpClass(cls):
@@ -387,25 +388,34 @@ class DataFeedDetailIngestionPanelTests(TestCase):
         self.client.force_login(self.user)
         self.feed = _feed()
 
-    def test_panel_shows_recent_records_and_links_to_the_full_page(self):
-        _ingestion(
-            self.feed, "recent-orphan.grib", status=FileIngestion.Status.FAILED,
-        )
+    def _detail_url(self):
+        return reverse("data_feed_detail", kwargs={"pk": self.feed.pk})
 
-        response = self.client.get(
-            reverse("data_feed_detail", kwargs={"pk": self.feed.pk})
-        )
+    def test_card_counts_ingestions_by_status_with_filtered_links(self):
+        for i in range(3):
+            _ingestion(self.feed, f"done-{i}.grib")
+        _ingestion(self.feed, "stuck.grib", status=FileIngestion.Status.PENDING)
+        _ingestion(self.feed, "broken.grib", status=FileIngestion.Status.FAILED)
+        # Another catalog's records must not leak into the counts.
+        other = _feed(name="Other", slug="other")
+        _ingestion(other, "foreign.grib", status=FileIngestion.Status.FAILED)
 
-        self.assertContains(
-            response,
-            reverse("data_feed_ingestions", kwargs={"feed_pk": self.feed.pk}),
-        )
-        self.assertContains(response, "recent-orphan.grib")
+        response = self.client.get(self._detail_url())
 
-    def test_panel_offers_the_check_unprocessed_action(self):
-        response = self.client.get(
-            reverse("data_feed_detail", kwargs={"pk": self.feed.pk})
+        self.assertEqual(response.context["ingestion_counts"], {
+            "pending": 1, "processing": 0, "completed": 3, "failed": 1,
+        })
+        list_url = reverse(
+            "data_feed_ingestions", kwargs={"feed_pk": self.feed.pk}
         )
+        for status in ("completed", "pending", "processing", "failed"):
+            self.assertContains(response, f"{list_url}?status={status}")
+        self.assertContains(response, list_url)  # View all
 
-        self.assertContains(response, 'value="check_unprocessed"')
-        self.assertContains(response, "Check unprocessed files")
+    def test_card_renders_zero_counts_for_a_quiet_feed(self):
+        response = self.client.get(self._detail_url())
+
+        self.assertEqual(
+            set(response.context["ingestion_counts"].values()), {0}
+        )
+        self.assertEqual(response.status_code, 200)

--- a/georiva/src/georiva/sources/views.py
+++ b/georiva/src/georiva/sources/views.py
@@ -105,21 +105,19 @@ def data_feed_detail(request, pk):
     """Dashboard view for a single DataFeed."""
     feed = get_object_or_404(DataFeed, pk=pk)
 
-    if request.method == "POST" and request.POST.get("action") == "run_now":
-        feed.run_now(user=request.user)
-        messages.success(request, _("Run started for '%s'.") % feed.name)
-        return redirect("data_feed_detail", pk=pk)
+    # Activity stat cards (PRD #217 follow-up): pure summaries — actions
+    # (Fetch now, checks, retries) live on the linked activity pages.
+    from georiva.sources.acquisition_tracking import feed_fetch_runs
+    runs = feed_fetch_runs(feed)
+    acquisition_summary = {"total_runs": runs.count(), "last_run": runs.first()}
 
-    from georiva.sources.acquisition_tracking import feed_fetch_runs, run_duration_seconds
-    recent_fetch_runs = [
-        {"run": run, "duration": run_duration_seconds(run)}
-        for run in feed_fetch_runs(feed)[:5]
+    from georiva.ingestion.ingestion_tracking import feed_ingestion_status_counts
+    from georiva.ingestion.models import FileIngestion
+    ingestion_counts = feed_ingestion_status_counts(feed)
+    ingestion_count_rows = [
+        (value, label, ingestion_counts[value])
+        for value, label in FileIngestion.Status.choices
     ]
-
-    from georiva.ingestion.ingestion_tracking import feed_file_ingestions
-    recent_ingestions = list(
-        feed_file_ingestions(feed).prefetch_related("collections")[:5]
-    )
     
     raw_links = feed.collection_links.select_related("collection__catalog").all()
     collection_links = [link.get_real_instance() for link in raw_links]
@@ -175,8 +173,9 @@ def data_feed_detail(request, pk):
         "definition_link_pairs": definition_link_pairs,
         "product_stage_lanes": product_stage_lanes,
         "product_orphans": product_orphans,
-        "recent_fetch_runs": recent_fetch_runs,
-        "recent_ingestions": recent_ingestions,
+        "acquisition_summary": acquisition_summary,
+        "ingestion_counts": ingestion_counts,
+        "ingestion_count_rows": ingestion_count_rows,
         "feed_type_name": type(real_feed)._meta.verbose_name,
     }
 


### PR DESCRIPTION
Follow-up to PRD #217 (design change requested after using the pages).

- The 3 stat tiles (Total Runs / Last Run / Files Fetched) and both bottom activity table cards are replaced by a two-card top row:
  - **Acquisition Activity**: total runs from `feed_fetch_runs(feed).count()` (can never disagree with the View-all list), last-run summary (status dot, timesince, requested · failed) linking to that run's detail page
  - **Ingestion Activity**: all-time status counts over the catalog-prefix queryset via new `feed_ingestion_status_counts` (zero-filled), each count linking to `?status=<value>` on the list page
- Actions consolidated on the list pages: the detail page's Run Now button + POST handler and both check buttons are gone ("Fetch now" on the Acquisition Activity page covers run-now)
- Orphaned CSS from the removed tables pruned

Tests: detail-page panel tests rewritten as card specs (5 tests: summary + links, empty state, no-actions guarantee, counts with cross-catalog leak guard, zero counts). Full `sources` + `ingestion` suites pass (542 tests).