### PR TITLE
fix(sources): underline activity-card links on hover

### DIFF
--- a/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
+++ b/georiva/src/georiva/sources/templates/georivasources/data_feed_detail.html
@@ -91,6 +91,10 @@
             color: inherit;
         }
 
+        .gfeed-activity-card__link:hover {
+            text-decoration: underline;
+        }
+
         .gfeed-activity-counts {
             display: flex;
             gap: 1.25em;
@@ -100,6 +104,10 @@
         .gfeed-activity-counts a {
             text-decoration: none;
             color: inherit;
+        }
+
+        .gfeed-activity-counts a:hover {
+            text-decoration: underline;
         }
 
         .gfeed-activity-count--failed .gfeed-stat__value {


### PR DESCRIPTION
Follow-up to #233/#234: the last-run summary link and the per-status count links on the feed-detail activity cards now underline on hover, signalling they're clickable. The "View all" buttons keep their button styling.